### PR TITLE
Feature/license fixes discounts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,3 +58,13 @@ samples/
 backups/
 .github/
 
+# Runtime container mounts (DB files, staging) — never used by build
+backend/docker-data/
+
+# Root-level metadata not needed inside the container
+# (LICENSE / LICENSE-COMMERCIAL.md intentionally kept)
+/AGENTS.md
+/CLAUDE.md
+/CLA.md
+/README.md
+/release.json

--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -401,3 +401,14 @@ END $$;
 UPDATE systems SET agent_type = 'os_linux' WHERE agent_type = 'os' AND (platform = 'linux' OR platform = 'unknown');
 UPDATE systems SET agent_type = 'os_windows' WHERE agent_type = 'os' AND platform = 'windows';
 UPDATE systems SET agent_type = 'ipmi_host' WHERE agent_type = 'ipmi';
+
+-- Migration: Add last_sync_at column to license_config (persist license-server sync timestamp across restarts)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'license_config' AND column_name = 'last_sync_at'
+  ) THEN
+    ALTER TABLE license_config ADD COLUMN last_sync_at TIMESTAMPTZ;
+    RAISE NOTICE 'Migration: Added last_sync_at column to license_config';
+  END IF;
+END $$;

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -27,6 +27,8 @@ export class LicenseManager {
   private nextBillingDate: Date | null = null;  // Next payment date (subscriptions)
   private discountCode: string | null = null;  // Applied promo code
   private discountCyclesRemaining: number | null = null;  // Remaining discounted renewals
+  private periodInterval: string | null = null;  // From JWT period_interval claim — billing cadence display ("Day"|"Week"|"Month"|"Year")
+  private periodCount: number | null = null;     // From JWT period_count claim — e.g. 1, 7
   private lastSyncAt: Date | null = null;  // Last successful sync with license server
   private readonly CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -136,6 +138,8 @@ export class LicenseManager {
       this.nextBillingDate = null;
       this.discountCode = null;
       this.discountCyclesRemaining = null;
+      this.periodInterval = null;
+      this.periodCount = null;
       this.lastSyncAt = null;
       this.cacheExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
@@ -236,6 +240,8 @@ export class LicenseManager {
     nextBillingDate: string | null;
     discountCode: string | null;
     discountCyclesRemaining: number | null;
+    periodInterval: string | null;
+    periodCount: number | null;
     lastSyncAt: string | null;
   }> {
     // Check if auto-sync is needed before returning info
@@ -259,6 +265,8 @@ export class LicenseManager {
       nextBillingDate: this.nextBillingDate ? this.nextBillingDate.toISOString() : null,
       discountCode: this.discountCode,
       discountCyclesRemaining: this.discountCyclesRemaining,
+      periodInterval: this.periodInterval,
+      periodCount: this.periodCount,
       lastSyncAt: this.lastSyncAt ? this.lastSyncAt.toISOString() : null,
     };
   }
@@ -398,6 +406,115 @@ export class LicenseManager {
   }
 
   /**
+   * Force-renew license token via Worker /renew (vendor-independent recovery path).
+   *
+   * Unlike syncWithLicenseServer (which reads /status to pick up existing fresher tokens),
+   * this actively mints a new token via /renew. Use case: customer's token can't be
+   * recovered via Sync (e.g., Dodo webhook failed to fire), customer wants to force
+   * a refresh subject to the worker's cooldown (15min) + daily cap (3/day).
+   *
+   * D-redesign rules apply on the worker side: exp = MAX(Dodo's next_billing_date,
+   * current_exp) when Dodo reachable, 24h bridge when Dodo unreachable. No
+   * unilateral free extension.
+   */
+  async renewLicenseToken(): Promise<{
+    success: boolean;
+    changed: boolean;
+    newExpiresAt?: Date;
+    isRateLimited?: boolean;
+    error?: string;
+  }> {
+    if (!this.licenseId) {
+      return { success: false, changed: false, error: 'No license token to renew' };
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const storedToken = await this.getStoredLicenseKey();
+      if (!storedToken) {
+        return { success: false, changed: false, error: 'No stored license token' };
+      }
+
+      const response = await fetch(`${LICENSE_API_URL}/renew`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: storedToken }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        log.error(`Renew failed (${response.status}): ${errorBody}`, 'LicenseManager');
+        let parsed: { error?: string } | null = null;
+        try { parsed = JSON.parse(errorBody); } catch { /* non-JSON body */ }
+
+        if (response.status === 429) {
+          return {
+            success: false,
+            changed: false,
+            isRateLimited: true,
+            error: parsed?.error || 'Rate limit reached. Try again later.',
+          };
+        }
+        return {
+          success: false,
+          changed: false,
+          error: parsed?.error || 'License server error',
+        };
+      }
+
+      const result = await response.json() as {
+        success: boolean;
+        newToken?: string;
+        expiresAt?: string;
+        error?: string;
+      };
+
+      if (!result.success || !result.newToken) {
+        return {
+          success: false,
+          changed: false,
+          error: result.error || 'Renewal returned no token',
+        };
+      }
+
+      log.info('Renewal succeeded — applying new token', 'LicenseManager');
+      const applyResult = await this.setLicenseKey(result.newToken);
+      if (!applyResult.success) {
+        return {
+          success: false,
+          changed: false,
+          error: `Token apply failed: ${applyResult.error}`,
+        };
+      }
+
+      log.info(`Token renewed: now on ${applyResult.tier} tier`, 'LicenseManager');
+      return {
+        success: true,
+        changed: true,
+        newExpiresAt: result.expiresAt && result.expiresAt !== 'NA'
+          ? new Date(result.expiresAt)
+          : undefined,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        log.error('Renew timeout', 'LicenseManager');
+        return { success: false, changed: false, error: 'Timeout' };
+      }
+      log.error('Renew error', 'LicenseManager', error);
+      return {
+        success: false,
+        changed: false,
+        error: error instanceof Error ? error.message : 'Network error',
+      };
+    }
+  }
+
+  /**
    * Check if auto-sync is needed based on time-to-expiry
    * Progressive frequency: closer to expiry = more frequent syncs
    *
@@ -512,6 +629,8 @@ export class LicenseManager {
     this.customerName = result.customerName || null;  // Store customer name
     this.customerEmail = result.customerEmail || null;  // Store customer email
     this.licenseId = result.licenseId || null;  // Store license ID for /status lookups
+    this.periodInterval = result.periodInterval || null;  // From JWT period_interval claim
+    this.periodCount = (typeof result.periodCount === 'number' && result.periodCount > 0) ? result.periodCount : null;  // From JWT period_count claim
 
     // Persist to database for offline resilience
     try {

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -12,6 +12,7 @@ import { LicenseValidator, ValidationResult } from './LicenseValidator';
 import { TIERS, TierConfig, getTier } from './tiers';
 import { LICENSE_API_URL } from './license-config';
 import Database from '../database/database';
+import { log } from '../utils/logger';
 
 export class LicenseManager {
   private validator: LicenseValidator;
@@ -69,19 +70,19 @@ export class LicenseManager {
         }
 
         await this.validateAndCache(result.rows[0].license_key);
-        console.log(`[LicenseManager] Initialized with tier: ${this.cachedTier.name}`);
+        log.info(`Initialized with tier: ${this.cachedTier.name}`, 'LicenseManager');
 
         // Auto-sync on startup if we have a paid token on file (active OR
         // recently expired) to detect Dodo-side renewals during downtime.
         if (this.hasPaidTokenOnFile()) {
-          console.log('[LicenseManager] Syncing subscription data...');
+          log.info('Syncing subscription data...', 'LicenseManager');
           await this.syncWithLicenseServer();
         }
       } else {
-        console.log('[LicenseManager] No license key found, using free tier');
+        log.info('No license key found, using free tier', 'LicenseManager');
       }
     } catch (error) {
-      console.error('[LicenseManager] Initialization error:', error);
+      log.error('Initialization error', 'LicenseManager', error);
       // Continue with free tier
     }
   }
@@ -111,7 +112,7 @@ export class LicenseManager {
 
       return { success: true, tier: result.tier };
     } catch (error) {
-      console.error('[LicenseManager] Failed to save license:', error);
+      log.error('Failed to save license', 'LicenseManager', error);
       return { success: false, tier: 'free', error: 'Failed to save license' };
     }
   }
@@ -138,10 +139,10 @@ export class LicenseManager {
       this.lastSyncAt = null;
       this.cacheExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
-      console.log('[LicenseManager] License removed, reverted to free tier');
+      log.info('License removed, reverted to free tier', 'LicenseManager');
       return { success: true };
     } catch (error) {
-      console.error('[LicenseManager] Failed to remove license:', error);
+      log.error('Failed to remove license', 'LicenseManager', error);
       return { success: false, error: 'Failed to remove license' };
     }
   }
@@ -164,7 +165,7 @@ export class LicenseManager {
         await this.validateAndCache(result.rows[0].license_key);
       }
     } catch (error) {
-      console.error('[LicenseManager] Re-validation failed:', error);
+      log.error('Re-validation failed', 'LicenseManager', error);
       // Keep using cached tier
     }
 
@@ -304,7 +305,7 @@ export class LicenseManager {
 
       if (!response.ok) {
         const errorBody = await response.text();
-        console.error('[LicenseManager] Sync failed:', errorBody);
+        log.error(`Sync failed: ${errorBody}`, 'LicenseManager');
         // Distinguish "license unknown to server" (permanent) from transient errors.
         // Worker returns 404 with {found: false, ...} when the lid is not in D1.
         let parsed: { found?: boolean } | null = null;
@@ -321,27 +322,30 @@ export class LicenseManager {
         nextBillingDate?: string;
         discountCode?: string;
         discountCyclesRemaining?: number;
-        upgradeToken?: string;
+        replacementToken?: string;
       };
 
       if (!status.found) {
         return { success: true, changed: false };
       }
 
-      // Auto-upgrade: if server returns an upgradeToken, activate the new license
-      if (status.upgradeToken) {
-        console.log('[LicenseManager] Auto-upgrade detected! Activating new license...');
-        const upgradeResult = await this.setLicenseKey(status.upgradeToken);
-        if (upgradeResult.success) {
-          console.log(`[LicenseManager] Auto-upgrade successful: now on ${upgradeResult.tier} tier`);
-          // Sync again to fetch D1 metadata (discount, billing date, etc.) for the new license.
-          // No recursion risk: the new license won't have an upgradeToken.
+      // Same-lid token refresh: D1 holds a fresher JWT for our existing license
+      // (e.g. after a Dodo subscription.renewed UPDATEd the row in place, or
+      // after /renew). Identity-preserving — same lid, possibly new tier/billing
+      // from a plan change. Worker enforces the lineage rules; trust the field.
+      if (status.replacementToken) {
+        log.info('Token replacement detected (same-lid refresh)', 'LicenseManager');
+        const refreshResult = await this.setLicenseKey(status.replacementToken);
+        if (refreshResult.success) {
+          log.info(`Token refreshed: now on ${refreshResult.tier} tier`, 'LicenseManager');
+          // Re-sync to capture updated metadata (discount, billing date, etc.).
+          // Idempotent: post-refresh, status.replacementToken will be absent (hash match).
           const followUp = await this.syncWithLicenseServer();
-          console.log(`[LicenseManager] Post-upgrade sync: discountCode=${followUp.discountCode || 'none'}`);
-          return { success: true, changed: true, upgraded: true };
+          log.info(`Post-refresh sync: discountCode=${followUp.discountCode || 'none'}`, 'LicenseManager');
+          return { success: true, changed: true, upgraded: false };
         } else {
-          console.error(`[LicenseManager] Auto-upgrade failed: ${upgradeResult.error}`);
-          // Fall through to normal sync logic
+          log.error(`Token replacement failed: ${refreshResult.error}`, 'LicenseManager');
+          // Fall through to expiry-only update path below.
         }
       }
 
@@ -358,7 +362,7 @@ export class LicenseManager {
         // Update cached expiry - renewal detected!
         this.licenseExpiresAt = serverExpiry;
         this.cacheExpiry = new Date(Date.now() + this.CACHE_DURATION_MS);
-        console.log(`[LicenseManager] Expiry updated via sync: ${serverExpiry.toISOString()}`);
+        log.info(`Expiry updated via sync: ${serverExpiry.toISOString()}`, 'LicenseManager');
       }
 
       // Update other fields
@@ -381,10 +385,10 @@ export class LicenseManager {
 
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        console.error('[LicenseManager] Sync timeout');
+        log.error('Sync timeout', 'LicenseManager');
         return { success: false, changed: false, error: 'Timeout' };
       }
-      console.error('[LicenseManager] Sync error:', error);
+      log.error('Sync error', 'LicenseManager', error);
       return {
         success: false,
         changed: false,
@@ -446,7 +450,7 @@ export class LicenseManager {
 
     // Sync if interval exceeded
     if (requiredInterval && timeSinceLastSync >= requiredInterval) {
-      console.log(`[LicenseManager] Auto-sync triggered (${Math.round(timeToExpiry / HOUR)}h to expiry, ${Math.round(timeSinceLastSync / 60000)}min since last sync)`);
+      log.info(`Auto-sync triggered (${Math.round(timeToExpiry / HOUR)}h to expiry, ${Math.round(timeSinceLastSync / 60000)}min since last sync)`, 'LicenseManager');
       await this.syncWithLicenseServer();
     }
   }
@@ -477,7 +481,7 @@ export class LicenseManager {
         [when]
       );
     } catch (error) {
-      console.error('[LicenseManager] Failed to persist last_sync_at:', error);
+      log.error('Failed to persist last_sync_at', 'LicenseManager', error);
     }
   }
 
@@ -489,7 +493,7 @@ export class LicenseManager {
       const result = await this.validator.validate(key);
       await this.cacheResult(key, result);
     } catch (error) {
-      console.error('[LicenseManager] Validation error, using cached value');
+      log.error('Validation error, using cached value', 'LicenseManager');
       // Try to load from local cache
       await this.loadFromLocalCache(key);
     }
@@ -521,7 +525,7 @@ export class LicenseManager {
           tier = $2, agent_limit = $3, retention_days = $4, validated_at = NOW()
       `, [key, tier, agentLimit, this.cachedTier.retentionDays]);
     } catch (error) {
-      console.error('[LicenseManager] Failed to cache result:', error);
+      log.error('Failed to cache result', 'LicenseManager', error);
     }
   }
 
@@ -540,7 +544,7 @@ export class LicenseManager {
         this.cacheExpiry = new Date(Date.now() + this.CACHE_DURATION_MS);
       }
     } catch (error) {
-      console.error('[LicenseManager] Failed to load from cache:', error);
+      log.error('Failed to load from cache', 'LicenseManager', error);
       this.cachedTier = TIERS.free;
     }
   }

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -10,6 +10,7 @@
 
 import { LicenseValidator, ValidationResult } from './LicenseValidator';
 import { TIERS, TierConfig, getTier } from './tiers';
+import { LICENSE_API_URL } from './license-config';
 import Database from '../database/database';
 
 export class LicenseManager {
@@ -27,7 +28,6 @@ export class LicenseManager {
   private discountCyclesRemaining: number | null = null;  // Remaining discounted renewals
   private lastSyncAt: Date | null = null;  // Last successful sync with license server
   private readonly CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
-  private readonly LICENSE_API_URL = 'https://license.pankha.app';
 
   constructor() {
     this.validator = new LicenseValidator();
@@ -43,20 +43,37 @@ export class LicenseManager {
   }
 
   /**
+   * Whether we have a stored token from a paid (non-lifetime) purchase.
+   * Drives sync eligibility independently of the current cached tier — so
+   * a token that expired past grace can still recover via /status.
+   */
+  private hasPaidTokenOnFile(): boolean {
+    return this.licenseId !== null
+      && this.licenseBilling !== null
+      && this.licenseBilling !== 'lifetime';
+  }
+
+  /**
    * Initialize license manager - load and validate stored license key
    */
   async initialize(): Promise<void> {
     try {
       const result = await this.getPool().query(
-        'SELECT license_key FROM license_config WHERE id = 1'
+        'SELECT license_key, last_sync_at FROM license_config WHERE id = 1'
       );
 
       if (result.rows.length > 0 && result.rows[0].license_key) {
+        // Load persisted lastSyncAt before sync so checkAutoSync can honor cooldown
+        if (result.rows[0].last_sync_at) {
+          this.lastSyncAt = new Date(result.rows[0].last_sync_at);
+        }
+
         await this.validateAndCache(result.rows[0].license_key);
         console.log(`[LicenseManager] Initialized with tier: ${this.cachedTier.name}`);
 
-        // Auto-sync on startup for paid subscriptions to get nextBillingDate, discountCode, etc.
-        if (this.cachedTier.name !== 'Free' && this.licenseBilling !== 'lifetime' && this.licenseId) {
+        // Auto-sync on startup if we have a paid token on file (active OR
+        // recently expired) to detect Dodo-side renewals during downtime.
+        if (this.hasPaidTokenOnFile()) {
           console.log('[LicenseManager] Syncing subscription data...');
           await this.syncWithLicenseServer();
         }
@@ -80,15 +97,17 @@ export class LicenseManager {
     }
 
     try {
-      // Save to database
+      // Save to database — reset last_sync_at so the fresh license starts
+      // with a clean sync history (prevents stale cooldown from prior token).
       await this.getPool().query(`
-        INSERT INTO license_config (id, license_key, updated_at)
-        VALUES (1, $1, NOW())
-        ON CONFLICT (id) DO UPDATE SET license_key = $1, updated_at = NOW()
+        INSERT INTO license_config (id, license_key, updated_at, last_sync_at)
+        VALUES (1, $1, NOW(), NULL)
+        ON CONFLICT (id) DO UPDATE SET license_key = $1, updated_at = NOW(), last_sync_at = NULL
       `, [key]);
 
       // Cache locally
       await this.cacheResult(key, result);
+      this.lastSyncAt = null;
 
       return { success: true, tier: result.tier };
     } catch (error) {
@@ -113,6 +132,10 @@ export class LicenseManager {
       this.customerName = null;
       this.customerEmail = null;
       this.licenseId = null;
+      this.nextBillingDate = null;
+      this.discountCode = null;
+      this.discountCyclesRemaining = null;
+      this.lastSyncAt = null;
       this.cacheExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
       console.log('[LicenseManager] License removed, reverted to free tier');
@@ -253,13 +276,10 @@ export class LicenseManager {
     discountCyclesRemaining?: number;
     error?: string;
   }> {
-    // Skip sync for free tier or lifetime licenses
-    if (this.cachedTier.name === 'Free' || this.licenseBilling === 'lifetime') {
-      return { success: true, changed: false };
-    }
-
-    // Need licenseId to sync
-    if (!this.licenseId) {
+    // Skip sync for lifetime licenses or when no paid token is on file.
+    // Note: do NOT gate on cachedTier — a hard-expired paid token still
+    // qualifies for sync so we can recover the renewed license from /status.
+    if (!this.hasPaidTokenOnFile()) {
       return { success: true, changed: false };
     }
 
@@ -273,7 +293,7 @@ export class LicenseManager {
         return { success: true, changed: false };
       }
 
-      const response = await fetch(`${this.LICENSE_API_URL}/status`, {
+      const response = await fetch(`${LICENSE_API_URL}/status`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: storedToken, licenseId: this.licenseId }),
@@ -283,8 +303,15 @@ export class LicenseManager {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        const error = await response.text();
-        console.error('[LicenseManager] Sync failed:', error);
+        const errorBody = await response.text();
+        console.error('[LicenseManager] Sync failed:', errorBody);
+        // Distinguish "license unknown to server" (permanent) from transient errors.
+        // Worker returns 404 with {found: false, ...} when the lid is not in D1.
+        let parsed: { found?: boolean } | null = null;
+        try { parsed = JSON.parse(errorBody); } catch { /* non-JSON body */ }
+        if (response.status === 404 && parsed?.found === false) {
+          return { success: false, changed: false, error: 'License not found' };
+        }
         return { success: false, changed: false, error: 'License server error' };
       }
 
@@ -341,6 +368,7 @@ export class LicenseManager {
       this.discountCode = status.discountCode || null;
       this.discountCyclesRemaining = status.discountCyclesRemaining ?? null;
       this.lastSyncAt = new Date();
+      await this.persistLastSyncAt(this.lastSyncAt);
 
       return {
         success: true,
@@ -378,13 +406,15 @@ export class LicenseManager {
    * - < 12 hours out: every 15 minutes
    */
   private async checkAutoSync(): Promise<void> {
-    // Skip for free tier or lifetime
-    if (this.cachedTier.name === 'Free' || this.licenseBilling === 'lifetime') {
+    // Same gate as syncWithLicenseServer — paid (non-lifetime) token must
+    // be on file. Demoted-to-Free state with a hard-expired token still
+    // passes, allowing recovery via /status.
+    if (!this.hasPaidTokenOnFile()) {
       return;
     }
 
-    // Need expiry date and licenseId
-    if (!this.licenseExpiresAt || !this.licenseId) {
+    // Need expiry date to compute interval
+    if (!this.licenseExpiresAt) {
       return;
     }
 
@@ -432,6 +462,22 @@ export class LicenseManager {
       return result.rows[0]?.license_key || null;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Persist lastSyncAt to license_config so it survives container restarts.
+   * Failure here is non-fatal; in-memory value still drives behaviour for
+   * the current process lifetime.
+   */
+  private async persistLastSyncAt(when: Date | null): Promise<void> {
+    try {
+      await this.getPool().query(
+        'UPDATE license_config SET last_sync_at = $1 WHERE id = 1',
+        [when]
+      );
+    } catch (error) {
+      console.error('[LicenseManager] Failed to persist last_sync_at:', error);
     }
   }
 

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -24,6 +24,9 @@ export class LicenseManager {
   private customerName: string | null = null;
   private customerEmail: string | null = null;
   private licenseId: string | null = null;  // License ID for /status lookups
+  private subscriptionId: string | null = null;  // From JWT `sid` claim — Dodo subscription identifier (subscriptions only)
+  private customerId: string | null = null;  // Dodo persistent customer identifier (from /status sync)
+  private licenseKey: string | null = null;  // Raw JWT token — exposed read-only via getLicenseInfo for user copy/backup
   private nextBillingDate: Date | null = null;  // Next payment date (subscriptions)
   private discountCode: string | null = null;  // Applied promo code
   private discountCyclesRemaining: number | null = null;  // Remaining discounted renewals
@@ -135,6 +138,9 @@ export class LicenseManager {
       this.customerName = null;
       this.customerEmail = null;
       this.licenseId = null;
+      this.subscriptionId = null;
+      this.customerId = null;
+      this.licenseKey = null;
       this.nextBillingDate = null;
       this.discountCode = null;
       this.discountCyclesRemaining = null;
@@ -229,6 +235,9 @@ export class LicenseManager {
     customerName: string | null;
     customerEmail: string | null;
     licenseId: string | null;
+    subscriptionId: string | null;
+    customerId: string | null;
+    token: string | null;
     agentLimit: number;
     retentionDays: number;
     alertLimit: number;
@@ -254,6 +263,9 @@ export class LicenseManager {
       customerName: this.customerName,
       customerEmail: this.customerEmail,
       licenseId: this.licenseId,
+      subscriptionId: this.subscriptionId,
+      customerId: this.customerId,
+      token: this.licenseKey,
       agentLimit: tier.agentLimit === Infinity ? -1 : tier.agentLimit,
       retentionDays: tier.retentionDays,
       alertLimit: tier.alertLimit === Infinity ? -1 : tier.alertLimit,
@@ -330,6 +342,7 @@ export class LicenseManager {
         nextBillingDate?: string;
         discountCode?: string;
         discountCyclesRemaining?: number;
+        customerId?: string;
         replacementToken?: string;
       };
 
@@ -379,6 +392,7 @@ export class LicenseManager {
         : null;
       this.discountCode = status.discountCode || null;
       this.discountCyclesRemaining = status.discountCyclesRemaining ?? null;
+      this.customerId = status.customerId || null;
       this.lastSyncAt = new Date();
       await this.persistLastSyncAt(this.lastSyncAt);
 
@@ -629,6 +643,8 @@ export class LicenseManager {
     this.customerName = result.customerName || null;  // Store customer name
     this.customerEmail = result.customerEmail || null;  // Store customer email
     this.licenseId = result.licenseId || null;  // Store license ID for /status lookups
+    this.subscriptionId = result.subscriptionId || null;  // From JWT `sid` claim
+    this.licenseKey = key;  // Store raw JWT for read-only exposure to user (copy/backup)
     this.periodInterval = result.periodInterval || null;  // From JWT period_interval claim
     this.periodCount = (typeof result.periodCount === 'number' && result.periodCount > 0) ? result.periodCount : null;  // From JWT period_count claim
 

--- a/backend/src/license/LicenseValidator.ts
+++ b/backend/src/license/LicenseValidator.ts
@@ -22,6 +22,7 @@ export interface ValidationResult {
   tier: string;
   billing?: 'monthly' | 'yearly' | 'lifetime';
   licenseId?: string;
+  subscriptionId?: string;    // From JWT `sid` claim — Dodo subscription identifier; absent for lifetime/one-time
   expiresAt: Date | null;
   isGracePeriod: boolean;      // New field: true if currently in 3-day buffer
   activatedAt: Date | null;  // When license was issued
@@ -39,6 +40,7 @@ interface LicensePayload {
   billing?: 'monthly' | 'yearly' | 'lifetime';
   name?: string;   // Customer name
   oid?: string;    // Order ID
+  sid?: string;    // Dodo subscription ID (subscription products only)
   period_interval?: string;  // "Day"|"Week"|"Month"|"Year" — Dodo payment_frequency_interval; absent for lifetime/pre-2026-05-11 tokens
   period_count?: number;     // Dodo payment_frequency_count
 
@@ -209,6 +211,7 @@ export class LicenseValidator {
           tier: 'free',
           billing: payload.billing,
           licenseId: payload.lid || payload.sub,
+          subscriptionId: payload.sid,
           expiresAt: new Date(payload.exp * 1000),
           isGracePeriod: false,
           activatedAt: payload.iat ? new Date(payload.iat * 1000) : null,
@@ -244,6 +247,7 @@ export class LicenseValidator {
         tier: payload.tier,
         billing,
         licenseId,
+        subscriptionId: payload.sid,
         expiresAt,
         isGracePeriod,
         activatedAt: payload.iat ? new Date(payload.iat * 1000) : null,

--- a/backend/src/license/LicenseValidator.ts
+++ b/backend/src/license/LicenseValidator.ts
@@ -197,12 +197,19 @@ export class LicenseValidator {
       const isGracePeriod = !isLifetime && !!payload.exp && payload.exp < now && (payload.exp + GRACE_PERIOD_SECONDS) >= now;
 
       if (isHardExpired) {
+        // Signature already verified above, so payload fields are trustworthy.
+        // Return identifying fields so LicenseManager can still call /status
+        // for renewal recovery even after the local token is past grace.
         return {
           valid: false,
           tier: 'free',
+          billing: payload.billing,
+          licenseId: payload.lid || payload.sub,
           expiresAt: new Date(payload.exp * 1000),
           isGracePeriod: false,
           activatedAt: payload.iat ? new Date(payload.iat * 1000) : null,
+          customerName: payload.name,
+          customerEmail: payload.email,
           error: 'License expired',
         };
       }

--- a/backend/src/license/LicenseValidator.ts
+++ b/backend/src/license/LicenseValidator.ts
@@ -27,6 +27,8 @@ export interface ValidationResult {
   activatedAt: Date | null;  // When license was issued
   customerName?: string;
   customerEmail?: string;
+  periodInterval?: string;   // From JWT period_interval claim — "Day" | "Week" | "Month" | "Year"; absent for lifetime/legacy tokens
+  periodCount?: number;      // From JWT period_count claim — e.g. 1, 7
   error?: string;
 }
 
@@ -37,7 +39,9 @@ interface LicensePayload {
   billing?: 'monthly' | 'yearly' | 'lifetime';
   name?: string;   // Customer name
   oid?: string;    // Order ID
-  
+  period_interval?: string;  // "Day"|"Week"|"Month"|"Year" — Dodo payment_frequency_interval; absent for lifetime/pre-2026-05-11 tokens
+  period_count?: number;     // Dodo payment_frequency_count
+
   // Core fields (both v1 and v2)
   tier: 'pro' | 'enterprise';
   email: string;
@@ -210,6 +214,8 @@ export class LicenseValidator {
           activatedAt: payload.iat ? new Date(payload.iat * 1000) : null,
           customerName: payload.name,
           customerEmail: payload.email,
+          periodInterval: payload.period_interval,
+          periodCount: payload.period_count,
           error: 'License expired',
         };
       }
@@ -243,6 +249,8 @@ export class LicenseValidator {
         activatedAt: payload.iat ? new Date(payload.iat * 1000) : null,
         customerName: payload.name,
         customerEmail: payload.email,
+        periodInterval: payload.period_interval,
+        periodCount: payload.period_count,
       };
     } catch (error) {
       console.error('[LicenseValidator] Validation error:', error);

--- a/backend/src/license/license-config.ts
+++ b/backend/src/license/license-config.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared license/worker configuration constants.
+ *
+ * Single source of truth for the license Worker's base URL. Imported by
+ * LicenseManager (for /status, /sync) and routes (for /promo, /checkout
+ * proxies).
+ */
+
+export const LICENSE_API_URL = 'https://license.pankha.app';

--- a/backend/src/license/routes.ts
+++ b/backend/src/license/routes.ts
@@ -6,12 +6,15 @@
  * - GET /api/license/pricing - Get all tier pricing info
  * - POST /api/license - Set/update license key
  * - POST /api/license/sync - Force sync with license server (for renewals)
+ * - GET /api/license/promo - List advertised discounts (proxies to Worker)
+ * - POST /api/license/checkout - Create Dodo checkout session (proxies to Worker)
  * - DELETE /api/license - Remove license (revert to free tier)
  */
 
 import { Router, Request, Response } from 'express';
 import { licenseManager } from './LicenseManager';
 import { TIERS } from './tiers';
+import { LICENSE_API_URL } from './license-config';
 
 const router = Router();
 
@@ -46,6 +49,7 @@ router.get('/pricing', async (req: Request, res: Response) => {
         apiAccess: TIERS.free.apiAccess,
         showBranding: TIERS.free.showBranding,
         pricing: TIERS.free.pricing,
+        benefits: TIERS.free.benefits,
       },
       pro: {
         name: TIERS.pro.name,
@@ -56,6 +60,7 @@ router.get('/pricing', async (req: Request, res: Response) => {
         apiAccess: TIERS.pro.apiAccess,
         showBranding: TIERS.pro.showBranding,
         pricing: TIERS.pro.pricing,
+        benefits: TIERS.pro.benefits,
       },
       enterprise: {
         name: TIERS.enterprise.name,
@@ -66,6 +71,7 @@ router.get('/pricing', async (req: Request, res: Response) => {
         apiAccess: TIERS.enterprise.apiAccess,
         showBranding: TIERS.enterprise.showBranding,
         pricing: TIERS.enterprise.pricing,
+        benefits: TIERS.enterprise.benefits,
       },
     };
     res.json(pricing);
@@ -139,6 +145,69 @@ router.post('/sync', async (req: Request, res: Response) => {
     res.status(500).json({
       success: false,
       error: 'Sync failed'
+    });
+  }
+});
+
+/**
+ * GET /api/license/promo
+ * List currently-advertised Dodo discounts. Proxies to Worker GET /promo.
+ * Worker holds DODO_API_KEY; this backend never sees it.
+ * On any failure, returns an empty offers array so the UI gracefully shows
+ * no banner instead of erroring.
+ */
+router.get('/promo', async (req: Request, res: Response) => {
+  try {
+    const r = await fetch(`${LICENSE_API_URL}/promo`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!r.ok) {
+      return res.json({ offers: [], fetchedAt: null });
+    }
+    const data = await r.json();
+    res.json(data);
+  } catch (error) {
+    console.error('[License API] Promo proxy error:', error);
+    res.json({ offers: [], fetchedAt: null });
+  }
+});
+
+/**
+ * POST /api/license/checkout
+ * Create a Dodo checkout session with optional pre-applied discount.
+ * Proxies to Worker POST /checkout. Returns { ok, checkoutUrl } on success
+ * or { ok: false, error, message } on failure so the frontend can decide
+ * whether to retry, fall back to a static URL, or surface an error.
+ */
+router.post('/checkout', async (req: Request, res: Response) => {
+  const { productId, discountCode, returnUrl } = req.body || {};
+
+  if (!productId || typeof productId !== 'string') {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_request',
+      message: 'productId required',
+    });
+  }
+
+  try {
+    const r = await fetch(`${LICENSE_API_URL}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        productId,
+        discountCode: typeof discountCode === 'string' ? discountCode : undefined,
+        returnUrl: typeof returnUrl === 'string' ? returnUrl : undefined,
+      }),
+    });
+    const data = await r.json();
+    res.status(r.status).json(data);
+  } catch (error) {
+    console.error('[License API] Checkout proxy error:', error);
+    res.status(502).json({
+      ok: false,
+      error: 'dodo_error',
+      message: 'License server unreachable',
     });
   }
 });

--- a/backend/src/license/routes.ts
+++ b/backend/src/license/routes.ts
@@ -150,6 +150,36 @@ router.post('/sync', async (req: Request, res: Response) => {
 });
 
 /**
+ * POST /api/license/renew
+ * Force-refresh license token via worker /renew (vendor-independent recovery path).
+ * Different from /sync which only reads /status. /renew actively mints a fresh JWT.
+ * Subject to worker-side rate limits (15min cooldown, 3/day cap).
+ */
+router.post('/renew', async (req: Request, res: Response) => {
+  try {
+    const result = await licenseManager.renewLicenseToken();
+
+    if (result.success && result.changed) {
+      const info = await licenseManager.getLicenseInfo();
+      res.json({
+        ...result,
+        license: info,
+      });
+    } else {
+      // 429 for rate limit, 400 for client-side problems, 502 for upstream
+      const status = result.isRateLimited ? 429 : (result.success ? 200 : 502);
+      res.status(status).json(result);
+    }
+  } catch (error) {
+    console.error('[License API] Renew error:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Renew failed',
+    });
+  }
+});
+
+/**
  * GET /api/license/promo
  * List currently-advertised Dodo discounts. Proxies to Worker GET /promo.
  * Worker holds DODO_API_KEY; this backend never sees it.

--- a/backend/src/license/tiers.ts
+++ b/backend/src/license/tiers.ts
@@ -27,40 +27,67 @@ export interface TierConfig {
   apiAccess: 'none' | 'read' | 'full';
   showBranding: boolean;
   pricing: TierPricing;
+  benefits: string[];
 }
 
-export const TIERS: Record<string, TierConfig> = {
-  free: {
-    name: 'Free',
-    agentLimit: 3,
-    retentionDays: 7,
-    alertLimit: 2,  // Critical temp and fan fail only
-    alertChannels: ['dashboard', 'email'],
-    apiAccess: 'none',
-    showBranding: true,
-    pricing: { monthly: 0, yearly: 0, lifetime: 0 },
-  },
-  pro: {
-    name: 'Pro',
-    agentLimit: 10,
-    retentionDays: 30,
-    alertLimit: Infinity,
-    alertChannels: ['dashboard', 'email', 'webhook'],
-    apiAccess: 'full',
-    showBranding: true,
-    pricing: { monthly: 5, yearly: 49, lifetime: 199 },
-  },
-  enterprise: {
-    name: 'Enterprise',
-    agentLimit: Infinity,
-    retentionDays: 365,
-    alertLimit: Infinity,
-    alertChannels: ['dashboard', 'email', 'webhook'],
-    apiAccess: 'full',
-    showBranding: false,
-    pricing: { monthly: 25, yearly: 249, lifetime: 649 },
-  },
+const free: TierConfig = {
+  name: 'Free',
+  agentLimit: 3,
+  retentionDays: 7,
+  alertLimit: 2,  // Critical temp and fan fail only
+  alertChannels: ['dashboard', 'email'],
+  apiAccess: 'none',
+  showBranding: true,
+  pricing: { monthly: 0, yearly: 0, lifetime: 0 },
+  benefits: [],
 };
+free.benefits = [
+  `${free.agentLimit} Agents`,
+  `${free.retentionDays} Days History`,
+  'Critical Temp & Fan Fail Alerts',
+  'Dashboard & Email Notifications',
+];
+
+const pro: TierConfig = {
+  name: 'Pro',
+  agentLimit: 10,
+  retentionDays: 30,
+  alertLimit: Infinity,
+  alertChannels: ['dashboard', 'email', 'webhook'],
+  apiAccess: 'full',
+  showBranding: true,
+  pricing: { monthly: 5, yearly: 49, lifetime: 199 },
+  benefits: [],
+};
+pro.benefits = [
+  `${pro.agentLimit} Agents`,
+  `${pro.retentionDays} Days History`,
+  'Unlimited Alerts',
+  'All Notification Channels',
+  'Full API Access',
+];
+
+const enterprise: TierConfig = {
+  name: 'Enterprise',
+  agentLimit: Infinity,
+  retentionDays: 365,
+  alertLimit: Infinity,
+  alertChannels: ['dashboard', 'email', 'webhook'],
+  apiAccess: 'full',
+  showBranding: false,
+  pricing: { monthly: 25, yearly: 249, lifetime: 649 },
+  benefits: [],
+};
+enterprise.benefits = [
+  enterprise.agentLimit === Infinity ? 'Unlimited Agents' : `${enterprise.agentLimit} Agents`,
+  `${enterprise.retentionDays} Days History`,
+  'Unlimited Alerts',
+  'All Notification Channels',
+  'Full API Access',
+  'No Branding',
+];
+
+export const TIERS: Record<string, TierConfig> = { free, pro, enterprise };
 
 /**
  * Get tier configuration by name (case-insensitive)

--- a/frontend/src/license/LicenseContext.tsx
+++ b/frontend/src/license/LicenseContext.tsx
@@ -22,6 +22,8 @@ export interface LicenseInfo {
   nextBillingDate: string | null;
   discountCode: string | null;
   discountCyclesRemaining: number | null;
+  periodInterval: string | null;  // From JWT period_interval claim — "Day"|"Week"|"Month"|"Year"; null falls back to billing enum for badge display
+  periodCount: number | null;     // From JWT period_count claim — e.g. 1, 7
   lastSyncAt: string | null;
 }
 
@@ -70,6 +72,8 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
         nextBillingDate: null,
         discountCode: null,
         discountCyclesRemaining: null,
+        periodInterval: null,
+        periodCount: null,
         lastSyncAt: null,
       });
     } finally {

--- a/frontend/src/license/LicenseContext.tsx
+++ b/frontend/src/license/LicenseContext.tsx
@@ -11,6 +11,9 @@ export interface LicenseInfo {
   customerName: string | null;
   customerEmail: string | null;
   licenseId: string | null;
+  subscriptionId: string | null;  // JWT `sid` claim — Dodo subscription identifier; null for lifetime/free
+  customerId: string | null;      // Dodo persistent customer identifier (from /status sync); null if not yet synced
+  token: string | null;           // Raw JWT for user-visible reveal/copy field; null on free tier
   agentLimit: number;
   retentionDays: number;
   alertLimit: number;
@@ -61,6 +64,9 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
         customerName: null,
         customerEmail: null,
         licenseId: null,
+        subscriptionId: null,
+        customerId: null,
+        token: null,
         agentLimit: 3,
         retentionDays: 7,
         alertLimit: 2,

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -1861,11 +1861,25 @@ const Settings: React.FC = () => {
                           else barUrgency = 'normal';
                         }
 
+                        // Stamp tier — drives the big "%" amount color so it
+                        // matches the rarity color of the highest tier this
+                        // discount applies to. Highest rarity wins:
+                        // lifetime > enterprise > pro.
+                        let stampTier: 'pro' | 'enterprise' | 'lifetime' | null = null;
+                        if (offer.appliesTo.some((a) => a.billing === 'lifetime')) {
+                          stampTier = 'lifetime';
+                        } else if (offer.appliesTo.some((a) => a.tier === 'enterprise')) {
+                          stampTier = 'enterprise';
+                        } else if (offer.appliesTo.some((a) => a.tier === 'pro')) {
+                          stampTier = 'pro';
+                        }
+
                         return (
                           <article
                             key={offer.code}
                             className="promo-offer"
                             data-urgency={urgency ?? undefined}
+                            data-stamp-tier={stampTier ?? undefined}
                           >
                             <div className="promo-offer-stamp">
                               <span className="promo-offer-stamp-label">SAVE</span>
@@ -1892,20 +1906,26 @@ const Settings: React.FC = () => {
                                   <span className="promo-offer-label-dot" aria-hidden="true" />
                                   {hasLimit ? 'LIMITED OFFER' : 'OFFER'}
                                 </span>
-                                {daysRemaining != null && (
-                                  <span className="promo-offer-days">{daysRemaining} days remaining</span>
-                                )}
                               </div>
                               <h4 className="promo-offer-title">{productSummary || 'Select plans'}</h4>
 
-                              {offer.remaining != null && (
+                              {(offer.remaining != null || daysRemaining != null) && (
                                 <div className="promo-offer-spots">
-                                  <span className="promo-offer-spots-text">
-                                    {urgency === 'critical' && (
-                                      <Flame size={12} className="promo-offer-spots-icon" aria-hidden="true" />
+                                  <div className="promo-offer-spots-row">
+                                    {offer.remaining != null && (
+                                      <span className="promo-offer-spots-text">
+                                        {urgency === 'critical' && (
+                                          <Flame size={12} className="promo-offer-spots-icon" aria-hidden="true" />
+                                        )}
+                                        <span className="promo-offer-spots-current">{offer.remaining}</span>
+                                        {offer.totalLimit != null && <> of {offer.totalLimit}</>}
+                                        {' '}{offer.remaining === 1 ? 'spot' : 'spots'} left
+                                      </span>
                                     )}
-                                    {offer.remaining} {offer.remaining === 1 ? 'spot' : 'spots'} left
-                                  </span>
+                                    {daysRemaining != null && (
+                                      <span className="promo-offer-days">{daysRemaining} days remaining</span>
+                                    )}
+                                  </div>
                                   {spotsRatio != null && (
                                     <div
                                       className="promo-offer-spots-bar"
@@ -1966,7 +1986,7 @@ const Settings: React.FC = () => {
                       const proStaticUrl = CHECKOUT_URLS.pro[proBilling];
                       const proPeriodSuffix = proBilling === 'monthly' ? 'mo' : 'yr';
                       return (
-                        <div className="pricing-card featured">
+                        <div className="pricing-card featured" data-tier="pro">
                           <div className="pricing-header">
                             <h4>Pro</h4>
                             <div className="pricing-toggle">
@@ -2050,7 +2070,7 @@ const Settings: React.FC = () => {
                       const entStaticUrl = CHECKOUT_URLS.enterprise[enterpriseBilling];
                       const entPeriodSuffix = enterpriseBilling === 'monthly' ? 'mo' : 'yr';
                       return (
-                        <div className="pricing-card">
+                        <div className="pricing-card" data-tier="enterprise">
                           <div className="pricing-header">
                             <h4>Enterprise</h4>
                             <div className="pricing-toggle">
@@ -2134,7 +2154,7 @@ const Settings: React.FC = () => {
                       const lifeStaticUrl = CHECKOUT_URLS[lifetimeTier].lifetime;
                       const lifeTierLabel = lifetimeTier === 'pro' ? 'Pro' : 'Enterprise';
                       return (
-                        <div className="pricing-card lifetime">
+                        <div className="pricing-card lifetime" data-tier="lifetime">
                           <div className="pricing-badge best-value">BEST VALUE</div>
                           <div className="pricing-header">
                             <h4>Lifetime</h4>

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -3,10 +3,10 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useLicense } from '../../license';
+import { useLicense, type LicenseInfo } from '../../license';
 import { PRIMARY_FONT_OPTIONS, SECONDARY_FONT_OPTIONS, type UIPrimaryFontChoice, type UISecondaryFontChoice, useDashboardSettings } from '../../contexts/DashboardSettingsContext';
 import { setLicense, getPricing, deleteLicense, getSystems, getDiagnostics } from '../../services/api';
-import { formatDate, formatFriendlyDate } from '../../utils/formatters';
+import { formatDate, formatFriendlyDate, USER_TIMEZONE } from '../../utils/formatters';
 import { toast } from '../../utils/toast';
 import { useDemoMode } from '../../hooks/useDemoMode';
 import ColorPicker from './ColorPicker';
@@ -30,7 +30,9 @@ import {
   Check,
   KeyRound,
   Clock,
-  Flame
+  Flame,
+  Eye,
+  EyeOff
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -828,9 +830,13 @@ const Settings: React.FC = () => {
   const [pricing, setPricing] = useState<PricingData | null>(null);
   const [promo, setPromo] = useState<PromoResponse | null>(null);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
+  const [tokenRevealed, setTokenRevealed] = useState(false);
+  // Tracks which one-shot copy succeeded so the icon can flip to a check briefly.
+  // Values: 'token' (license token field), 'account' (Copy All in Account Details).
+  const [copiedTarget, setCopiedTarget] = useState<'token' | 'account' | null>(null);
 
   // General Settings from Context
-  const { graphScale, updateGraphScale, dataRetentionDays, updateDataRetention, timezone, hardwarePruneDays, updateHardwarePruneDays, hubLogLevel, updateHubLogLevel } = useDashboardSettings();
+  const { graphScale, updateGraphScale, dataRetentionDays, updateDataRetention, hardwarePruneDays, updateHardwarePruneDays, hubLogLevel, updateHubLogLevel } = useDashboardSettings();
   const [isCustomScale, setIsCustomScale] = useState(false);
   const [customScaleInput, setCustomScaleInput] = useState(graphScale.toString());
   const [isCustomRetention, setIsCustomRetention] = useState(false);
@@ -992,6 +998,67 @@ const Settings: React.FC = () => {
     }
   };
 
+  // Copy arbitrary text using the same secure-context fallback strategy as
+  // copyDiscountCode. `target` keys the brief icon-flip on the calling button.
+  const copyToClipboard = async (text: string, target: 'token' | 'account'): Promise<void> => {
+    let ok = false;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        ok = true;
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.top = '0';
+        ta.style.left = '0';
+        ta.style.opacity = '0';
+        ta.style.pointerEvents = 'none';
+        document.body.appendChild(ta);
+        ta.select();
+        ta.setSelectionRange(0, ta.value.length);
+        ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+    } catch {
+      ok = false;
+    }
+    if (ok) {
+      setCopiedTarget(target);
+      setTimeout(() => setCopiedTarget((t) => (t === target ? null : t)), 1500);
+    } else {
+      toast.error('Could not copy. Select and copy manually.');
+    }
+  };
+
+  // Mask a token to first 24 + dots + last 12 chars for the default hidden view.
+  const maskToken = (t: string): string => {
+    if (t.length <= 40) return t;
+    return `${t.slice(0, 24)}${'.'.repeat(12)}${t.slice(-12)}`;
+  };
+
+  // Compose Account Details as plain text for the "Copy All" button. The token
+  // is intentionally excluded — users with paranoid clipboards / screen-share
+  // contexts can copy it separately via the dedicated token copy button.
+  const composeAccountDetails = (info: LicenseInfo): string => {
+    const lines: string[] = ['Account Details'];
+    if (info.customerName) lines.push(`Name: ${info.customerName}`);
+    if (info.customerEmail) lines.push(`Email: ${info.customerEmail}`);
+    if (info.licenseId) lines.push(`License ID: ${info.licenseId}`);
+    if (info.subscriptionId) lines.push(`Subscription ID: ${info.subscriptionId}`);
+    if (info.customerId) lines.push(`Customer ID: ${info.customerId}`);
+    if (info.discountCode) {
+      const cycles = info.discountCyclesRemaining;
+      const cyclesPart = cycles != null && cycles > 0 ? `, ${cycles} cycles remaining` : '';
+      lines.push(`Discount: ${info.discountCode}${cyclesPart}`);
+    }
+    if (info.lastSyncAt) {
+      lines.push(`Last Synced: ${formatFriendlyDate(info.lastSyncAt, USER_TIMEZONE)}`);
+    }
+    return lines.join('\n');
+  };
+
   // Click handler for "Get Pro/Enterprise" buttons. With a discount code,
   // calls backend /checkout to get a Dodo Sessions URL with discount
   // pre-applied. Without a discount, opens the static Dodo URL directly.
@@ -1007,7 +1074,11 @@ const Settings: React.FC = () => {
       const r = await fetch('/api/license/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId, discountCode }),
+        body: JSON.stringify({
+          productId,
+          discountCode,
+          returnUrl: `${window.location.origin}/settings?tab=license`,
+        }),
       });
       const data = await r.json();
       if (data.ok && data.checkoutUrl) {
@@ -2261,8 +2332,8 @@ const Settings: React.FC = () => {
                       <div className="limit-item" title={formatDateTooltip(license.activatedAt)}>
                         <span className="limit-label">Activated</span>
                         <div className="limit-value-group">
-                          <span className="limit-value">{formatDate(license.activatedAt, timezone)}</span>
-                          <span className="limit-subtext-date">{formatFriendlyDate(license.activatedAt, timezone)}</span>
+                          <span className="limit-value">{formatDate(license.activatedAt, USER_TIMEZONE)}</span>
+                          <span className="limit-subtext-date">{formatFriendlyDate(license.activatedAt, USER_TIMEZONE)}</span>
                         </div>
                       </div>
                     )}
@@ -2270,10 +2341,10 @@ const Settings: React.FC = () => {
                       <span className="limit-label">Expires</span>
                       <div className="limit-value-group">
                         <span className="limit-value">
-                          {license.expiresAt ? formatDate(license.expiresAt, timezone) : 'Lifetime'}
+                          {license.expiresAt ? formatDate(license.expiresAt, USER_TIMEZONE) : 'Lifetime'}
                         </span>
                         {license.expiresAt && (
-                          <span className="limit-subtext-date">{formatFriendlyDate(license.expiresAt, timezone)}</span>
+                          <span className="limit-subtext-date">{formatFriendlyDate(license.expiresAt, USER_TIMEZONE)}</span>
                         )}
                       </div>
                     </div>
@@ -2290,7 +2361,7 @@ const Settings: React.FC = () => {
                             {/* Show "Renews {date}" for subscriptions, or nothing for lifetime */}
                             {license.billing !== 'lifetime' && license.nextBillingDate && (
                               <span className="limit-subtext-date">
-                                Renews {formatFriendlyDate(license.nextBillingDate, timezone)}
+                                Renews {formatFriendlyDate(license.nextBillingDate, USER_TIMEZONE)}
                               </span>
                             )}
                           </div>
@@ -2387,7 +2458,18 @@ const Settings: React.FC = () => {
 
                 {license.tier !== 'Free' && (license.customerName || license.customerEmail) && (
                   <div className="license-details">
-                    <h4 className="license-details-title">Account Details</h4>
+                    <div className="license-details-header">
+                      <h4 className="license-details-title">Account Details</h4>
+                      <button
+                        type="button"
+                        className="license-details-copy-all"
+                        onClick={() => copyToClipboard(composeAccountDetails(license), 'account')}
+                        title="Copy account details (excludes token)"
+                        aria-label="Copy account details (excludes token)"
+                      >
+                        {copiedTarget === 'account' ? <Check size={14} /> : <Copy size={14} />}
+                      </button>
+                    </div>
                     {license.customerName && (
                       <div className="license-details-row">
                         <span className="license-details-label">Name</span>
@@ -2404,6 +2486,63 @@ const Settings: React.FC = () => {
                       <div className="license-details-row">
                         <span className="license-details-label">License ID</span>
                         <span className="license-details-value license-id-value">{license.licenseId}</span>
+                      </div>
+                    )}
+                    {license.subscriptionId && (
+                      <div className="license-details-row">
+                        <span className="license-details-label">Subscription ID</span>
+                        <span className="license-details-value license-id-value">{license.subscriptionId}</span>
+                      </div>
+                    )}
+                    {license.customerId && (
+                      <div className="license-details-row">
+                        <span className="license-details-label">Customer ID</span>
+                        <span className="license-details-value license-id-value">{license.customerId}</span>
+                      </div>
+                    )}
+                    {license.discountCode && (
+                      <div className="license-details-row">
+                        <span className="license-details-label">Discount</span>
+                        <span className="license-details-value">
+                          {license.discountCode}
+                          {license.discountCyclesRemaining != null && license.discountCyclesRemaining > 0 && (
+                            <>, {license.discountCyclesRemaining} cycles remaining</>
+                          )}
+                        </span>
+                      </div>
+                    )}
+                    {license.lastSyncAt && (
+                      <div className="license-details-row">
+                        <span className="license-details-label">Last Synced</span>
+                        <span className="license-details-value">{formatFriendlyDate(license.lastSyncAt, USER_TIMEZONE)}</span>
+                      </div>
+                    )}
+                    {license.token && (
+                      <div className="license-details-row license-token-row">
+                        <span className="license-details-label">License Token</span>
+                        <div className="license-token-controls">
+                          <button
+                            type="button"
+                            className="license-details-icon-button"
+                            onClick={() => setTokenRevealed((r) => !r)}
+                            title={tokenRevealed ? 'Hide token' : 'Show token'}
+                            aria-label={tokenRevealed ? 'Hide token' : 'Show token'}
+                          >
+                            {tokenRevealed ? <EyeOff size={14} /> : <Eye size={14} />}
+                          </button>
+                          <button
+                            type="button"
+                            className="license-details-icon-button"
+                            onClick={() => copyToClipboard(license.token!, 'token')}
+                            title="Copy token"
+                            aria-label="Copy token"
+                          >
+                            {copiedTarget === 'token' ? <Check size={14} /> : <Copy size={14} />}
+                          </button>
+                        </div>
+                        <span className="license-details-value license-token-value">
+                          {tokenRevealed ? license.token : maskToken(license.token)}
+                        </span>
                       </div>
                     )}
                   </div>

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -25,7 +25,9 @@ import {
   ClipboardPaste,
   RotateCcw,
   Square,
-  CheckSquare
+  CheckSquare,
+  Copy,
+  Check
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -48,12 +50,34 @@ interface TierPricing {
   apiAccess: string;
   showBranding: boolean;
   pricing: { monthly: number; yearly: number; lifetime: number };
+  benefits: string[];
 }
 
 interface PricingData {
   free: TierPricing;
   pro: TierPricing;
   enterprise: TierPricing;
+}
+
+// Advertised discount data — populated from /api/license/promo (Worker → Dodo)
+interface PromoOffer {
+  code: string;
+  name: string;
+  amountPct: number;
+  expiresAt: string | null;
+  remaining: number | null;
+  totalLimit: number | null;
+  cycles: number | null;
+  appliesTo: Array<{
+    tier: 'pro' | 'enterprise';
+    billing: 'monthly' | 'yearly' | 'lifetime';
+    productId: string;
+  }>;
+}
+
+interface PromoResponse {
+  offers: PromoOffer[];
+  fetchedAt: string | null;
 }
 
 // Dodo Payments configuration - Toggle IS_LIVE to switch modes
@@ -101,6 +125,17 @@ const CHECKOUT_URLS = {
     lifetime: `${CHECKOUT_BASE}/${PRODUCT_IDS.enterprise.lifetime}`,
   },
 } as const;
+
+// productId → static checkout URL lookup. Used by handleCheckout to resolve
+// the fallback URL when a Sessions API call fails or no discount is present.
+const PRODUCT_TO_STATIC_URL: Record<string, string> = {
+  [PRODUCT_IDS.pro.monthly]: CHECKOUT_URLS.pro.monthly,
+  [PRODUCT_IDS.pro.yearly]: CHECKOUT_URLS.pro.yearly,
+  [PRODUCT_IDS.pro.lifetime]: CHECKOUT_URLS.pro.lifetime,
+  [PRODUCT_IDS.enterprise.monthly]: CHECKOUT_URLS.enterprise.monthly,
+  [PRODUCT_IDS.enterprise.yearly]: CHECKOUT_URLS.enterprise.yearly,
+  [PRODUCT_IDS.enterprise.lifetime]: CHECKOUT_URLS.enterprise.lifetime,
+};
 
 // Diagnostics Tab Component
 interface SystemInfo {
@@ -720,6 +755,8 @@ const Settings: React.FC = () => {
   
   // Dynamic pricing from API
   const [pricing, setPricing] = useState<PricingData | null>(null);
+  const [promo, setPromo] = useState<PromoResponse | null>(null);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
   // General Settings from Context
   const { graphScale, updateGraphScale, dataRetentionDays, updateDataRetention, timezone, hardwarePruneDays, updateHardwarePruneDays, hubLogLevel, updateHubLogLevel } = useDashboardSettings();
@@ -808,8 +845,100 @@ const Settings: React.FC = () => {
         console.error('Failed to fetch pricing:', error);
       }
     };
+    const fetchPromo = async () => {
+      try {
+        const r = await fetch('/api/license/promo');
+        if (r.ok) {
+          setPromo(await r.json());
+        }
+      } catch {
+        // graceful no-op: empty banner on failure
+      }
+    };
     fetchPricing();
+    fetchPromo();
   }, []);
+
+  // Find the highest-amount discount applicable to a (tier, billing) card.
+  // Returns null if no discount applies. Used for per-card strikethrough +
+  // discount-aware checkout button.
+  const discountForCard = (
+    promoData: PromoResponse | null,
+    tier: 'pro' | 'enterprise',
+    billing: 'monthly' | 'yearly' | 'lifetime'
+  ): PromoOffer | null => {
+    if (!promoData || !promoData.offers.length) return null;
+    const matches = promoData.offers.filter((o) =>
+      o.appliesTo.some((a) => a.tier === tier && a.billing === billing)
+    );
+    if (!matches.length) return null;
+    return matches.reduce((best, cur) => (cur.amountPct > best.amountPct ? cur : best));
+  };
+
+  const productIdForCard = (
+    tier: 'pro' | 'enterprise',
+    billing: 'monthly' | 'yearly' | 'lifetime'
+  ): string | undefined => {
+    const offer = discountForCard(promo, tier, billing);
+    if (!offer) return undefined;
+    const match = offer.appliesTo.find((a) => a.tier === tier && a.billing === billing);
+    return match?.productId;
+  };
+
+  // Copy a discount code to the clipboard, briefly flip the icon to a check.
+  const copyDiscountCode = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopiedCode(code);
+      setTimeout(() => setCopiedCode((c) => (c === code ? null : c)), 2000);
+    } catch {
+      // clipboard API unavailable — silently no-op; the code is still visible
+    }
+  };
+
+  // Click handler for "Get Pro/Enterprise" buttons. With a discount code,
+  // calls backend /checkout to get a Dodo Sessions URL with discount
+  // pre-applied. Without a discount, opens the static Dodo URL directly.
+  // Any backend/network failure on the discounted path falls back to the
+  // static URL so the customer can always complete a purchase.
+  const handleCheckout = async (productId: string, discountCode?: string) => {
+    const fallbackUrl = PRODUCT_TO_STATIC_URL[productId];
+    if (!discountCode) {
+      if (fallbackUrl) window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    try {
+      const r = await fetch('/api/license/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productId, discountCode }),
+      });
+      const data = await r.json();
+      if (data.ok && data.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+        return;
+      }
+      console.warn('[checkout] backend returned error, falling back to static URL', data);
+    } catch (e) {
+      console.warn('[checkout] request failed, falling back to static URL', e);
+    }
+    if (fallbackUrl) window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  // Build per-card "Save X% for Y months" caption. Uses the active billing
+  // toggle so phrasing is natural ("for 7 months" on monthly, "for 7 years"
+  // on yearly), falling back to "for X cycles" when ambiguous.
+  const buildSavingsLine = (offer: PromoOffer, billing: 'monthly' | 'yearly' | 'lifetime'): string => {
+    const head = `Save ${offer.amountPct}%`;
+    if (offer.cycles == null) return head;
+    if (billing === 'monthly') {
+      return `${head} for ${offer.cycles} ${offer.cycles === 1 ? 'month' : 'months'}`;
+    }
+    if (billing === 'yearly') {
+      return `${head} for ${offer.cycles} ${offer.cycles === 1 ? 'year' : 'years'}`;
+    }
+    return `${head} for ${offer.cycles} ${offer.cycles === 1 ? 'cycle' : 'cycles'}`;
+  };
 
   const handleCustomScaleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -875,6 +1004,7 @@ const Settings: React.FC = () => {
    */
   const handleSyncLicense = async () => {
     setIsSyncing(true);
+    const wasExpired = license?.tier === 'Free' && !!license?.licenseId;
     try {
       const response = await fetch('/api/license/sync', {
         method: 'POST',
@@ -883,13 +1013,34 @@ const Settings: React.FC = () => {
       const result = await response.json();
 
       if (result.success) {
-        setLicenseStatus({ success: true, message: result.changed ? 'License updated!' : 'License is up to date' });
+        let message: string;
+        if (result.upgraded) {
+          message = 'License renewed! Your subscription is active again.';
+        } else if (result.changed) {
+          message = 'License updated — new expiry applied.';
+        } else if (wasExpired) {
+          message = 'No renewal available yet. If you paid recently, give it a minute and try again, or check your email for the renewal token.';
+        } else {
+          message = 'License is up to date.';
+        }
+        setLicenseStatus({ success: true, message });
         await refreshLicense();
       } else {
-        setLicenseStatus({ success: false, message: result.error || 'Sync failed' });
+        const err = result.error || '';
+        let message: string;
+        if (err === 'Timeout') {
+          message = 'License server did not respond in time. Check your internet connection and try again.';
+        } else if (err === 'License not found') {
+          message = 'This license isn\'t recognized by our server. Please contact support@pankha.app and include your license ID.';
+        } else if (err === 'License server error') {
+          message = 'License server returned an error. Please try again in a few minutes.';
+        } else {
+          message = err || 'Sync failed.';
+        }
+        setLicenseStatus({ success: false, message });
       }
     } catch {
-      setLicenseStatus({ success: false, message: 'Could not reach license server' });
+      setLicenseStatus({ success: false, message: 'Could not reach license server. Check your internet connection.' });
     } finally {
       setIsSyncing(false);
     }
@@ -1507,8 +1658,63 @@ const Settings: React.FC = () => {
             ) : license ? (
               <>
                 {/* Available Plans - First */}
+                {/* Tier benefits, agent limits, retention, and prices below all flow from
+                    backend/src/license/tiers.ts via /api/license/pricing. The `|| N` price
+                    fallbacks only render during the brief loading window before the API
+                    responds — keep them in sync with tiers.ts pricing if you change it. */}
                 <div className="pricing-section">
                   <h3>Available Plans</h3>
+
+                  {promo && promo.offers.length > 0 && (
+                    <div className="promo-offers" role="region" aria-label="Available discount offers">
+                      {promo.offers.map((offer) => {
+                        const hasLimit = offer.expiresAt != null || offer.totalLimit != null;
+                        const productSummary = offer.appliesTo
+                          .map((a) => `${a.tier === 'pro' ? 'Pro' : 'Enterprise'} ${a.billing.charAt(0).toUpperCase() + a.billing.slice(1)}`)
+                          .join(' & ');
+                        const meta: string[] = [];
+                        if (offer.remaining != null) {
+                          meta.push(`${offer.remaining} ${offer.remaining === 1 ? 'spot' : 'spots'} left`);
+                        }
+                        if (offer.cycles != null) {
+                          meta.push(`for ${offer.cycles} ${offer.cycles === 1 ? 'cycle' : 'cycles'}`);
+                        }
+                        if (offer.expiresAt) {
+                          const dt = new Date(offer.expiresAt);
+                          meta.push(`ends ${dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`);
+                        }
+                        return (
+                          <div key={offer.code} className="promo-offer">
+                            <Tag size={16} className="promo-offer-icon" aria-hidden="true" />
+                            <div className="promo-offer-body">
+                              <div className="promo-offer-headline">
+                                <span className="promo-offer-label">{hasLimit ? 'LIMITED OFFER' : 'OFFER'}</span>
+                                <span className="promo-offer-headline-text">{offer.amountPct}% off {productSummary || 'select plans'}</span>
+                              </div>
+                              {meta.length > 0 && (
+                                <div className="promo-offer-meta">{meta.join(' · ')}</div>
+                              )}
+                              <div className="promo-offer-cta">
+                                <span className="promo-offer-code-line">
+                                  Use code <code className="promo-offer-code">{offer.code}</code> at checkout
+                                </span>
+                                <button
+                                  type="button"
+                                  className="promo-copy-btn"
+                                  onClick={() => copyDiscountCode(offer.code)}
+                                  aria-label={`Copy code ${offer.code}`}
+                                >
+                                  {copiedCode === offer.code ? <Check size={14} /> : <Copy size={14} />}
+                                  <span>{copiedCode === offer.code ? 'Copied' : 'Copy'}</span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
                   <div className="pricing-cards">
                     {/* Free Plan */}
                     <div className={`pricing-card ${license.tier === 'Free' ? 'current' : ''}`}>
@@ -1518,194 +1724,253 @@ const Settings: React.FC = () => {
                         <div className="pricing-period">forever</div>
                       </div>
                       <ul className="pricing-features">
-                        <li>{pricing?.free.agents || 3} Agents</li>
-                        <li>{pricing?.free.retentionDays || 7} Days History</li>
-                        <li>Critical Temp & Fan Fail Alerts</li>
-                        <li>Dashboard & Email Notifications</li>
+                        {pricing?.free.benefits?.map((b, i) => <li key={i}>{b}</li>)}
                       </ul>
                       {license.tier === 'Free' && <div className="current-plan-badge">Current Plan</div>}
                     </div>
 
                     {/* Pro Plan */}
-                    <div className="pricing-card featured">
-                      <div className="pricing-header">
-                        <h4>Pro</h4>
-                        <div className="pricing-toggle">
-                          <button 
-                            className={`toggle-btn ${proBilling === 'monthly' ? 'active' : ''}`}
-                            onClick={() => setProBilling('monthly')}
-                          >
-                            Monthly
-                          </button>
-                          <button 
-                            className={`toggle-btn ${proBilling === 'yearly' ? 'active' : ''}`}
-                            onClick={() => setProBilling('yearly')}
-                          >
-                            Yearly
-                          </button>
+                    {(() => {
+                      const proDiscount = discountForCard(promo, 'pro', proBilling);
+                      const proPriceRaw = proBilling === 'monthly'
+                        ? (pricing?.pro.pricing.monthly || 5)
+                        : (pricing?.pro.pricing.yearly || 49);
+                      const proPriceShown = proDiscount
+                        ? Math.round(proPriceRaw * (1 - proDiscount.amountPct / 100) * 100) / 100
+                        : proPriceRaw;
+                      const proProductId = productIdForCard('pro', proBilling);
+                      const proStaticUrl = CHECKOUT_URLS.pro[proBilling];
+                      const proPeriodSuffix = proBilling === 'monthly' ? 'mo' : 'yr';
+                      return (
+                        <div className="pricing-card featured">
+                          <div className="pricing-header">
+                            <h4>Pro</h4>
+                            <div className="pricing-toggle">
+                              <button
+                                className={`toggle-btn ${proBilling === 'monthly' ? 'active' : ''}`}
+                                onClick={() => setProBilling('monthly')}
+                              >
+                                Monthly
+                              </button>
+                              <button
+                                className={`toggle-btn ${proBilling === 'yearly' ? 'active' : ''}`}
+                                onClick={() => setProBilling('yearly')}
+                              >
+                                Yearly
+                              </button>
+                            </div>
+                            <div className="pricing-price">
+                              {proDiscount ? (
+                                <>
+                                  <span className="pricing-price-strike">${proPriceRaw}</span>
+                                  <span className="pricing-price-discounted">${proPriceShown}</span>
+                                </>
+                              ) : (
+                                <>${proPriceRaw}</>
+                              )}
+                            </div>
+                            <div className="pricing-period">
+                              {proBilling === 'monthly' ? 'per month' : 'per year'}
+                              {proBilling === 'yearly' && !proDiscount && <span className="savings"> (save 18%)</span>}
+                            </div>
+                            {proDiscount && (
+                              <div className="pricing-savings-line">{buildSavingsLine(proDiscount, proBilling)}</div>
+                            )}
+                          </div>
+                          <ul className="pricing-features">
+                            {pricing?.pro.benefits?.map((b, i) => <li key={i}>{b}</li>)}
+                          </ul>
+                          {license.tier === 'Pro' && license.billing === proBilling ? (
+                            <div className="current-plan-badge">Current Plan</div>
+                          ) : proDiscount && proProductId ? (
+                            <button
+                              type="button"
+                              className={`pricing-buy-btn ${license.tier === 'Pro' ? 'current-tier-btn' : ''}`}
+                              onClick={() => handleCheckout(proProductId, proDiscount.code)}
+                            >
+                              {license.tier === 'Pro' ? 'Switch to' : 'Get'} Pro {proBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${proPriceShown}/{proPeriodSuffix})
+                            </button>
+                          ) : license.tier === 'Pro' ? (
+                            <a
+                              href={proStaticUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="pricing-buy-btn current-tier-btn"
+                            >
+                              Switch to {proBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${proPriceRaw}/{proPeriodSuffix})
+                            </a>
+                          ) : (
+                            <a
+                              href={proStaticUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="pricing-buy-btn"
+                            >
+                              Get Pro (${proPriceRaw}/{proPeriodSuffix})
+                            </a>
+                          )}
                         </div>
-                        <div className="pricing-price">
-                          ${proBilling === 'monthly' 
-                            ? pricing?.pro.pricing.monthly || 5 
-                            : pricing?.pro.pricing.yearly || 49}
-                        </div>
-                        <div className="pricing-period">
-                          {proBilling === 'monthly' ? 'per month' : 'per year'}
-                          {proBilling === 'yearly' && <span className="savings"> (save 18%)</span>}
-                        </div>
-                      </div>
-                      <ul className="pricing-features">
-                        <li>{pricing?.pro.agents || 10} Agents</li>
-                        <li>{pricing?.pro.retentionDays || 30} Days History</li>
-                        <li>Unlimited Alerts</li>
-                        <li>All Notification Channels</li>
-                        <li>Full API Access</li>
-                      </ul>
-                      {license.tier === 'Pro' && license.billing === proBilling ? (
-                        <div className="current-plan-badge">Current Plan</div>
-                      ) : license.tier === 'Pro' ? (
-                        <a 
-                          href={CHECKOUT_URLS.pro[proBilling]} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="pricing-buy-btn current-tier-btn"
-                        >
-                          Switch to {proBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${proBilling === 'monthly' 
-                            ? `${pricing?.pro.pricing.monthly || 5}/mo` 
-                            : `${pricing?.pro.pricing.yearly || 49}/yr`})
-                        </a>
-                      ) : (
-                        <a 
-                          href={CHECKOUT_URLS.pro[proBilling]} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="pricing-buy-btn"
-                        >
-                          Get Pro (${proBilling === 'monthly' 
-                            ? `${pricing?.pro.pricing.monthly || 5}/mo` 
-                            : `${pricing?.pro.pricing.yearly || 49}/yr`})
-                        </a>
-                      )}
-                    </div>
+                      );
+                    })()}
 
                     {/* Enterprise Plan */}
-                    <div className="pricing-card">
-                      <div className="pricing-header">
-                        <h4>Enterprise</h4>
-                        <div className="pricing-toggle">
-                          <button 
-                            className={`toggle-btn ${enterpriseBilling === 'monthly' ? 'active' : ''}`}
-                            onClick={() => setEnterpriseBilling('monthly')}
-                          >
-                            Monthly
-                          </button>
-                          <button 
-                            className={`toggle-btn ${enterpriseBilling === 'yearly' ? 'active' : ''}`}
-                            onClick={() => setEnterpriseBilling('yearly')}
-                          >
-                            Yearly
-                          </button>
+                    {(() => {
+                      const entDiscount = discountForCard(promo, 'enterprise', enterpriseBilling);
+                      const entPriceRaw = enterpriseBilling === 'monthly'
+                        ? (pricing?.enterprise.pricing.monthly || 25)
+                        : (pricing?.enterprise.pricing.yearly || 249);
+                      const entPriceShown = entDiscount
+                        ? Math.round(entPriceRaw * (1 - entDiscount.amountPct / 100) * 100) / 100
+                        : entPriceRaw;
+                      const entProductId = productIdForCard('enterprise', enterpriseBilling);
+                      const entStaticUrl = CHECKOUT_URLS.enterprise[enterpriseBilling];
+                      const entPeriodSuffix = enterpriseBilling === 'monthly' ? 'mo' : 'yr';
+                      return (
+                        <div className="pricing-card">
+                          <div className="pricing-header">
+                            <h4>Enterprise</h4>
+                            <div className="pricing-toggle">
+                              <button
+                                className={`toggle-btn ${enterpriseBilling === 'monthly' ? 'active' : ''}`}
+                                onClick={() => setEnterpriseBilling('monthly')}
+                              >
+                                Monthly
+                              </button>
+                              <button
+                                className={`toggle-btn ${enterpriseBilling === 'yearly' ? 'active' : ''}`}
+                                onClick={() => setEnterpriseBilling('yearly')}
+                              >
+                                Yearly
+                              </button>
+                            </div>
+                            <div className="pricing-price">
+                              {entDiscount ? (
+                                <>
+                                  <span className="pricing-price-strike">${entPriceRaw}</span>
+                                  <span className="pricing-price-discounted">${entPriceShown}</span>
+                                </>
+                              ) : (
+                                <>${entPriceRaw}</>
+                              )}
+                            </div>
+                            <div className="pricing-period">
+                              {enterpriseBilling === 'monthly' ? 'per month' : 'per year'}
+                              {enterpriseBilling === 'yearly' && !entDiscount && <span className="savings"> (save 17%)</span>}
+                            </div>
+                            {entDiscount && (
+                              <div className="pricing-savings-line">{buildSavingsLine(entDiscount, enterpriseBilling)}</div>
+                            )}
+                          </div>
+                          <ul className="pricing-features">
+                            {pricing?.enterprise.benefits?.map((b, i) => <li key={i}>{b}</li>)}
+                          </ul>
+                          {license.tier === 'Enterprise' && license.billing === enterpriseBilling ? (
+                            <div className="current-plan-badge">Current Plan</div>
+                          ) : entDiscount && entProductId ? (
+                            <button
+                              type="button"
+                              className={`pricing-buy-btn ${license.tier === 'Enterprise' ? 'current-tier-btn' : ''}`}
+                              onClick={() => handleCheckout(entProductId, entDiscount.code)}
+                            >
+                              {license.tier === 'Enterprise' ? 'Switch to' : 'Get'} Enterprise {enterpriseBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${entPriceShown}/{entPeriodSuffix})
+                            </button>
+                          ) : license.tier === 'Enterprise' ? (
+                            <a
+                              href={entStaticUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="pricing-buy-btn current-tier-btn"
+                            >
+                              Switch to {enterpriseBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${entPriceRaw}/{entPeriodSuffix})
+                            </a>
+                          ) : (
+                            <a
+                              href={entStaticUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="pricing-buy-btn"
+                            >
+                              Get Enterprise (${entPriceRaw}/{entPeriodSuffix})
+                            </a>
+                          )}
                         </div>
-                        <div className="pricing-price">
-                          ${enterpriseBilling === 'monthly' 
-                            ? pricing?.enterprise.pricing.monthly || 35 
-                            : pricing?.enterprise.pricing.yearly || 249}
-                        </div>
-                        <div className="pricing-period">
-                          {enterpriseBilling === 'monthly' ? 'per month' : 'per year'}
-                          {enterpriseBilling === 'yearly' && <span className="savings"> (save 17%)</span>}
-                        </div>
-                      </div>
-                      <ul className="pricing-features">
-                        <li>Unlimited Agents</li>
-                        <li>{pricing?.enterprise.retentionDays || 365} Days History</li>
-                        <li>Unlimited Alerts</li>
-                        <li>All Notification Channels</li>
-                        <li>Full API Access</li>
-                        <li>No Branding</li>
-                      </ul>
-                      {license.tier === 'Enterprise' && license.billing === enterpriseBilling ? (
-                        <div className="current-plan-badge">Current Plan</div>
-                      ) : license.tier === 'Enterprise' ? (
-                        <a 
-                          href={CHECKOUT_URLS.enterprise[enterpriseBilling]} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="pricing-buy-btn current-tier-btn"
-                        >
-                          Switch to {enterpriseBilling === 'monthly' ? 'Monthly' : 'Yearly'} (${enterpriseBilling === 'monthly' 
-                            ? `${pricing?.enterprise.pricing.monthly || 35}/mo` 
-                            : `${pricing?.enterprise.pricing.yearly || 249}/yr`})
-                        </a>
-                      ) : (
-                        <a 
-                          href={CHECKOUT_URLS.enterprise[enterpriseBilling]} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="pricing-buy-btn"
-                        >
-                          Get Enterprise (${enterpriseBilling === 'monthly' 
-                            ? `${pricing?.enterprise.pricing.monthly || 35}/mo` 
-                            : `${pricing?.enterprise.pricing.yearly || 249}/yr`})
-                        </a>
-                      )}
-                    </div>
+                      );
+                    })()}
 
                     {/* Lifetime Plan */}
-                    <div className="pricing-card lifetime">
-                      <div className="pricing-badge best-value">BEST VALUE</div>
-                      <div className="pricing-header">
-                        <h4>Lifetime</h4>
-                        <div className="pricing-toggle">
-                          <button 
-                            className={`toggle-btn ${lifetimeTier === 'pro' ? 'active' : ''}`}
-                            onClick={() => setLifetimeTier('pro')}
-                          >
-                            Pro
-                          </button>
-                          <button 
-                            className={`toggle-btn ${lifetimeTier === 'enterprise' ? 'active' : ''}`}
-                            onClick={() => setLifetimeTier('enterprise')}
-                          >
-                            Enterprise
-                          </button>
+                    {(() => {
+                      const lifeDiscount = discountForCard(promo, lifetimeTier, 'lifetime');
+                      const lifePriceRaw = lifetimeTier === 'pro'
+                        ? (pricing?.pro.pricing.lifetime || 199)
+                        : (pricing?.enterprise.pricing.lifetime || 649);
+                      const lifePriceShown = lifeDiscount
+                        ? Math.round(lifePriceRaw * (1 - lifeDiscount.amountPct / 100) * 100) / 100
+                        : lifePriceRaw;
+                      const lifeProductId = productIdForCard(lifetimeTier, 'lifetime');
+                      const lifeStaticUrl = CHECKOUT_URLS[lifetimeTier].lifetime;
+                      const lifeTierLabel = lifetimeTier === 'pro' ? 'Pro' : 'Enterprise';
+                      return (
+                        <div className="pricing-card lifetime">
+                          <div className="pricing-badge best-value">BEST VALUE</div>
+                          <div className="pricing-header">
+                            <h4>Lifetime</h4>
+                            <div className="pricing-toggle">
+                              <button
+                                className={`toggle-btn ${lifetimeTier === 'pro' ? 'active' : ''}`}
+                                onClick={() => setLifetimeTier('pro')}
+                              >
+                                Pro
+                              </button>
+                              <button
+                                className={`toggle-btn ${lifetimeTier === 'enterprise' ? 'active' : ''}`}
+                                onClick={() => setLifetimeTier('enterprise')}
+                              >
+                                Enterprise
+                              </button>
+                            </div>
+                            <div className="pricing-price">
+                              {lifeDiscount ? (
+                                <>
+                                  <span className="pricing-price-strike">${lifePriceRaw}</span>
+                                  <span className="pricing-price-discounted">${lifePriceShown}</span>
+                                </>
+                              ) : (
+                                <>${lifePriceRaw}</>
+                              )}
+                            </div>
+                            <div className="pricing-period">one-time payment</div>
+                            {lifeDiscount && (
+                              <div className="pricing-savings-line">{buildSavingsLine(lifeDiscount, 'lifetime')}</div>
+                            )}
+                          </div>
+                          <ul className="pricing-features">
+                            <li>Pay once, own forever</li>
+                            {(lifetimeTier === 'pro' ? pricing?.pro.benefits : pricing?.enterprise.benefits)
+                              ?.map((b, i) => <li key={i}>{b}</li>)}
+                          </ul>
+                          {license.tier === lifeTierLabel && license.billing === 'lifetime' ? (
+                            <div className="current-plan-badge">Current Plan</div>
+                          ) : lifeDiscount && lifeProductId ? (
+                            <button
+                              type="button"
+                              className="pricing-buy-btn lifetime-btn"
+                              onClick={() => handleCheckout(lifeProductId, lifeDiscount.code)}
+                            >
+                              Get {lifeTierLabel} Lifetime (${lifePriceShown})
+                            </button>
+                          ) : (
+                            <a
+                              href={lifeStaticUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="pricing-buy-btn lifetime-btn"
+                            >
+                              Get {lifeTierLabel} Lifetime (${lifePriceRaw})
+                            </a>
+                          )}
                         </div>
-                        <div className="pricing-price">
-                          ${lifetimeTier === 'pro' 
-                            ? pricing?.pro.pricing.lifetime || 149 
-                            : pricing?.enterprise.pricing.lifetime || 499}
-                        </div>
-                        <div className="pricing-period">one-time payment</div>
-                      </div>
-                      <ul className="pricing-features">
-                        <li>Pay once, own forever</li>
-                        <li>{lifetimeTier === 'pro' 
-                          ? (pricing?.pro.agents || 10)
-                          : (pricing?.enterprise.agents === -1 ? 'Unlimited' : pricing?.enterprise.agents || 'Unlimited')} Agents</li>
-                        <li>{lifetimeTier === 'pro' 
-                          ? (pricing?.pro.retentionDays || 30)
-                          : (pricing?.enterprise.retentionDays || 365)} Days History</li>
-                        <li>Unlimited Alerts</li>
-                        <li>All Notification Channels</li>
-                        <li>Full API Access</li>
-                        {lifetimeTier === 'enterprise' && <li>No Branding</li>}
-                      </ul>
-                      {license.tier === (lifetimeTier === 'pro' ? 'Pro' : 'Enterprise') && license.billing === 'lifetime' ? (
-                        <div className="current-plan-badge">Current Plan</div>
-                      ) : (
-                        <a 
-                          href={CHECKOUT_URLS[lifetimeTier].lifetime} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="pricing-buy-btn lifetime-btn"
-                        >
-                          Get {lifetimeTier === 'pro' ? 'Pro' : 'Enterprise'} Lifetime ($
-                          {lifetimeTier === 'pro' 
-                            ? pricing?.pro.pricing.lifetime || 149 
-                            : pricing?.enterprise.pricing.lifetime || 499})
-                        </a>
-                      )}
-                    </div>
+                      );
+                    })()}
                   </div>
                 </div>
 
@@ -1806,38 +2071,45 @@ const Settings: React.FC = () => {
                     >
                       {isSubmitting ? 'Validating...' : 'Activate'}
                     </button>
-                    {license.tier !== 'Free' && (
+                    {(license.tier !== 'Free' || license.licenseId) && (
                       <div className="license-action-row">
-                        <button
-                          type="button"
-                          className="remove-license-btn"
-                          onClick={handleRemoveLicense}
-                          disabled={isSubmitting}
-                        >
-                          Remove
-                        </button>
-                        <button
-                          type="button"
-                          className="refresh-button"
-                          onClick={handleSyncLicense}
-                          disabled={isSyncing}
-                          title="Check for license updates"
-                        >
-                          <svg
-                            viewBox="0 0 24 24"
-                            width="18"
-                            height="18"
-                            style={{
-                              animation: isSyncing ? 'spin 1s linear infinite' : 'none',
-                              display: 'block'
-                            }}
+                        {license.tier !== 'Free' && (
+                          <button
+                            type="button"
+                            className="remove-license-btn"
+                            onClick={handleRemoveLicense}
+                            disabled={isSubmitting}
                           >
-                            <path
-                              fill="currentColor"
-                              d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                            />
-                          </svg>
-                        </button>
+                            Remove
+                          </button>
+                        )}
+                        {license.licenseId && (
+                          <button
+                            type="button"
+                            className="refresh-button"
+                            onClick={handleSyncLicense}
+                            disabled={isSyncing}
+                            title={license.tier === 'Free'
+                              ? 'Check the license server for a renewed token'
+                              : 'Check for license updates'}
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                              width="18"
+                              height="18"
+                              style={{
+                                animation: isSyncing ? 'spin 1s linear infinite' : 'none',
+                                display: 'block'
+                              }}
+                            >
+                              <path
+                                fill="currentColor"
+                                d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                              />
+                            </svg>
+                            <span>{license.tier === 'Free' ? 'Renew' : 'Sync'}</span>
+                          </button>
+                        )}
                       </div>
                     )}
                   </div>

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -27,7 +27,8 @@ import {
   Square,
   CheckSquare,
   Copy,
-  Check
+  Check,
+  KeyRound
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -78,6 +79,73 @@ interface PromoOffer {
 interface PromoResponse {
   offers: PromoOffer[];
   fetchedAt: string | null;
+}
+
+// Period-claim badge label.
+// Sourced from JWT pi/pc claims (Dodo payment_frequency_interval/count).
+// Falls back to capitalised billing enum for legacy tokens that pre-date the claims.
+// count=1 collapses to natural English ("Daily", "Monthly"); count>1 expands ("7 Days").
+function formatPeriodBadge(
+  interval: string | null,
+  count: number | null,
+  billingFallback: string | null
+): string {
+  if (interval && count && count > 0) {
+    if (count === 1) {
+      const map: Record<string, string> = {
+        Day: 'Daily',
+        Week: 'Weekly',
+        Month: 'Monthly',
+        Year: 'Yearly',
+      };
+      return map[interval] || `1 ${interval}`;
+    }
+    return `${count} ${interval}s`;
+  }
+  if (billingFallback) {
+    return billingFallback.charAt(0).toUpperCase() + billingFallback.slice(1);
+  }
+  return '';
+}
+
+// 3-line tooltip showing local, UTC, and relative time for a date.
+// Mirrors the format used by Dodo's dashboard:
+//   Asia/Kolkata: May 12, 2026, 1:58:32 AM
+//   UTC: May 11, 2026, 8:28:32 PM
+//   in 8 hours
+// Returns `fallback` when date is null/invalid (use for lifetime products etc.).
+function formatDateTooltip(dateInput: string | null, fallback = ''): string {
+  if (!dateInput) return fallback;
+  const d = new Date(dateInput);
+  if (Number.isNaN(d.getTime())) return fallback;
+
+  const userTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const fmt: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  };
+
+  const local = new Intl.DateTimeFormat('en-US', { ...fmt, timeZone: userTz }).format(d);
+  const utc = new Intl.DateTimeFormat('en-US', { ...fmt, timeZone: 'UTC' }).format(d);
+
+  // Relative — pick the best unit so values like "in 8 hours" or "2 days ago" feel natural
+  const diffSec = (d.getTime() - Date.now()) / 1000;
+  const absSec = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  let rel: string;
+  if (absSec < 45) rel = rtf.format(Math.round(diffSec), 'second');
+  else if (absSec < 45 * 60) rel = rtf.format(Math.round(diffSec / 60), 'minute');
+  else if (absSec < 22 * 3600) rel = rtf.format(Math.round(diffSec / 3600), 'hour');
+  else if (absSec < 26 * 86400) rel = rtf.format(Math.round(diffSec / 86400), 'day');
+  else if (absSec < 320 * 86400) rel = rtf.format(Math.round(diffSec / (30.44 * 86400)), 'month');
+  else rel = rtf.format(Math.round(diffSec / (365.25 * 86400)), 'year');
+
+  return `${userTz}: ${local}\nUTC: ${utc}\n${rel}`;
 }
 
 // Dodo Payments configuration - Toggle IS_LIVE to switch modes
@@ -747,6 +815,7 @@ const Settings: React.FC = () => {
   const [licenseStatus, setLicenseStatus] = useState<{ success: boolean; message: string } | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
+  const [isRenewing, setIsRenewing] = useState(false);
 
   // Billing period toggles for pricing cards
   const [proBilling, setProBilling] = useState<'monthly' | 'yearly'>('monthly');
@@ -915,7 +984,7 @@ const Settings: React.FC = () => {
       });
       const data = await r.json();
       if (data.ok && data.checkoutUrl) {
-        window.location.href = data.checkoutUrl;
+        window.open(data.checkoutUrl, '_blank', 'noopener,noreferrer');
         return;
       }
       console.warn('[checkout] backend returned error, falling back to static URL', data);
@@ -1045,6 +1114,55 @@ const Settings: React.FC = () => {
       setIsSyncing(false);
     }
   };
+
+  /**
+   * Force-renew license via worker /renew (vendor-independent recovery).
+   * Used when Sync alone can't recover the license — e.g., Dodo's webhook
+   * never fired but the customer paid. Subject to 15min cooldown + 3/day cap.
+   */
+  const handleRenewLicense = async () => {
+    setIsRenewing(true);
+    try {
+      const response = await fetch('/api/license/renew', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const result = await response.json();
+
+      if (result.success) {
+        const message = result.changed
+          ? 'License refreshed from server.'
+          : 'License is up to date.';
+        setLicenseStatus({ success: true, message });
+        await refreshLicense();
+      } else {
+        let message: string;
+        if (result.isRateLimited) {
+          message = result.error || 'You can only Renew 3 times per day. Try again later.';
+        } else if (result.error === 'Timeout') {
+          message = 'License server did not respond in time. Check your internet connection and try again.';
+        } else if (result.error === 'No license token to renew' || result.error === 'No stored license token') {
+          message = 'No license token on file to renew. Please activate a token first.';
+        } else {
+          message = result.error || 'Renew failed.';
+        }
+        setLicenseStatus({ success: false, message });
+      }
+    } catch {
+      setLicenseStatus({ success: false, message: 'Could not reach license server. Check your internet connection.' });
+    } finally {
+      setIsRenewing(false);
+    }
+  };
+
+  // Renew is enabled when the local license is in a state Sync alone may not recover:
+  //  1. Demoted to Free with a licenseId on file (hard-expired past 3-day grace)
+  //  2. Token's exp has passed (covers the 3-day grace window before validator demotes)
+  // Disabled otherwise — Sync handles the normal path.
+  const canRenew = !!license?.licenseId && (
+    license.tier === 'Free' ||
+    (!!license.expiresAt && new Date(license.expiresAt).getTime() < Date.now())
+  );
 
   const formatLimit = (value: number) => {
     return value === -1 ? '∞' : value.toString();
@@ -1981,9 +2099,9 @@ const Settings: React.FC = () => {
                     <div className={`tier-badge tier-${license.tier.toLowerCase()}`}>
                       {license.tier}
                     </div>
-                    {license.billing && (
+                    {(license.billing || license.periodInterval) && (
                       <div className="billing-badge">
-                        {license.billing.charAt(0).toUpperCase() + license.billing.slice(1)}
+                        {formatPeriodBadge(license.periodInterval, license.periodCount, license.billing)}
                       </div>
                     )}
                   </div>
@@ -2014,7 +2132,7 @@ const Settings: React.FC = () => {
                       <span className="limit-value">{license.apiAccess === 'none' ? 'No' : license.apiAccess}</span>
                     </div>
                     {license.activatedAt && (
-                      <div className="limit-item">
+                      <div className="limit-item" title={formatDateTooltip(license.activatedAt)}>
                         <span className="limit-label">Activated</span>
                         <div className="limit-value-group">
                           <span className="limit-value">{formatDate(license.activatedAt, timezone)}</span>
@@ -2022,7 +2140,7 @@ const Settings: React.FC = () => {
                         </div>
                       </div>
                     )}
-                    <div className="limit-item">
+                    <div className="limit-item" title={formatDateTooltip(license.expiresAt, 'Lifetime — never expires')}>
                       <span className="limit-label">Expires</span>
                       <div className="limit-value-group">
                         <span className="limit-value">
@@ -2035,8 +2153,11 @@ const Settings: React.FC = () => {
                     </div>
                     {(() => {
                       const remaining = formatRemaining(license.expiresAt);
+                      const remainingTooltip = license.billing === 'lifetime'
+                        ? 'Lifetime — unlimited access'
+                        : formatDateTooltip(license.nextBillingDate, 'No upcoming renewal scheduled');
                       return (
-                        <div className={`limit-item remaining-${remaining.urgency}`}>
+                        <div className={`limit-item remaining-${remaining.urgency}`} title={remainingTooltip}>
                           <span className="limit-label">Remaining</span>
                           <div className="limit-value-group">
                             <span className="limit-value">{remaining.text}</span>
@@ -2084,31 +2205,49 @@ const Settings: React.FC = () => {
                           </button>
                         )}
                         {license.licenseId && (
-                          <button
-                            type="button"
-                            className="refresh-button"
-                            onClick={handleSyncLicense}
-                            disabled={isSyncing}
-                            title={license.tier === 'Free'
-                              ? 'Check the license server for a renewed token'
-                              : 'Check for license updates'}
-                          >
-                            <svg
-                              viewBox="0 0 24 24"
-                              width="18"
-                              height="18"
-                              style={{
-                                animation: isSyncing ? 'spin 1s linear infinite' : 'none',
-                                display: 'block'
-                              }}
+                          <>
+                            <button
+                              type="button"
+                              className="refresh-button"
+                              onClick={handleSyncLicense}
+                              disabled={isSyncing}
+                              title="Check the license server for renewals or updates"
                             >
-                              <path
-                                fill="currentColor"
-                                d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                              <svg
+                                viewBox="0 0 24 24"
+                                width="18"
+                                height="18"
+                                style={{
+                                  animation: isSyncing ? 'spin 1s linear infinite' : 'none',
+                                  display: 'block'
+                                }}
+                              >
+                                <path
+                                  fill="currentColor"
+                                  d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                                />
+                              </svg>
+                              <span>Sync</span>
+                            </button>
+                            <button
+                              type="button"
+                              className="refresh-button"
+                              onClick={handleRenewLicense}
+                              disabled={!canRenew || isRenewing}
+                              title={canRenew
+                                ? 'Force-refresh your license token from the server. 15 min cooldown, 3/day.'
+                                : 'Available when Sync cannot recover your license (e.g., token expired or webhook lost). Try Sync first.'}
+                            >
+                              <KeyRound
+                                size={18}
+                                style={{
+                                  animation: isRenewing ? 'spin 1s linear infinite' : 'none',
+                                  display: 'block'
+                                }}
                               />
-                            </svg>
-                            <span>{license.tier === 'Free' ? 'Renew' : 'Sync'}</span>
-                          </button>
+                              <span>Renew</span>
+                            </button>
+                          </>
                         )}
                       </div>
                     )}

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -32,7 +32,9 @@ import {
   Clock,
   Flame,
   Eye,
-  EyeOff
+  EyeOff,
+  Trash2,
+  RefreshCw
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -150,6 +152,24 @@ function formatDateTooltip(dateInput: string | null, fallback = ''): string {
   else rel = rtf.format(Math.round(diffSec / (365.25 * 86400)), 'year');
 
   return `${userTz}: ${local}\nUTC: ${utc}\n${rel}`;
+}
+
+// Short relative-time phrase ("2 hours ago", "in 3 days") for inline use under
+// the Account Details title. Same picker as formatDateTooltip's relative line
+// so phrasing stays consistent across the panel and its tooltip.
+function formatRelativeTime(dateInput: string | null): string {
+  if (!dateInput) return '';
+  const d = new Date(dateInput);
+  if (Number.isNaN(d.getTime())) return '';
+  const diffSec = (d.getTime() - Date.now()) / 1000;
+  const absSec = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  if (absSec < 45) return rtf.format(Math.round(diffSec), 'second');
+  if (absSec < 45 * 60) return rtf.format(Math.round(diffSec / 60), 'minute');
+  if (absSec < 22 * 3600) return rtf.format(Math.round(diffSec / 3600), 'hour');
+  if (absSec < 26 * 86400) return rtf.format(Math.round(diffSec / 86400), 'day');
+  if (absSec < 320 * 86400) return rtf.format(Math.round(diffSec / (30.44 * 86400)), 'month');
+  return rtf.format(Math.round(diffSec / (365.25 * 86400)), 'year');
 }
 
 // Dodo Payments configuration - Toggle IS_LIVE to switch modes
@@ -2372,9 +2392,10 @@ const Settings: React.FC = () => {
                 </div>
 
                 <form onSubmit={handleLicenseSubmit} className="license-form">
-                  <h3>Enter License Key</h3>
-                  <div className="license-input-group">
+                  <label className="license-form-label" htmlFor="license-key-input">Enter License Key</label>
+                  <div className="license-form-row">
                     <input
+                      id="license-key-input"
                       type="text"
                       value={licenseKey}
                       onChange={(e) => setLicenseKey(e.target.value)}
@@ -2382,71 +2403,56 @@ const Settings: React.FC = () => {
                       className="license-input"
                       disabled={isSubmitting}
                     />
-                    <button 
-                      type="submit" 
+                    <button
+                      type="submit"
                       className="license-submit"
                       disabled={isSubmitting || !licenseKey.trim()}
                     >
                       {isSubmitting ? 'Validating...' : 'Activate'}
                     </button>
-                    {(license.tier !== 'Free' || license.licenseId) && (
-                      <div className="license-action-row">
-                        {license.tier !== 'Free' && (
-                          <button
-                            type="button"
-                            className="remove-license-btn"
-                            onClick={handleRemoveLicense}
-                            disabled={isSubmitting}
-                          >
-                            Remove
-                          </button>
-                        )}
-                        {license.licenseId && (
-                          <>
-                            <button
-                              type="button"
-                              className="refresh-button"
-                              onClick={handleSyncLicense}
-                              disabled={isSyncing}
-                              title="Check the license server for renewals or updates"
-                            >
-                              <svg
-                                viewBox="0 0 24 24"
-                                width="18"
-                                height="18"
-                                style={{
-                                  animation: isSyncing ? 'spin 1s linear infinite' : 'none',
-                                  display: 'block'
-                                }}
-                              >
-                                <path
-                                  fill="currentColor"
-                                  d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                                />
-                              </svg>
-                              <span>Sync</span>
-                            </button>
-                            <button
-                              type="button"
-                              className="refresh-button"
-                              onClick={handleRenewLicense}
-                              disabled={!canRenew || isRenewing}
-                              title={canRenew
-                                ? 'Force-refresh your license token from the server. 15 min cooldown, 3/day.'
-                                : 'Available when Sync cannot recover your license (e.g., token expired or webhook lost). Try Sync first.'}
-                            >
-                              <KeyRound
-                                size={18}
-                                style={{
-                                  animation: isRenewing ? 'spin 1s linear infinite' : 'none',
-                                  display: 'block'
-                                }}
-                              />
-                              <span>Renew</span>
-                            </button>
-                          </>
-                        )}
-                      </div>
+                    {license.tier !== 'Free' && (
+                      <button
+                        type="button"
+                        className="license-action-btn license-action-btn--danger"
+                        onClick={handleRemoveLicense}
+                        disabled={isSubmitting}
+                        title="Remove license and revert to free tier"
+                      >
+                        <Trash2 size={16} />
+                        <span>Remove</span>
+                      </button>
+                    )}
+                    {license.licenseId && (
+                      <>
+                        <button
+                          type="button"
+                          className="license-action-btn"
+                          onClick={handleSyncLicense}
+                          disabled={isSyncing}
+                          title="Check the license server for renewals or updates"
+                        >
+                          <RefreshCw
+                            size={16}
+                            style={{ animation: isSyncing ? 'spin 1s linear infinite' : 'none' }}
+                          />
+                          <span>Sync</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="license-action-btn"
+                          onClick={handleRenewLicense}
+                          disabled={!canRenew || isRenewing}
+                          title={canRenew
+                            ? 'Force-refresh your license token from the server. 15 min cooldown, 3/day.'
+                            : 'Available when Sync cannot recover your license (e.g., token expired or webhook lost). Try Sync first.'}
+                        >
+                          <KeyRound
+                            size={16}
+                            style={{ animation: isRenewing ? 'spin 1s linear infinite' : 'none' }}
+                          />
+                          <span>Renew</span>
+                        </button>
+                      </>
                     )}
                   </div>
                   {licenseStatus && (
@@ -2459,92 +2465,207 @@ const Settings: React.FC = () => {
                 {license.tier !== 'Free' && (license.customerName || license.customerEmail) && (
                   <div className="license-details">
                     <div className="license-details-header">
-                      <h4 className="license-details-title">Account Details</h4>
-                      <button
-                        type="button"
-                        className="license-details-copy-all"
-                        onClick={() => copyToClipboard(composeAccountDetails(license), 'account')}
-                        title="Copy account details (excludes token)"
-                        aria-label="Copy account details (excludes token)"
-                      >
-                        {copiedTarget === 'account' ? <Check size={14} /> : <Copy size={14} />}
-                      </button>
+                      <div className="license-details-heading">
+                        <h4 className="license-details-title">Account Details</h4>
+                        {license.lastSyncAt && (
+                          <p
+                            className="license-details-subtitle"
+                            title={formatDateTooltip(license.lastSyncAt)}
+                          >
+                            Last synced {formatFriendlyDate(license.lastSyncAt, USER_TIMEZONE)}
+                            <span className="license-details-subtitle-sep"> · </span>
+                            {formatRelativeTime(license.lastSyncAt)}
+                          </p>
+                        )}
+                      </div>
+                      <div className="license-details-meta">
+                        <span
+                          className="license-status-pill"
+                          data-tier={license.billing === 'lifetime' ? 'lifetime' : license.tier.toLowerCase()}
+                          title={license.billing ? `${license.tier} · ${license.billing}` : license.tier}
+                        >
+                          <span className="license-status-pill-dot" aria-hidden="true" />
+                          <span className="license-status-pill-text">
+                            ACTIVE
+                            {license.billing && <> · {license.tier.toUpperCase()} {license.billing.toUpperCase()}</>}
+                          </span>
+                        </span>
+                        <button
+                          type="button"
+                          className="license-details-copy-all"
+                          onClick={() => copyToClipboard(composeAccountDetails(license), 'account')}
+                          title="Copy account details (excludes token)"
+                          aria-label="Copy account details (excludes token)"
+                        >
+                          {copiedTarget === 'account' ? <Check size={14} /> : <Copy size={14} />}
+                        </button>
+                      </div>
                     </div>
-                    {license.customerName && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Name</span>
-                        <span className="license-details-value">{license.customerName}</span>
-                      </div>
-                    )}
-                    {license.customerEmail && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Email</span>
-                        <span className="license-details-value">{license.customerEmail}</span>
-                      </div>
-                    )}
-                    {license.licenseId && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">License ID</span>
-                        <span className="license-details-value license-id-value">{license.licenseId}</span>
-                      </div>
-                    )}
-                    {license.subscriptionId && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Subscription ID</span>
-                        <span className="license-details-value license-id-value">{license.subscriptionId}</span>
-                      </div>
-                    )}
-                    {license.customerId && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Customer ID</span>
-                        <span className="license-details-value license-id-value">{license.customerId}</span>
-                      </div>
-                    )}
-                    {license.discountCode && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Discount</span>
-                        <span className="license-details-value">
-                          {license.discountCode}
-                          {license.discountCyclesRemaining != null && license.discountCyclesRemaining > 0 && (
-                            <>, {license.discountCyclesRemaining} cycles remaining</>
-                          )}
-                        </span>
-                      </div>
-                    )}
-                    {license.lastSyncAt && (
-                      <div className="license-details-row">
-                        <span className="license-details-label">Last Synced</span>
-                        <span className="license-details-value">{formatFriendlyDate(license.lastSyncAt, USER_TIMEZONE)}</span>
-                      </div>
-                    )}
-                    {license.token && (
-                      <div className="license-details-row license-token-row">
-                        <span className="license-details-label">License Token</span>
-                        <div className="license-token-controls">
-                          <button
-                            type="button"
-                            className="license-details-icon-button"
-                            onClick={() => setTokenRevealed((r) => !r)}
-                            title={tokenRevealed ? 'Hide token' : 'Show token'}
-                            aria-label={tokenRevealed ? 'Hide token' : 'Show token'}
-                          >
-                            {tokenRevealed ? <EyeOff size={14} /> : <Eye size={14} />}
-                          </button>
-                          <button
-                            type="button"
-                            className="license-details-icon-button"
-                            onClick={() => copyToClipboard(license.token!, 'token')}
-                            title="Copy token"
-                            aria-label="Copy token"
-                          >
-                            {copiedTarget === 'token' ? <Check size={14} /> : <Copy size={14} />}
-                          </button>
+
+                    <div className="license-field-grid">
+                      {license.customerName && (
+                        <div className="license-field">
+                          <div className="license-field-header">
+                            <span className="license-field-label">Name</span>
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value">{license.customerName}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.customerName!, 'account')}
+                                title="Copy name"
+                                aria-label="Copy name"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
                         </div>
-                        <span className="license-details-value license-token-value">
-                          {tokenRevealed ? license.token : maskToken(license.token)}
-                        </span>
-                      </div>
-                    )}
+                      )}
+                      {license.customerEmail && (
+                        <div className="license-field">
+                          <div className="license-field-header">
+                            <span className="license-field-label">Email</span>
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value">{license.customerEmail}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.customerEmail!, 'account')}
+                                title="Copy email"
+                                aria-label="Copy email"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {license.licenseId && (
+                        <div className="license-field">
+                          <div className="license-field-header">
+                            <span className="license-field-label">License ID</span>
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value license-field-value--mono">{license.licenseId}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.licenseId!, 'account')}
+                                title="Copy License ID"
+                                aria-label="Copy License ID"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {license.subscriptionId && (
+                        <div className="license-field">
+                          <div className="license-field-header">
+                            <span className="license-field-label">Subscription ID</span>
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value license-field-value--mono">{license.subscriptionId}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.subscriptionId!, 'account')}
+                                title="Copy Subscription ID"
+                                aria-label="Copy Subscription ID"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {license.customerId && (
+                        <div className="license-field">
+                          <div className="license-field-header">
+                            <span className="license-field-label">Customer ID</span>
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value license-field-value--mono">{license.customerId}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.customerId!, 'account')}
+                                title="Copy Customer ID"
+                                aria-label="Copy Customer ID"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {license.discountCode && (
+                        <div className="license-field license-field--full">
+                          <div className="license-field-header">
+                            <span className="license-field-label">Discount code</span>
+                            {license.discountCyclesRemaining != null && license.discountCyclesRemaining > 0 && (
+                              <span className="license-field-hint">{license.discountCyclesRemaining} cycles remaining</span>
+                            )}
+                          </div>
+                          <div className="license-field-input">
+                            <span className="license-field-value license-field-value--mono">{license.discountCode}</span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.discountCode!, 'account')}
+                                title="Copy discount code"
+                                aria-label="Copy discount code"
+                              >
+                                <Copy size={14} />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {license.token && (
+                        <div className="license-field license-field--full">
+                          <div className="license-field-header">
+                            <span className="license-field-label">License Token</span>
+                            <span className="license-field-hint">Keep this secret — it authenticates your client.</span>
+                          </div>
+                          <div className="license-field-input license-field-input--token">
+                            <span className="license-field-value license-field-value--mono license-field-value--token">
+                              {tokenRevealed ? license.token : maskToken(license.token)}
+                            </span>
+                            <div className="license-field-actions">
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => setTokenRevealed((r) => !r)}
+                                title={tokenRevealed ? 'Hide token' : 'Show token'}
+                                aria-label={tokenRevealed ? 'Hide token' : 'Show token'}
+                              >
+                                {tokenRevealed ? <EyeOff size={14} /> : <Eye size={14} />}
+                              </button>
+                              <button
+                                type="button"
+                                className="license-details-icon-button"
+                                onClick={() => copyToClipboard(license.token!, 'token')}
+                                title="Copy token"
+                                aria-label="Copy token"
+                              >
+                                {copiedTarget === 'token' ? <Check size={14} /> : <Copy size={14} />}
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )}
               </>

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -28,7 +28,9 @@ import {
   CheckSquare,
   Copy,
   Check,
-  KeyRound
+  KeyRound,
+  Clock,
+  Flame
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -955,13 +957,38 @@ const Settings: React.FC = () => {
   };
 
   // Copy a discount code to the clipboard, briefly flip the icon to a check.
+  // navigator.clipboard only works in secure contexts (HTTPS / localhost), so
+  // fall back to a legacy textarea + execCommand path for http://<lan-ip>:port
+  // dev/self-hosted deployments. Surface failure via toast so the user knows.
   const copyDiscountCode = async (code: string) => {
+    let ok = false;
     try {
-      await navigator.clipboard.writeText(code);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+        ok = true;
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = code;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.top = '0';
+        ta.style.left = '0';
+        ta.style.opacity = '0';
+        ta.style.pointerEvents = 'none';
+        document.body.appendChild(ta);
+        ta.select();
+        ta.setSelectionRange(0, ta.value.length);
+        ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+    } catch {
+      ok = false;
+    }
+    if (ok) {
       setCopiedCode(code);
       setTimeout(() => setCopiedCode((c) => (c === code ? null : c)), 2000);
-    } catch {
-      // clipboard API unavailable — silently no-op; the code is still visible
+    } else {
+      toast.error('Could not copy code. Select and copy manually.');
     }
   };
 
@@ -1781,41 +1808,118 @@ const Settings: React.FC = () => {
                     fallbacks only render during the brief loading window before the API
                     responds — keep them in sync with tiers.ts pricing if you change it. */}
                 <div className="pricing-section">
-                  <h3>Available Plans</h3>
-
                   {promo && promo.offers.length > 0 && (
-                    <div className="promo-offers" role="region" aria-label="Available discount offers">
+                    <>
+                      <h3>Offers</h3>
+                      <div className="promo-offers" role="region" aria-label="Available discount offers">
                       {promo.offers.map((offer) => {
                         const hasLimit = offer.expiresAt != null || offer.totalLimit != null;
                         const productSummary = offer.appliesTo
                           .map((a) => `${a.tier === 'pro' ? 'Pro' : 'Enterprise'} ${a.billing.charAt(0).toUpperCase() + a.billing.slice(1)}`)
                           .join(' & ');
-                        const meta: string[] = [];
-                        if (offer.remaining != null) {
-                          meta.push(`${offer.remaining} ${offer.remaining === 1 ? 'spot' : 'spots'} left`);
-                        }
-                        if (offer.cycles != null) {
-                          meta.push(`for ${offer.cycles} ${offer.cycles === 1 ? 'cycle' : 'cycles'}`);
-                        }
+
+                        let daysRemaining: number | null = null;
+                        let endDateLabel: string | null = null;
                         if (offer.expiresAt) {
                           const dt = new Date(offer.expiresAt);
-                          meta.push(`ends ${dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`);
+                          const msLeft = dt.getTime() - Date.now();
+                          daysRemaining = Math.max(0, Math.ceil(msLeft / (1000 * 60 * 60 * 24)));
+                          endDateLabel = dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
                         }
+
+                        const spotsRatio = offer.remaining != null && offer.totalLimit != null && offer.totalLimit > 0
+                          ? Math.max(0, Math.min(1, offer.remaining / offer.totalLimit))
+                          : null;
+
+                        // Card urgency drives all non-bar elements (label dot,
+                        // stamp number, hover glow, etc.). Based on absolute
+                        // remaining count: <=3 critical, <=10 caution, else
+                        // normal. Days-to-expiry can escalate the tier.
+                        let urgency: 'normal' | 'caution' | 'critical' | null = null;
+                        if (offer.remaining != null) {
+                          if (offer.remaining <= 3) urgency = 'critical';
+                          else if (offer.remaining <= 10) urgency = 'caution';
+                          else urgency = 'normal';
+                        }
+                        if (daysRemaining != null) {
+                          if (daysRemaining <= 7) {
+                            urgency = 'critical';
+                          } else if (daysRemaining <= 30 && urgency !== 'critical') {
+                            urgency = urgency === null || urgency === 'normal' ? 'caution' : urgency;
+                          }
+                        }
+
+                        // Bar urgency drives the progress bar fill only.
+                        // Based on % of slots remaining (independent of card):
+                        //   > 60% left -> normal (green)
+                        //   30-60% left -> caution (amber)
+                        //   < 30% left -> critical (red)
+                        let barUrgency: 'normal' | 'caution' | 'critical' | null = null;
+                        if (spotsRatio != null) {
+                          if (spotsRatio < 0.30) barUrgency = 'critical';
+                          else if (spotsRatio <= 0.60) barUrgency = 'caution';
+                          else barUrgency = 'normal';
+                        }
+
                         return (
-                          <div key={offer.code} className="promo-offer">
-                            <Tag size={16} className="promo-offer-icon" aria-hidden="true" />
-                            <div className="promo-offer-body">
-                              <div className="promo-offer-headline">
-                                <span className="promo-offer-label">{hasLimit ? 'LIMITED OFFER' : 'OFFER'}</span>
-                                <span className="promo-offer-headline-text">{offer.amountPct}% off {productSummary || 'select plans'}</span>
+                          <article
+                            key={offer.code}
+                            className="promo-offer"
+                            data-urgency={urgency ?? undefined}
+                          >
+                            <div className="promo-offer-stamp">
+                              <span className="promo-offer-stamp-label">SAVE</span>
+                              <div className="promo-offer-stamp-amount">
+                                <span className="promo-offer-stamp-number">{offer.amountPct}</span>
+                                <span className="promo-offer-stamp-symbol">%</span>
                               </div>
-                              {meta.length > 0 && (
-                                <div className="promo-offer-meta">{meta.join(' · ')}</div>
-                              )}
-                              <div className="promo-offer-cta">
-                                <span className="promo-offer-code-line">
-                                  Use code <code className="promo-offer-code">{offer.code}</code> at checkout
+                              {offer.cycles != null && (
+                                <span className="promo-offer-stamp-cycles">
+                                  for {offer.cycles} {offer.cycles === 1 ? 'cycle' : 'cycles'}
                                 </span>
+                              )}
+                              {endDateLabel && (
+                                <span className="promo-offer-stamp-expires">
+                                  <Clock size={11} aria-hidden="true" />
+                                  Ends {endDateLabel}
+                                </span>
+                              )}
+                            </div>
+
+                            <div className="promo-offer-content">
+                              <div className="promo-offer-header">
+                                <span className="promo-offer-label">
+                                  <span className="promo-offer-label-dot" aria-hidden="true" />
+                                  {hasLimit ? 'LIMITED OFFER' : 'OFFER'}
+                                </span>
+                                {daysRemaining != null && (
+                                  <span className="promo-offer-days">{daysRemaining} days remaining</span>
+                                )}
+                              </div>
+                              <h4 className="promo-offer-title">{productSummary || 'Select plans'}</h4>
+
+                              {offer.remaining != null && (
+                                <div className="promo-offer-spots">
+                                  <span className="promo-offer-spots-text">
+                                    {urgency === 'critical' && (
+                                      <Flame size={12} className="promo-offer-spots-icon" aria-hidden="true" />
+                                    )}
+                                    {offer.remaining} {offer.remaining === 1 ? 'spot' : 'spots'} left
+                                  </span>
+                                  {spotsRatio != null && (
+                                    <div
+                                      className="promo-offer-spots-bar"
+                                      data-urgency={barUrgency ?? undefined}
+                                      aria-hidden="true"
+                                    >
+                                      <div className="promo-offer-spots-fill" style={{ width: `${spotsRatio * 100}%` }} />
+                                    </div>
+                                  )}
+                                </div>
+                              )}
+
+                              <div className="promo-offer-code-row">
+                                <code className="promo-offer-code">{offer.code}</code>
                                 <button
                                   type="button"
                                   className="promo-copy-btn"
@@ -1827,12 +1931,14 @@ const Settings: React.FC = () => {
                                 </button>
                               </div>
                             </div>
-                          </div>
+                          </article>
                         );
                       })}
-                    </div>
+                      </div>
+                    </>
                   )}
 
+                  <h3>Available Plans</h3>
                   <div className="pricing-cards">
                     {/* Free Plan */}
                     <div className={`pricing-card ${license.tier === 'Free' ? 'current' : ''}`}>

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -1176,10 +1176,46 @@
 }
 
 .license-details-title {
-  margin: 0 0 var(--spacing-sm) 0;
+  margin: 0;
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
   font-weight: var(--font-weight-medium);
+}
+
+.license-details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+
+.license-details-copy-all,
+.license-details-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.license-details-copy-all:hover,
+.license-details-icon-button:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border-color: var(--text-tertiary);
+}
+
+.license-details-copy-all:focus-visible,
+.license-details-icon-button:focus-visible {
+  outline: 2px solid var(--color-accent, var(--text-primary));
+  outline-offset: 2px;
 }
 
 .license-details-row {
@@ -1206,6 +1242,27 @@
 .license-id-value {
   font-family: var(--font-mono);
   font-size: 0.75rem;
+}
+
+/* Token row: label + controls on one line, masked/full value wraps below. */
+.license-token-row {
+  flex-wrap: wrap;
+  row-gap: var(--spacing-xs);
+}
+
+.license-token-controls {
+  display: inline-flex;
+  gap: var(--spacing-xs);
+  margin-left: auto;
+}
+
+.license-token-value {
+  flex-basis: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  word-break: break-all;
+  line-height: 1.4;
 }
 
 .license-status {

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -151,122 +151,280 @@
   font-size: var(--font-size-lg);
 }
 
-/* Available offers banner — public discount advertising on the Subscription tab.
-   Visually distinct from .discount-banner (green/applied to your sub) by using
-   the caution palette (amber). One container; one .promo-offer per advertised
-   discount. Both light and dark themes are covered by --temp-caution-* tokens. */
+/* Available offers — public discount advertising on the Subscription tab.
+   Split-card layout: stamp column (left) + content column (right).
+   --promo-accent drives the card color; defaults to --color-accent-dynamic
+   (user's theme color from Settings > General > Appearance) but is overridden
+   by data-urgency on .promo-offer (absolute remaining count) to reflect tier
+   colors via Pankha's existing --temp-* tokens. The progress bar fill uses
+   its OWN data-urgency on .promo-offer-spots-bar (percentage of slots left)
+   so the bar can show a different tier than the rest of the card. */
 .promo-offers {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+  gap: var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
-  padding: var(--spacing-md) var(--spacing-lg);
-  background: var(--temp-caution-bg);
-  border: 1px solid var(--temp-caution-border);
-  border-radius: var(--radius-lg);
 }
 
 .promo-offer {
-  display: flex;
-  gap: var(--spacing-md);
-  align-items: flex-start;
+  --promo-accent: var(--color-accent-dynamic);
+  display: grid;
+  grid-template-columns: minmax(120px, 30%) 1fr;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.promo-offer + .promo-offer {
-  padding-top: var(--spacing-md);
-  border-top: 1px dashed var(--border-color);
+.promo-offer[data-urgency="normal"] {
+  --promo-accent: var(--temp-normal-text);
 }
 
-.promo-offer-icon {
-  color: var(--temp-caution-text);
-  flex-shrink: 0;
-  margin-top: 2px;
+.promo-offer[data-urgency="caution"] {
+  --promo-accent: var(--temp-caution-text);
 }
 
-.promo-offer-body {
-  flex: 1;
+.promo-offer[data-urgency="critical"] {
+  --promo-accent: var(--temp-critical-text);
+}
+
+.promo-offer:hover {
+  border-color: color-mix(in srgb, var(--promo-accent), transparent 60%);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2),
+              0 0 12px color-mix(in srgb, var(--promo-accent), transparent 90%);
+}
+
+.promo-offer-stamp {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  /* gap: var(--spacing-xs); */
+  padding: var(--spacing-lg) var(--spacing-md);
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--promo-accent), transparent 82%) 0%, transparent 70%),
+    var(--bg-tertiary);
+  border-right: 1px dashed var(--border-color);
+  text-align: center;
+}
+
+.promo-offer-stamp-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--promo-accent), transparent 25%);
+}
+
+.promo-offer-stamp-amount {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 2px;
+  color: var(--promo-accent);
+  line-height: 1;
+}
+
+.promo-offer-stamp-number {
+  font-family: var(--font-primary);
+  font-size: 64px; /* 88px — matches mockup; outside the token scale */
+  font-weight: var(--font-weight-bold-xl);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.promo-offer-stamp-symbol {
+  font-size: var(--font-size-2xl); /* 32px — matches mockup's ~33px */
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+}
+
+.promo-offer-stamp-cycles {
+  font-size: var(--font-size-sm2);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+
+.promo-offer-stamp-expires {
+  display: inline-flex;
+  align-items: center;
   gap: var(--spacing-xs);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-tertiary);
+  margin-top: var(--spacing-sm);
+}
+
+.promo-offer-content {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
   min-width: 0;
 }
 
-.promo-offer-headline {
+.promo-offer-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-sm);
   flex-wrap: wrap;
 }
 
 .promo-offer-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--temp-caution-text);
-  background: var(--bg-secondary);
-  padding: 2px var(--spacing-sm);
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
+  color: var(--promo-accent);
 }
 
-.promo-offer-headline-text {
-  font-size: var(--font-size-md);
+.promo-offer-label-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-circle);
+  background: var(--promo-accent);
+  box-shadow: 0 0 8px var(--promo-accent);
+}
+
+.promo-offer-days {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+}
+
+.promo-offer-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
   color: var(--text-primary);
+  line-height: 1.3;
 }
 
-.promo-offer-meta {
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-}
-
-.promo-offer-cta {
+.promo-offer-spots {
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
-  flex-wrap: wrap;
   margin-top: var(--spacing-xs);
 }
 
-.promo-offer-code-line {
+.promo-offer-spots-text {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.promo-offer-spots-icon {
+  color: var(--promo-accent);
+  flex-shrink: 0;
+}
+
+.promo-offer-spots-bar {
+  flex: 1;
+  height: 3px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+/* Bar color is decoupled from the card's --promo-accent: the bar wrapper
+   has its OWN data-urgency (% slots left), independent from the card's
+   data-urgency (absolute count). Default is caution/amber. */
+.promo-offer-spots-fill {
+  height: 100%;
+  background: var(--temp-caution-text);
+  border-radius: inherit;
+  box-shadow: 0 0 6px color-mix(in srgb, var(--temp-caution-text), transparent 50%);
+}
+
+.promo-offer-spots-bar[data-urgency="normal"] .promo-offer-spots-fill {
+  background: var(--temp-normal-text);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--temp-normal-text), transparent 50%);
+}
+
+.promo-offer-spots-bar[data-urgency="critical"] .promo-offer-spots-fill {
+  background: var(--temp-critical-text);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--temp-critical-text), transparent 50%);
+}
+
+.promo-offer-code-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
 }
 
 .promo-offer-code {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
-  color: var(--text-primary);
-  background: var(--bg-secondary);
-  padding: 1px var(--spacing-xs);
-  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .promo-copy-btn {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  padding: var(--spacing-xs) var(--spacing-sm);
-  background: var(--bg-secondary);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .promo-copy-btn:hover {
-  background: var(--bg-hover);
-  border-color: var(--temp-caution-border);
+  background: color-mix(in srgb, var(--promo-accent) 4%, var(--bg-primary));
+  border-color: var(--promo-accent);
+  color: var(--promo-accent);
 }
 
 .promo-copy-btn:focus-visible {
-  outline: 2px solid var(--temp-caution-border);
+  outline: 2px solid var(--promo-accent);
   outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .promo-offers {
+    grid-template-columns: 1fr;
+  }
+  .promo-offer {
+    grid-template-columns: 1fr;
+  }
+  .promo-offer-stamp {
+    border-right: none;
+    border-bottom: 1px dashed var(--border-color);
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: var(--spacing-sm) var(--spacing-md);
+  }
+  .promo-offer-stamp-expires {
+    margin-top: 0;
+  }
 }
 
 /* Per-card price strikethrough + discounted price emphasis (driven by the

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -151,6 +151,145 @@
   font-size: var(--font-size-lg);
 }
 
+/* Available offers banner — public discount advertising on the Subscription tab.
+   Visually distinct from .discount-banner (green/applied to your sub) by using
+   the caution palette (amber). One container; one .promo-offer per advertised
+   discount. Both light and dark themes are covered by --temp-caution-* tokens. */
+.promo-offers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--temp-caution-bg);
+  border: 1px solid var(--temp-caution-border);
+  border-radius: var(--radius-lg);
+}
+
+.promo-offer {
+  display: flex;
+  gap: var(--spacing-md);
+  align-items: flex-start;
+}
+
+.promo-offer + .promo-offer {
+  padding-top: var(--spacing-md);
+  border-top: 1px dashed var(--border-color);
+}
+
+.promo-offer-icon {
+  color: var(--temp-caution-text);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.promo-offer-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.promo-offer-headline {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.promo-offer-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--temp-caution-text);
+  background: var(--bg-secondary);
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.promo-offer-headline-text {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+}
+
+.promo-offer-meta {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.promo-offer-cta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-xs);
+}
+
+.promo-offer-code-line {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.promo-offer-code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 1px var(--spacing-xs);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+}
+
+.promo-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.promo-copy-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--temp-caution-border);
+}
+
+.promo-copy-btn:focus-visible {
+  outline: 2px solid var(--temp-caution-border);
+  outline-offset: 2px;
+}
+
+/* Per-card price strikethrough + discounted price emphasis (driven by the
+   same advertised-discounts data — only shown when restricted_to matches). */
+.pricing-price-strike {
+  text-decoration: line-through;
+  opacity: 0.45;
+  margin-right: var(--spacing-sm);
+  font-size: 0.7em;
+  vertical-align: baseline;
+}
+
+.pricing-price-discounted {
+  color: var(--temp-caution-text);
+}
+
+.pricing-savings-line {
+  margin-top: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  color: var(--temp-caution-text);
+}
+
 /* Discount banner - shows when promo code is active */
 .discount-banner {
   display: flex;
@@ -756,15 +895,43 @@
 .license-action-row {
   display: flex;
   gap: var(--spacing-md);
+  align-items: stretch;
 }
 
-.license-action-row .remove-license-btn {
+.license-action-row .remove-license-btn,
+.license-action-row .refresh-button {
   flex: 1;
 }
 
+/* Sync / Renew button — outlined secondary, pairs with Remove */
 .license-action-row .refresh-button {
-  padding: var(--spacing-md);
-  min-width: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-xl);
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+
+.license-action-row .refresh-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-info) 12%, transparent);
+  border-color: var(--color-info);
+  color: var(--text-primary);
+}
+
+.license-action-row .refresh-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.license-action-row .refresh-button svg {
   flex-shrink: 0;
 }
 

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -168,6 +168,10 @@
 
 .promo-offer {
   --promo-accent: var(--color-accent-dynamic);
+  /* Tier color for stamp bg + stamp amount. Defaults to --promo-accent;
+     overridden by [data-stamp-tier="..."] rules below to match the
+     pricing-card header colors. */
+  --stamp-tier-color: var(--promo-accent);
   display: grid;
   grid-template-columns: minmax(120px, 30%) 1fr;
   background: var(--bg-secondary);
@@ -203,7 +207,7 @@
   /* gap: var(--spacing-xs); */
   padding: var(--spacing-lg) var(--spacing-md);
   background:
-    radial-gradient(circle at top, color-mix(in srgb, var(--promo-accent), transparent 82%) 0%, transparent 70%),
+    radial-gradient(circle at top, color-mix(in srgb, var(--stamp-tier-color), transparent 82%) 0%, transparent 70%),
     var(--bg-tertiary);
   border-right: 1px dashed var(--border-color);
   text-align: center;
@@ -214,7 +218,7 @@
   font-weight: var(--font-weight-bold);
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--promo-accent), transparent 25%);
+  color: color-mix(in srgb, var(--stamp-tier-color), transparent 25%);
 }
 
 .promo-offer-stamp-amount {
@@ -222,8 +226,22 @@
   align-items: baseline;
   justify-content: center;
   gap: 2px;
-  color: var(--promo-accent);
+  color: var(--stamp-tier-color);
   line-height: 1;
+}
+
+/* Stamp tier color tracks the rarity of the tier(s) this discount applies to
+   (highest wins: lifetime > enterprise > pro). Matches the pricing-card
+   header colors. Drives both the stamp background gradient AND the amount
+   number via the single --stamp-tier-color custom property. */
+.promo-offer[data-stamp-tier="pro"] {
+  --stamp-tier-color: var(--temp-normal-text);
+}
+.promo-offer[data-stamp-tier="enterprise"] {
+  --stamp-tier-color: var(--color-primary);
+}
+.promo-offer[data-stamp-tier="lifetime"] {
+  --stamp-tier-color: var(--temp-caution-text);
 }
 
 .promo-offer-stamp-number {
@@ -294,8 +312,8 @@
 }
 
 .promo-offer-days {
-  font-size: var(--font-size-xs);
-  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
 }
 
 .promo-offer-title {
@@ -308,18 +326,33 @@
 
 .promo-offer-spots {
   display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
+  flex-direction: column;
+  gap: var(--spacing-xs);
   margin-top: var(--spacing-xs);
+}
+
+/* Row inside .promo-offer-spots: spots-text on the left, days on the right. */
+.promo-offer-spots-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--spacing-sm);
 }
 
 .promo-offer-spots-text {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--spacing-xs);
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
   white-space: nowrap;
+}
+
+/* Current count ("7" in "7 of 10 spots left") is emphasized vs the rest. */
+.promo-offer-spots-current {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
 }
 
 .promo-offer-spots-icon {
@@ -328,7 +361,6 @@
 }
 
 .promo-offer-spots-bar {
-  flex: 1;
   height: 3px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
@@ -1282,7 +1314,7 @@
 .pricing-card:hover {
   transform: translateY(-4px);
   box-shadow: var(--shadow-md);
-  border-color: var(--color-info);
+  border-color: var(--text-tertiary);
 }
 
 .pricing-card.featured {
@@ -1355,6 +1387,31 @@
   margin: 0 0 var(--spacing-sm) 0;
   color: var(--text-primary);
   font-size: var(--font-size-lg);
+}
+
+/* Tier rarity colors for pricing-header + matching hover border (Free stays
+   neutral and keeps the default --color-info hover from .pricing-card:hover).
+   Ladder: Pro (uncommon/green) -> Enterprise (rare/blue) -> Lifetime (legendary/gold).
+   All values come from existing Pankha tokens; no new tokens added. */
+.pricing-card[data-tier="pro"] .pricing-header h4 {
+  color: var(--temp-normal-text);
+}
+.pricing-card[data-tier="pro"]:hover {
+  border-color: var(--temp-normal-text);
+}
+
+.pricing-card[data-tier="enterprise"] .pricing-header h4 {
+  color: var(--color-primary);
+}
+.pricing-card[data-tier="enterprise"]:hover {
+  border-color: var(--color-primary);
+}
+
+.pricing-card[data-tier="lifetime"] .pricing-header h4 {
+  color: var(--temp-caution-text);
+}
+.pricing-card[data-tier="lifetime"]:hover {
+  border-color: var(--temp-caution-text);
 }
 
 .pricing-price {

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -603,6 +603,79 @@
   margin-top: var(--spacing-xl);
 }
 
+/* Label above the inline input row — replaces the prior h3 heading. */
+.license-form-label {
+  display: block;
+  font-size: var(--font-size-sm2);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
+  letter-spacing: 0.01em;
+}
+
+/* Single inline row: input grows to fill, Activate (filled) + Remove/Sync/Renew
+   (outlined) sit to the right. Wraps to multi-row on narrow viewports so the
+   long input keeps usable width on mobile rather than getting squeezed. */
+.license-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--spacing-sm);
+}
+
+.license-form-row .license-input {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+/* Outlined secondary action button — Remove, Sync, Renew sit next to Activate.
+   Same hit-target height as the input + Activate button. */
+.license-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.license-action-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--text-tertiary);
+  color: var(--text-primary);
+}
+
+.license-action-btn:focus-visible {
+  outline: 2px solid var(--color-info);
+  outline-offset: 2px;
+}
+
+.license-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.license-action-btn svg {
+  flex-shrink: 0;
+  display: block;
+}
+
+/* Remove flips to error color on hover — visually warns the destructive action. */
+.license-action-btn--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-error) 14%, var(--bg-tertiary));
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
 /* General Settings UI */
 .settings-groups {
   display: flex;
@@ -1168,25 +1241,214 @@
 
 /* License account details - shown for paid tiers */
 .license-details {
-  margin-top: var(--spacing-md);
-  padding: var(--spacing-md);
-  background: var(--bg-tertiary);
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-}
-
-.license-details-title {
-  margin: 0;
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-lg);
 }
 
 .license-details-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: var(--spacing-sm);
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.license-details-heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.license-details-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--text-primary);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.005em;
+}
+
+.license-details-subtitle {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+  font-weight: var(--font-weight-normal);
+  cursor: default;
+}
+
+.license-details-subtitle-sep {
+  color: var(--border-light);
+}
+
+.license-details-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* Status pill — soft tinted surface, dot + uppercase tracking. The pill
+   communicates lifecycle state at-a-glance without dominating the header.
+   Tier ladder mirrors .pricing-card[data-tier="..."] .pricing-header h4
+   (Pro → green, Enterprise → blue, Lifetime → gold, Free → info blue).
+   Lifetime wins over tier when license.billing === 'lifetime'. */
+.license-status-pill {
+  --pill-color: var(--color-info);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: color-mix(in srgb, var(--pill-color) 14%, transparent);
+  color: var(--pill-color);
+  border: 1px solid color-mix(in srgb, var(--pill-color) 35%, transparent);
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.license-status-pill[data-tier="free"] {
+  --pill-color: var(--color-info);
+}
+
+.license-status-pill[data-tier="pro"] {
+  --pill-color: var(--temp-normal-text);
+}
+
+.license-status-pill[data-tier="enterprise"] {
+  --pill-color: var(--color-primary);
+}
+
+.license-status-pill[data-tier="lifetime"] {
+  --pill-color: var(--temp-caution-text);
+}
+
+.license-status-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 25%, transparent);
+  flex-shrink: 0;
+}
+
+/* Stacked field grid — labels above input-shaped read-only boxes.
+   2 columns at desktop, 1 column on narrow viewports. Discount + Token
+   span the full row via .license-field--full. */
+.license-field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 720px) {
+  .license-field-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.license-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.license-field--full {
+  grid-column: 1 / -1;
+}
+
+.license-field-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: 0 var(--spacing-xs);
+}
+
+.license-field-label {
+  font-size: var(--font-size-sm2);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0.01em;
+}
+
+.license-field-hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  font-weight: var(--font-weight-normal);
+}
+
+/* Input-shaped read-only box: matches the visual weight of the license
+   key input above so the panel reads as one cohesive form. The inline
+   action area on the right hosts copy / eye buttons. */
+.license-field-input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-height: 40px;
+  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.license-field-input:hover {
+  border-color: var(--border-light);
+}
+
+.license-field-input--token {
+  align-items: flex-start;
+}
+
+/* Icon buttons nested inside a field input use a subtler hover than the
+   standalone Copy-All — they sit on top of an already-bordered surface
+   so the lift is the highlight, not a heavier border. */
+.license-field-actions .license-details-icon-button {
+  background: transparent;
+  border-color: transparent;
+}
+
+.license-field-actions .license-details-icon-button:hover {
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  border-color: transparent;
+  color: var(--text-primary);
+}
+
+.license-field-value {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.license-field-value--mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm2);
+  letter-spacing: 0;
+}
+
+.license-field-value--token {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  word-break: break-all;
+  line-height: 1.55;
+  padding: var(--spacing-xs) 0;
+}
+
+.license-field-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .license-details-copy-all,

--- a/frontend/src/systems/components/SensorSparkline.tsx
+++ b/frontend/src/systems/components/SensorSparkline.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useRef, useId } from 'react';
-import { useDashboardSettings } from '../../contexts/DashboardSettingsContext';
+import { USER_TIMEZONE } from '../../utils/formatters';
 import type { HistoryDataPoint, GapInfo } from '../../types/api';
 
 interface SensorSparklineProps {
@@ -56,7 +56,6 @@ const SensorSparkline: React.FC<SensorSparklineProps> = ({
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   const [hoverGap, setHoverGap] = useState<GapPolygon | null>(null);
   const containerRef = useRef<SVGSVGElement>(null);
-  const { timezone } = useDashboardSettings();
 
   // Generate unique IDs for gradient (SSR-safe via React 18+ useId)
   const gradientId = useId();
@@ -381,12 +380,12 @@ const SensorSparkline: React.FC<SensorSparklineProps> = ({
             {new Date(activePoint.timestamp).toLocaleTimeString([], {
               hour: '2-digit',
               minute: '2-digit',
-              timeZone: timezone
+              timeZone: USER_TIMEZONE
             })}
           </span>
           <span className="tooltip-date">
             {new Date(activePoint.timestamp).toLocaleDateString('en-CA', {
-              timeZone: timezone
+              timeZone: USER_TIMEZONE
             })}
           </span>
         </div>

--- a/frontend/src/systems/components/SystemCard.tsx
+++ b/frontend/src/systems/components/SystemCard.tsx
@@ -31,7 +31,7 @@ import { getChipDisplayName, getSensorLabel } from "../../config/sensorLabels";
 import { sortSensorGroups, sortSensorGroupIds, deriveSensorGroupId, groupSensorsByChip } from "../../utils/sensorUtils";
 import { getSensorDisplayName, getFanDisplayName } from "../../utils/displayNames";
 import { getTemperatureClass, getFanRPMClass } from "../../utils/statusColors";
-import { formatTemperature, formatLastSeen } from "../../utils/formatters";
+import { formatTemperature, formatLastSeen, USER_TIMEZONE } from "../../utils/formatters";
 import { useDashboardSettings } from "../../contexts/DashboardSettingsContext";
 import {
   Loader2,
@@ -85,7 +85,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
   onToggleBmc,
 }) => {
   const [loading, setLoading] = useState<string | null>(null);
-  const { timezone, tempThresholds } = useDashboardSettings();
+  const { tempThresholds } = useDashboardSettings();
   const [agentInterval, setAgentInterval] = useState<number>(
     system.current_update_interval ?? getDefault<number>('updateInterval')
   );
@@ -1054,7 +1054,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
           </div>
           <div className="meta-item" title="Last seen">
             <Clock size={14} />
-            <span>{formatLastSeen(system.last_seen, timezone)}</span>
+            <span>{formatLastSeen(system.last_seen, USER_TIMEZONE)}</span>
           </div>
           <div className="meta-item" title="Agent Version">
             <ShieldCheck size={14} />

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -3,6 +3,10 @@
  * Centralizes number and date formatting logic.
  */
 
+// User-facing date displays should render in the browser's local timezone.
+// Resolved once at module load; pass to formatters expecting an IANA timezone.
+export const USER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 /**
  * Format temperature for UI display.
  * @param temp - Temperature value (may be null/undefined)


### PR DESCRIPTION
## Summary

This PR brings the license system to a near-final shape: independent renewal, in-app discount surfacing, accurate billing cadence, a redesigned License tab, and frontend-wide local time display. End-to-end purchase, activation, and renewal flows were exercised across monthly, yearly, lifetime plans.

## Work Done

- **Vendor-independent license renewal** — licenses stay renewable even when the payment provider is unreachable. 15 min cooldown, 3/day cap, 3-day grace, with a 24h bridge so a transient outage never locks anyone out.
- **Truthful expiry** — license expiry now matches the actual next billing date instead of a hardcoded period. Renewing early no longer loses any of the customer's unused time.
- **Accurate cadence badge** — License Info shows the real billing frequency (Daily, Weekly, Monthly, Yearly), so non-standard plans no longer misreport as "Monthly".
- **Discount surfacing** — advertised discounts appear in an in-app banner and as a strikethrough on pricing cards. Clicking "Get Pro" or "Get Enterprise" opens checkout with the discount already applied; customer doesn't have to copy and paste a code.
- **Tier benefits** — every tier now lists its specific benefits (Free, Pro, Enterprise), making the upgrade prompt more informative.
- **Account Details redesigned** — stacked-field layout with a status pill (color-coded per tier: Free, Pro, Enterprise, Lifetime), a "Last synced X ago" subtitle, a Copy-All button that excludes the secret token, and per-field copy buttons for fast support workflows.
- **License Token field** — masked by default with an eye-toggle to reveal, plus a copy button that always copies the full token regardless of reveal state.
- **Support references** — Subscription and Customer identifiers are now surfaced in Account Details so users can paste them into support tickets.
- **Inline License form** — Activate, Remove, Sync, and Renew collapsed onto one row with proper icons. Activate stays the filled primary action; Remove flips to a destructive color on hover.
- **Local time everywhere** — every user-facing date in Settings, the Dashboard's per-system "last seen", and the sensor sparkline hover tooltip now render in the viewer's local time zone. Tooltips still expose the UTC view for anyone correlating with backend logs.
- **Structured logging** — license-related backend logs are now consistent with the rest of the project (proper levels and component tags).

## Breaking Changes

None. All additions are additive; existing tokens and integrations continue to work unchanged.

## Testing

- Frontend and backend type checks both pass.
- End-to-end purchase, activation, and renewal verified across multiple billing frequencies.
- Indian-rails 48h settlement window confirmed handled correctly with no false stuck-payment states.
- Discounted checkout with pre-applied code verified end-to-end.
