### PR TITLE
chore(rust-agents): inject version via PANKHA_VERSION env, eliminate …

### DIFF
--- a/.github/workflows/release-public.yml
+++ b/.github/workflows/release-public.yml
@@ -65,24 +65,30 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
 
-      - name: Inject version into Cargo.toml
-        working-directory: agents/clients/linux/rust
+      - name: Compute PANKHA_VERSION
         run: |
           VERSION="${{ github.event.inputs.version || github.ref_name }}"
           VERSION_NUM="${VERSION#v}"  # Remove 'v' prefix
-          
+
           # Convert 4-part version to SemVer prerelease format: 0.1.7.1 → 0.1.7-1
           DOTS=$(echo "$VERSION_NUM" | grep -o '\.' | wc -l)
           if [ "$DOTS" -ge 3 ]; then
-            CARGO_VER=$(echo "$VERSION_NUM" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
-            echo "⚠️  Converting: $VERSION_NUM → $CARGO_VER (SemVer prerelease format)"
+            PANKHA_VERSION=$(echo "$VERSION_NUM" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
+            echo "⚠️  Converting: $VERSION_NUM → $PANKHA_VERSION (SemVer prerelease format)"
           else
-            CARGO_VER="$VERSION_NUM"
-            echo "📝 Using version: $CARGO_VER"
+            PANKHA_VERSION="$VERSION_NUM"
+            echo "📝 Using version: $PANKHA_VERSION"
           fi
-          
-          sed -i "s/^version = \".*\"/version = \"$CARGO_VER\"/" Cargo.toml
-          cat Cargo.toml | head -5
+
+          # Guard: refuse to build a release with empty or placeholder version
+          if [ -z "$PANKHA_VERSION" ] || [ "$PANKHA_VERSION" = "0.0.0-dev" ] || [ "$PANKHA_VERSION" = "dev" ]; then
+            echo "❌ ERROR: PANKHA_VERSION resolved to empty/placeholder: '$PANKHA_VERSION'"
+            echo "   Release builds require a real tag version."
+            exit 1
+          fi
+
+          echo "PANKHA_VERSION=$PANKHA_VERSION" >> $GITHUB_ENV
+          echo "✅ PANKHA_VERSION=$PANKHA_VERSION exported to subsequent steps"
 
       - name: Build Rust agent (${{ matrix.arch }})
         working-directory: agents/clients/linux/rust
@@ -136,8 +142,7 @@ jobs:
           workspaces: agents/clients/linux/virtual-agents/host-ipmi-rust
           shared-key: rust-cache-ipmi-x64
 
-      - name: Inject version into Cargo.toml
-        working-directory: agents/clients/linux/virtual-agents/host-ipmi-rust
+      - name: Compute PANKHA_VERSION
         run: |
           VERSION="${{ github.event.inputs.version || github.ref_name }}"
           VERSION_NUM="${VERSION#v}"  # Remove 'v' prefix
@@ -145,15 +150,22 @@ jobs:
           # Convert 4-part version to SemVer prerelease format: 0.1.7.1 → 0.1.7-1
           DOTS=$(echo "$VERSION_NUM" | grep -o '\.' | wc -l)
           if [ "$DOTS" -ge 3 ]; then
-            CARGO_VER=$(echo "$VERSION_NUM" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
-            echo "⚠️  Converting: $VERSION_NUM → $CARGO_VER (SemVer prerelease format)"
+            PANKHA_VERSION=$(echo "$VERSION_NUM" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
+            echo "⚠️  Converting: $VERSION_NUM → $PANKHA_VERSION (SemVer prerelease format)"
           else
-            CARGO_VER="$VERSION_NUM"
-            echo "📝 Using version: $CARGO_VER"
+            PANKHA_VERSION="$VERSION_NUM"
+            echo "📝 Using version: $PANKHA_VERSION"
           fi
 
-          sed -i "s/^version = \".*\"/version = \"$CARGO_VER\"/" Cargo.toml
-          cat Cargo.toml | head -5
+          # Guard: refuse to build a release with empty or placeholder version
+          if [ -z "$PANKHA_VERSION" ] || [ "$PANKHA_VERSION" = "0.0.0-dev" ] || [ "$PANKHA_VERSION" = "dev" ]; then
+            echo "❌ ERROR: PANKHA_VERSION resolved to empty/placeholder: '$PANKHA_VERSION'"
+            echo "   Release builds require a real tag version."
+            exit 1
+          fi
+
+          echo "PANKHA_VERSION=$PANKHA_VERSION" >> $GITHUB_ENV
+          echo "✅ PANKHA_VERSION=$PANKHA_VERSION exported to subsequent steps"
 
       - name: Build IPMI agent (x64)
         working-directory: agents/clients/linux/virtual-agents/host-ipmi-rust

--- a/agents/clients/linux/rust/Cargo.lock
+++ b/agents/clients/linux/rust/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pankha-agent"
-version = "1.0.0"
+version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/agents/clients/linux/rust/Cargo.toml
+++ b/agents/clients/linux/rust/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "pankha-agent"
-version = "1.0.0"
+# Version is set at build time via PANKHA_VERSION env var. See build.rs.
+# This static placeholder never changes; release pipeline embeds the real version.
+version = "0.0.0-dev"
 edition = "2021"
 authors = ["Pankha Development Team"]
 description = "Cross-platform hardware monitoring and fan control agent for Pankha"

--- a/agents/clients/linux/rust/Makefile
+++ b/agents/clients/linux/rust/Makefile
@@ -1,84 +1,72 @@
-.PHONY: all x86_64 aarch64 clean help inject-version reset-version
+.PHONY: all x86_64 aarch64 clean help
 
-# Version can be passed as: make VERSION=0.1.7 all
-# 4-part versions (0.1.7.2) will be auto-converted to 3-part (0.1.72)
+# Version can be passed as: make VERSION=0.4.24-alpha2 all
+# 4-part versions (0.1.7.2) auto-convert to SemVer prerelease (0.1.7-2)
 # example:
-# cd /path/to/agents/clients/linux/rust/ && make clean && make VERSION=0.2.19-dev all
+#   cd /path/to/agents/clients/linux/rust/ && make clean && make VERSION=0.2.19-dev all
+#
+# The VERSION value is forwarded to cargo as PANKHA_VERSION (consumed by build.rs).
+# Cargo.toml is NEVER mutated - the version is embedded into the binary at compile time.
 VERSION ?=
-DEFAULT_VERSION := 1.0.0
 
-# Reset Cargo.toml to default version (fixes corrupted state)
-reset-version:
-	@echo "🔄 Resetting Cargo.toml to default version $(DEFAULT_VERSION)..."
-	@sed -i 's/^version = ".*"/version = "$(DEFAULT_VERSION)"/' Cargo.toml
-	@head -3 Cargo.toml
-
-# Inject version into Cargo.toml if VERSION is provided
-# Conversion rules:
-#   0.1.7       → 0.1.7       (unchanged)
-#   0.1.7.1     → 0.1.7-1     (4th part becomes prerelease)
-#   v0.1.7.2    → 0.1.7-2     (strips 'v', converts to prerelease)
-#   0.1.7.2-foo → 0.1.7-2-foo (preserves suffix)
-inject-version:
+# Compute PANKHA_VERSION from VERSION: strip 'v', convert 4-part → prerelease
 ifdef VERSION
-	@# Strip 'v' prefix if present, then convert 4-part to prerelease format
-	@RAW_VER=$$(echo "$(VERSION)" | sed 's/^v//'); \
-	DOTS=$$(echo "$$RAW_VER" | grep -o '\.' | head -3 | wc -l); \
-	if [ "$$DOTS" -ge 3 ]; then \
-		CARGO_VER=$$(echo "$$RAW_VER" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/'); \
-		echo "⚠️  Converting: $(VERSION) → $$CARGO_VER (SemVer prerelease format)"; \
-		sed -i "s/^version = \".*\"/version = \"$$CARGO_VER\"/" Cargo.toml; \
-	else \
-		echo "📝 Injecting version $$RAW_VER into Cargo.toml..."; \
-		sed -i "s/^version = \".*\"/version = \"$$RAW_VER\"/" Cargo.toml; \
-	fi
-	@head -5 Cargo.toml
+  RAW_VER := $(shell echo "$(VERSION)" | sed 's/^v//')
+  DOT_COUNT := $(shell echo "$(RAW_VER)" | tr -cd '.' | wc -c)
+  ifeq ($(shell [ $(DOT_COUNT) -ge 3 ] && echo yes),yes)
+    PANKHA_VERSION := $(shell echo "$(RAW_VER)" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
+  else
+    PANKHA_VERSION := $(RAW_VER)
+  endif
+  export PANKHA_VERSION
 endif
 
-all: inject-version x86_64 aarch64
+all: x86_64 aarch64
 
-x86_64: inject-version
+x86_64:
 	@echo "Building x86_64..."
-	cargo build --release
-#	Optional: Copy to custom output directory
+ifdef VERSION
+	@echo "PANKHA_VERSION=$(PANKHA_VERSION)"
+endif
+	cargo build --release --locked
 	mkdir -p output/
 	cp target/release/pankha-agent-linux output/pankha-agent-linux_x86_64
 	@echo "✓ Copied to: output/pankha-agent-linux_x86_64"
 ifdef VERSION
-	@echo "✓ Version: $(VERSION)"
+	@echo "✓ Version: $(PANKHA_VERSION)"
 endif
 
-aarch64: inject-version
+aarch64:
 	@echo "Building aarch64..."
-	cargo build --release --target aarch64-unknown-linux-gnu
-#	Optional: Copy to custom output directory
+ifdef VERSION
+	@echo "PANKHA_VERSION=$(PANKHA_VERSION)"
+endif
+	cargo build --release --target aarch64-unknown-linux-gnu --locked
 	mkdir -p output/
 	cp target/aarch64-unknown-linux-gnu/release/pankha-agent-linux output/pankha-agent-linux_arm64
 	@echo "✓ Copied to: output/pankha-agent-linux_arm64"
 ifdef VERSION
-	@echo "✓ Version: $(VERSION)"
+	@echo "✓ Version: $(PANKHA_VERSION)"
 endif
 
 clean:
 	cargo clean
 	# Optional: Clean custom output directories
-	# Uncomment if you enabled custom output directories above
 	# rm -rf output
 
 help:
 	@echo "Pankha Agent Build System"
 	@echo ""
 	@echo "Usage:"
-	@echo "  make all                    - Build both x86_64 and aarch64 binaries"
-	@echo "  make x86_64                 - Build only x86_64 binary"
-	@echo "  make aarch64                - Build only aarch64 binary"
-	@echo "  make VERSION=0.1.7.2 all    - Build with specific version"
-	@echo "  make VERSION=0.1.7.2 x86_64 - Build x86_64 with specific version"
-	@echo "  make clean                  - Remove all build artifacts"
-	@echo "  make help                   - Show this help message"
+	@echo "  make all                          - Build both x86_64 and aarch64 (version=0.0.0-dev)"
+	@echo "  make x86_64                       - Build only x86_64 binary"
+	@echo "  make aarch64                      - Build only aarch64 binary"
+	@echo "  make VERSION=0.4.24-alpha2 all    - Build with specific version"
+	@echo "  make VERSION=0.4.24-alpha2 x86_64 - Build x86_64 with specific version"
+	@echo "  make clean                        - Remove all build artifacts"
+	@echo "  make help                         - Show this help message"
 	@echo ""
 	@echo "Output locations:"
 	@echo "  x86_64:  output/pankha-agent-linux_x86_64"
 	@echo "  aarch64: output/pankha-agent-linux_arm64"
 	@echo ""
-

--- a/agents/clients/linux/rust/build.rs
+++ b/agents/clients/linux/rust/build.rs
@@ -7,6 +7,32 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    inject_version();
+    generate_sst_validation();
+}
+
+/// Resolves PANKHA_VERSION from env, falls back to "0.0.0-dev" placeholder.
+/// Warns on local release builds (not CI) to remind devs to set the var explicitly.
+fn inject_version() {
+    let version = match env::var("PANKHA_VERSION") {
+        Ok(v) => v,
+        Err(_) => {
+            if env::var("PROFILE").as_deref() == Ok("release")
+                && env::var("CI").is_err()
+            {
+                println!("cargo:warning=PANKHA_VERSION not set, using placeholder \"0.0.0-dev\"");
+                println!("cargo:warning=To set, use one of:");
+                println!("cargo:warning=  PANKHA_VERSION=0.4.24-alpha2 cargo build --release");
+                println!("cargo:warning=  make VERSION=0.4.24-alpha2 all");
+            }
+            "0.0.0-dev".to_string()
+        }
+    };
+    println!("cargo:rustc-env=PANKHA_VERSION={}", version);
+    println!("cargo:rerun-if-env-changed=PANKHA_VERSION");
+}
+
+fn generate_sst_validation() {
     println!("cargo:rerun-if-changed=../../../../frontend/src/config/ui-options.json");
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/agents/clients/linux/rust/src/app/cli.rs
+++ b/agents/clients/linux/rust/src/app/cli.rs
@@ -29,7 +29,7 @@ Config & Debug:
 
 #[derive(Parser, Debug)]
 #[command(name = "pankha-agent")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = crate::version::VERSION)]
 #[command(about = "Pankha Cross-Platform Hardware Monitoring Agent", long_about = None)]
 #[command(after_help = "")]
 #[command(disable_help_flag = false)]

--- a/agents/clients/linux/rust/src/config/setup.rs
+++ b/agents/clients/linux/rust/src/config/setup.rs
@@ -34,7 +34,7 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
     println!("\n╔══════════════════════════════════════╗");
     println!("║    Pankha Rust Agent Setup Wizard    ║");
     println!("╚══════════════════════════════════════╝");
-    println!("Build: \x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("Build: \x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
 
     // Load existing config if present
     let existing_config = if config_file.exists() {

--- a/agents/clients/linux/rust/src/daemon/control.rs
+++ b/agents/clients/linux/rust/src/daemon/control.rs
@@ -29,7 +29,7 @@ pub fn start_daemon_with_log_level(log_level: Option<String>) -> Result<()> {
         process::exit(1);
     }
 
-    println!("\x1b[32mStarting pankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mStarting pankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
 
     // Prepare log file
     ensure_directories()?;
@@ -123,7 +123,7 @@ pub fn stop_daemon() -> Result<()> {
 }
 
 pub fn restart_daemon_with_log_level(log_level: Option<String>) -> Result<()> {
-    println!("\x1b[32mRestarting pankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mRestarting pankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
 
     // Check if systemd service is actively managing the process
     // If so, delegate to systemctl to prevent auto-restart conflicts

--- a/agents/clients/linux/rust/src/daemon/status.rs
+++ b/agents/clients/linux/rust/src/daemon/status.rs
@@ -9,7 +9,7 @@ use crate::daemon::{LOG_DIR, SYSTEMD_SERVICE_PATH};
 use crate::config::persistence::load_config;
 
 pub async fn show_status() -> Result<()> {
-    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
     println!("================================");
 
     if is_running() {
@@ -47,7 +47,7 @@ pub async fn show_status() -> Result<()> {
 
 /// Run health check to verify agent installation
 pub fn run_health_check() -> Result<()> {
-    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
     println!("Health Check");
     println!("============\n");
 

--- a/agents/clients/linux/rust/src/hardware/linux/diagnostics.rs
+++ b/agents/clients/linux/rust/src/hardware/linux/diagnostics.rs
@@ -56,7 +56,7 @@ impl super::monitor::LinuxHardwareMonitor {
     }
 
     async fn build_dump_metadata(&self) -> HardwareDumpMetadata {
-        let agent_version = env!("CARGO_PKG_VERSION").to_string();
+        let agent_version = crate::version::VERSION.to_string();
 
         // Get OS version from /etc/os-release or fallback
         let os_version = self.read_file(Path::new("/etc/os-release")).await

--- a/agents/clients/linux/rust/src/main.rs
+++ b/agents/clients/linux/rust/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 mod config;
 mod daemon;
 mod hardware;
+mod version;
 mod websocket;
 
 use anyhow::Result;
@@ -44,7 +45,7 @@ async fn main() -> Result<()> {
             }
             // Custom version output with architecture (green)
             if err.kind() == clap::error::ErrorKind::DisplayVersion {
-                println!("\x1b[32mpankha-agent {} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent {} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
                 std::process::exit(0);
             }
 
@@ -103,13 +104,13 @@ async fn main() -> Result<()> {
             Some(n) => {
                 // Show last N lines: tail -n <lines>
                 println!("Showing last {} log entries...", n);
-                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
                 cmd.arg("-n").arg(n.to_string());
             }
             None => {
                 // Follow logs: tail -f
                 println!("Showing live agent logs (Ctrl+C to exit)...");
-                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
                 cmd.arg("-f");
             }
         }
@@ -242,7 +243,7 @@ async fn main() -> Result<()> {
     }
 
     // Log startup message (only for normal operation, not setup/config commands)
-    info!("Pankha Agent v{} starting ({})", env!("CARGO_PKG_VERSION"), std::env::consts::OS);
+    info!("Pankha Agent v{} starting ({})", crate::version::VERSION, std::env::consts::OS);
 
     // Check if config file exists (required for normal operation)
     let config_file_path = std::env::current_exe()?

--- a/agents/clients/linux/rust/src/version.rs
+++ b/agents/clients/linux/rust/src/version.rs
@@ -1,0 +1,4 @@
+//! Agent version, embedded at build time from the PANKHA_VERSION env var.
+//! See build.rs for the resolution logic.
+
+pub const VERSION: &str = env!("PANKHA_VERSION");

--- a/agents/clients/linux/rust/src/websocket/messaging.rs
+++ b/agents/clients/linux/rust/src/websocket/messaging.rs
@@ -50,7 +50,7 @@ impl super::client::WebSocketClient {
                 "agentId": config.agent.id,
                 "name": config.agent.name,
                 "agent_type": "os_linux",
-                "agent_version": env!("CARGO_PKG_VERSION"),
+                "agent_version": crate::version::VERSION,
                 "platform": std::env::consts::OS, // "linux", "macos", "windows", etc.
                 "architecture": crate::app::platform::project_arch(),
                 "update_interval": config.agent.update_interval as u64, // Send in seconds to match frontend/backend format

--- a/agents/clients/linux/rust/src/websocket/self_update.rs
+++ b/agents/clients/linux/rust/src/websocket/self_update.rs
@@ -29,7 +29,7 @@ impl super::client::WebSocketClient {
     /// 5. Write .update_pending marker
     /// 6. Re-exec or systemctl restart
     pub(crate) async fn self_update(&self, target_version: Option<String>) -> Result<()> {
-        let current_version = env!("CARGO_PKG_VERSION");
+        let current_version = crate::version::VERSION;
 
         // Version check: skip if already on target version
         if let Some(ref target) = target_version {

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.lock
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pankha-agent-ipmi"
-version = "1.0.0"
+version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.toml
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "pankha-agent-ipmi"
-version = "1.0.0"
+# Version is set at build time via PANKHA_VERSION env var. See build.rs.
+# This static placeholder never changes; release pipeline embeds the real version.
+version = "0.0.0-dev"
 edition = "2021"
 authors = ["Pankha Development Team"]
 description = "IPMI host agent for Pankha - BMC fan control via ipmitool"

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/Makefile
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/Makefile
@@ -1,86 +1,75 @@
-.PHONY: all x86_64 aarch64 clean help inject-version reset-version
+.PHONY: all x86_64 aarch64 clean help
 
-# Version can be passed as: make VERSION=0.1.7 all
-# 4-part versions (0.1.7.2) will be auto-converted to 3-part (0.1.72)
+# Version can be passed as: make VERSION=0.4.24-alpha2 all
+# 4-part versions (0.1.7.2) auto-convert to SemVer prerelease (0.1.7-2)
 # example:
-# cd /path/to/agents/clients/linux/virtual-agents/host-ipmi-rust/ && make clean && make VERSION=0.2.19-dev all
+#   cd /path/to/agents/clients/linux/virtual-agents/host-ipmi-rust/ && make clean && make VERSION=0.2.19-dev all
+#
+# The VERSION value is forwarded to cargo as PANKHA_VERSION (consumed by build.rs).
+# Cargo.toml is NEVER mutated - the version is embedded into the binary at compile time.
 VERSION ?=
-DEFAULT_VERSION := 1.0.0
 
-# Reset Cargo.toml to default version (fixes corrupted state)
-reset-version:
-	@echo "🔄 Resetting Cargo.toml to default version $(DEFAULT_VERSION)..."
-	@sed -i 's/^version = ".*"/version = "$(DEFAULT_VERSION)"/' Cargo.toml
-	@head -3 Cargo.toml
-
-# Inject version into Cargo.toml if VERSION is provided
-# Conversion rules:
-#   0.1.7       → 0.1.7       (unchanged)
-#   0.1.7.1     → 0.1.7-1     (4th part becomes prerelease)
-#   v0.1.7.2    → 0.1.7-2     (strips 'v', converts to prerelease)
-#   0.1.7.2-foo → 0.1.7-2-foo (preserves suffix)
-inject-version:
+# Compute PANKHA_VERSION from VERSION: strip 'v', convert 4-part → prerelease
 ifdef VERSION
-	@# Strip 'v' prefix if present, then convert 4-part to prerelease format
-	@RAW_VER=$$(echo "$(VERSION)" | sed 's/^v//'); \
-	DOTS=$$(echo "$$RAW_VER" | grep -o '\.' | head -3 | wc -l); \
-	if [ "$$DOTS" -ge 3 ]; then \
-		CARGO_VER=$$(echo "$$RAW_VER" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/'); \
-		echo "⚠️  Converting: $(VERSION) → $$CARGO_VER (SemVer prerelease format)"; \
-		sed -i "s/^version = \".*\"/version = \"$$CARGO_VER\"/" Cargo.toml; \
-	else \
-		echo "📝 Injecting version $$RAW_VER into Cargo.toml..."; \
-		sed -i "s/^version = \".*\"/version = \"$$RAW_VER\"/" Cargo.toml; \
-	fi
-	@head -5 Cargo.toml
+  RAW_VER := $(shell echo "$(VERSION)" | sed 's/^v//')
+  DOT_COUNT := $(shell echo "$(RAW_VER)" | tr -cd '.' | wc -c)
+  ifeq ($(shell [ $(DOT_COUNT) -ge 3 ] && echo yes),yes)
+    PANKHA_VERSION := $(shell echo "$(RAW_VER)" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)\.\([0-9]*\)/\1-\2/')
+  else
+    PANKHA_VERSION := $(RAW_VER)
+  endif
+  export PANKHA_VERSION
 endif
 
-# TODO: enable this when we have aarch64 support
-# all: inject-version x86_64 aarch64
+# TODO: enable aarch64 when IPMI agent has aarch64 support
+# all: x86_64 aarch64
 # For now we only build for x86_64
-all: inject-version x86_64
-x86_64: inject-version
+all: x86_64
+
+x86_64:
 	@echo "Building x86_64..."
-	cargo build --release
-#	Optional: Copy to custom output directory
+ifdef VERSION
+	@echo "PANKHA_VERSION=$(PANKHA_VERSION)"
+endif
+	cargo build --release --locked
 	mkdir -p output/
 	cp target/release/pankha-agent-ipmi-linux output/pankha-agent-ipmi-linux_x86_64
 	@echo "✓ Copied to: output/pankha-agent-ipmi-linux_x86_64"
 ifdef VERSION
-	@echo "✓ Version: $(VERSION)"
+	@echo "✓ Version: $(PANKHA_VERSION)"
 endif
 
-aarch64: inject-version
+aarch64:
 	@echo "Building aarch64..."
-	cargo build --release --target aarch64-unknown-linux-gnu
-#	Optional: Copy to custom output directory
+ifdef VERSION
+	@echo "PANKHA_VERSION=$(PANKHA_VERSION)"
+endif
+	cargo build --release --target aarch64-unknown-linux-gnu --locked
 	mkdir -p output/
 	cp target/aarch64-unknown-linux-gnu/release/pankha-agent-ipmi-linux output/pankha-agent-ipmi-linux_arm64
 	@echo "✓ Copied to: output/pankha-agent-ipmi-linux_arm64"
 ifdef VERSION
-	@echo "✓ Version: $(VERSION)"
+	@echo "✓ Version: $(PANKHA_VERSION)"
 endif
 
 clean:
 	cargo clean
 	# Optional: Clean custom output directories
-	# Uncomment if you enabled custom output directories above
 	# rm -rf output
 
 help:
 	@echo "Pankha IPMI Agent Build System"
 	@echo ""
 	@echo "Usage:"
-	@echo "  make all                    - Build both x86_64 and aarch64 binaries"
-	@echo "  make x86_64                 - Build only x86_64 binary"
-	@echo "  make aarch64                - Build only aarch64 binary"
-	@echo "  make VERSION=0.1.7.2 all    - Build with specific version"
-	@echo "  make VERSION=0.1.7.2 x86_64 - Build x86_64 with specific version"
-	@echo "  make clean                  - Remove all build artifacts"
-	@echo "  make help                   - Show this help message"
+	@echo "  make all                          - Build x86_64 only (aarch64 not yet supported)"
+	@echo "  make x86_64                       - Build only x86_64 binary"
+	@echo "  make aarch64                      - Build only aarch64 binary (manual)"
+	@echo "  make VERSION=0.4.24-alpha2 all    - Build with specific version"
+	@echo "  make VERSION=0.4.24-alpha2 x86_64 - Build x86_64 with specific version"
+	@echo "  make clean                        - Remove all build artifacts"
+	@echo "  make help                         - Show this help message"
 	@echo ""
 	@echo "Output locations:"
 	@echo "  x86_64:  output/pankha-agent-ipmi-linux_x86_64"
 	@echo "  aarch64: output/pankha-agent-ipmi-linux_arm64"
 	@echo ""
-

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/build.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/build.rs
@@ -7,6 +7,32 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    inject_version();
+    generate_sst_validation();
+}
+
+/// Resolves PANKHA_VERSION from env, falls back to "0.0.0-dev" placeholder.
+/// Warns on local release builds (not CI) to remind devs to set the var explicitly.
+fn inject_version() {
+    let version = match env::var("PANKHA_VERSION") {
+        Ok(v) => v,
+        Err(_) => {
+            if env::var("PROFILE").as_deref() == Ok("release")
+                && env::var("CI").is_err()
+            {
+                println!("cargo:warning=PANKHA_VERSION not set, using placeholder \"0.0.0-dev\"");
+                println!("cargo:warning=To set, use one of:");
+                println!("cargo:warning=  PANKHA_VERSION=0.4.24-alpha2 cargo build --release");
+                println!("cargo:warning=  make VERSION=0.4.24-alpha2 all");
+            }
+            "0.0.0-dev".to_string()
+        }
+    };
+    println!("cargo:rustc-env=PANKHA_VERSION={}", version);
+    println!("cargo:rerun-if-env-changed=PANKHA_VERSION");
+}
+
+fn generate_sst_validation() {
     println!("cargo:rerun-if-changed=../../../../../frontend/src/config/ui-options.json");
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/app/cli.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/app/cli.rs
@@ -32,7 +32,7 @@ IPMI:
 
 #[derive(Parser, Debug)]
 #[command(name = "pankha-agent")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = crate::version::VERSION)]
 #[command(about = "Pankha IPMI Host Agent - BMC fan control via ipmitool", long_about = None)]
 #[command(after_help = "")]
 #[command(disable_help_flag = false)]

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
@@ -32,7 +32,7 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
     println!("\n╔══════════════════════════════════════════╗");
     println!("║    Pankha IPMI Host Agent Setup Wizard   ║");
     println!("╚══════════════════════════════════════════╝");
-    println!("Build: \x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("Build: \x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
 
     // Load existing config if present
     let existing_config = if config_file.exists() {

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/daemon/control.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/daemon/control.rs
@@ -29,7 +29,7 @@ pub fn start_daemon_with_log_level(log_level: Option<String>) -> Result<()> {
         process::exit(1);
     }
 
-    println!("\x1b[32mStarting pankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mStarting pankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
 
     // Prepare log file
     ensure_directories()?;
@@ -123,7 +123,7 @@ pub fn stop_daemon() -> Result<()> {
 }
 
 pub fn restart_daemon_with_log_level(log_level: Option<String>) -> Result<()> {
-    println!("\x1b[32mRestarting pankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mRestarting pankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
 
     // Check if systemd service is actively managing the process
     // If so, delegate to systemctl to prevent auto-restart conflicts

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/daemon/status.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/daemon/status.rs
@@ -9,7 +9,7 @@ use crate::daemon::{LOG_DIR, SYSTEMD_SERVICE_PATH};
 use crate::config::persistence::load_config;
 
 pub async fn show_status() -> Result<()> {
-    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
     println!("================================");
 
     if is_running() {
@@ -47,7 +47,7 @@ pub async fn show_status() -> Result<()> {
 
 /// Run health check to verify agent installation
 pub fn run_health_check() -> Result<()> {
-    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+    println!("\x1b[32mpankha-agent v{} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
     println!("Health Check");
     println!("============\n");
 

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/hardware/ipmi/ipmi_monitor.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/hardware/ipmi/ipmi_monitor.rs
@@ -537,7 +537,7 @@ impl HardwareMonitor for IpmiHardwareMonitor {
         }
 
         let metadata = HardwareDumpMetadata {
-            agent_version: env!("CARGO_PKG_VERSION").to_string(),
+            agent_version: crate::version::VERSION.to_string(),
             os_version: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
             is_elevated: unsafe { libc::geteuid() == 0 },
             timestamp: chrono::Utc::now().to_rfc3339(),

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
@@ -6,6 +6,7 @@ mod daemon;
 mod hardware;
 mod profiles;
 mod system;
+mod version;
 mod websocket;
 
 use anyhow::Result;
@@ -44,7 +45,7 @@ async fn main() -> Result<()> {
             }
             // Custom version output with architecture (green)
             if err.kind() == clap::error::ErrorKind::DisplayVersion {
-                println!("\x1b[32mpankha-agent {} ({})\x1b[0m", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent {} ({})\x1b[0m", crate::version::VERSION, std::env::consts::ARCH);
                 std::process::exit(0);
             }
 
@@ -103,13 +104,13 @@ async fn main() -> Result<()> {
             Some(n) => {
                 // Show last N lines: tail -n <lines>
                 println!("Showing last {} log entries...", n);
-                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
                 cmd.arg("-n").arg(n.to_string());
             }
             None => {
                 // Follow logs: tail -f
                 println!("Showing live agent logs (Ctrl+C to exit)...");
-                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", env!("CARGO_PKG_VERSION"), std::env::consts::ARCH);
+                println!("\x1b[32mpankha-agent v{} ({})\x1b[0m\n", crate::version::VERSION, std::env::consts::ARCH);
                 cmd.arg("-f");
             }
         }
@@ -242,7 +243,7 @@ async fn main() -> Result<()> {
     }
 
     // Log startup message (only for normal operation, not setup/config commands)
-    info!("Pankha IPMI Agent v{} starting ({})", env!("CARGO_PKG_VERSION"), std::env::consts::OS);
+    info!("Pankha IPMI Agent v{} starting ({})", crate::version::VERSION, std::env::consts::OS);
 
     // Check if config file exists (required for normal operation)
     let config_file_path = std::env::current_exe()?

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/version.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/version.rs
@@ -1,0 +1,4 @@
+//! Agent version, embedded at build time from the PANKHA_VERSION env var.
+//! See build.rs for the resolution logic.
+
+pub const VERSION: &str = env!("PANKHA_VERSION");

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/messaging.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/messaging.rs
@@ -83,7 +83,7 @@ impl super::client::WebSocketClient {
                 "name": config.agent.name,
                 "agent_type": "ipmi_host",
                 "profile_id": self.hardware_monitor.profile_id(),
-                "agent_version": env!("CARGO_PKG_VERSION"),
+                "agent_version": crate::version::VERSION,
                 "platform": std::env::consts::OS, // "linux", "macos", "windows", etc.
                 "architecture": crate::app::platform::project_arch(),
                 "update_interval": config.agent.update_interval as u64, // Send in seconds to match frontend/backend format

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/self_update.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/self_update.rs
@@ -29,7 +29,7 @@ impl super::client::WebSocketClient {
     /// 5. Write .update_pending marker
     /// 6. Re-exec or systemctl restart
     pub(crate) async fn self_update(&self, target_version: Option<String>) -> Result<()> {
-        let current_version = env!("CARGO_PKG_VERSION");
+        let current_version = crate::version::VERSION;
 
         // Version check: skip if already on target version
         if let Some(ref target) = target_version {


### PR DESCRIPTION
…Cargo.toml mutation

  - Add build.rs inject_version() resolving PANKHA_VERSION at compile time
  - Add src/version.rs central VERSION constant (replaces 26 env!("CARGO_PKG_VERSION") sites)
  - Pin Cargo.toml version to "0.0.0-dev" placeholder; release tag now embedded via env var
  - Update release-public.yml: drop sed step, compute PANKHA_VERSION, add empty/dev guard, --locked preserved
  - Update Makefiles: forward VERSION → PANKHA_VERSION, drop inject-version/reset-version targets

  Fixes the release-public.yml --locked failure introduced by the dependabot CI hardening. This new approach is more robust and eliminates the need for sed-based Cargo.toml mutation, which can lead to state corruption if interrupted. The version is now injected at build time via environment variables, and the code references a central VERSION constant, ensuring consistency across the codebase.