### PR TITLE
feat(frontend): add date to sparkline tooltip

### DIFF
--- a/frontend/src/systems/components/SensorItem.css
+++ b/frontend/src/systems/components/SensorItem.css
@@ -402,6 +402,12 @@
   color: var(--text-secondary);
 }
 
+.tooltip-date {
+  opacity: 0.5;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
 /* === RESPONSIVE === */
 @media (max-width: 480px) {
   .sensor-value-column {

--- a/frontend/src/systems/components/SensorSparkline.tsx
+++ b/frontend/src/systems/components/SensorSparkline.tsx
@@ -384,6 +384,11 @@ const SensorSparkline: React.FC<SensorSparklineProps> = ({
               timeZone: timezone
             })}
           </span>
+          <span className="tooltip-date">
+            {new Date(activePoint.timestamp).toLocaleDateString('en-CA', {
+              timeZone: timezone
+            })}
+          </span>
         </div>
       )}
 


### PR DESCRIPTION
Adds a date line (yyyy-mm-dd) below the time in the sensor graph tooltip.