### PR TITLE
feat: implement release notes automation workflow and templates

### DIFF
--- a/.github/input/release-body-template.md
+++ b/.github/input/release-body-template.md
@@ -1,0 +1,75 @@
+## Pankha Fan Control (पंखा) - {{RELEASE_TYPE}} {{VERSION}}
+
+### Instructions:
+  1. Deploy the Pankha Server Docker Container
+  2. Deploy the Pankha Agents to your client devices
+  3. Access the Pankha Web Interface at `http://<server-ip>:<port>`
+
+## ![Docker](https://img.shields.io/badge/-Docker-0db7ed?logo=docker&logoColor=white&style=flat-square) Quick Start (Pankha Server)
+**Docker Compose Method (Recommended):**
+```bash
+# Download Docker Compose files from release
+wget -O compose.yml https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/compose.yml
+wget -O .env https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/example.env
+
+# Edit .env with your settings, then start
+docker compose up -d
+```
+
+**Docker Run Method:**
+```bash
+# Specific version (recommended for production)
+docker run -d --name pankha anexgohan/pankha:{{VERSION}}
+
+# Latest version
+docker run -d --name pankha anexgohan/pankha:latest
+```
+
+## Quick Start (Pankha Agents)
+
+### ![Linux](https://img.shields.io/badge/-Linux-FCC624?logo=linux&logoColor=black&style=flat-square) Linux Agents
+#### ![Intel x64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD x64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For x64 systems:
+```bash
+wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/pankha-agent-linux_x64
+chmod +x pankha-agent
+./pankha-agent --setup
+./pankha-agent --start
+```
+
+#### ![ARM64](https://img.shields.io/badge/CPU-ARM64-0091BD?logo=arm&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For ARM64 systems (Raspberry Pi 5):
+```bash
+wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/pankha-agent-linux_arm64
+chmod +x pankha-agent
+./pankha-agent --setup
+./pankha-agent --start
+```
+
+### [![Windows](https://img.shields.io/badge/-Windows-0078D4?logo=windows&logoColor=white&style=flat-square)](https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/pankha-agent-windows_x64.msi) Windows Agent
+#### ![Intel 64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD 64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For x64 systems:
+```bash
+# Download MSI form release assets below, then run it
+wget -O pankha-agent-windows_x64.msi https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/pankha-agent-windows_x64.msi
+```
+
+### ![Linux](https://img.shields.io/badge/-Linux-FCC624?logo=linux&logoColor=black&style=flat-square) IPMI Host Agent (Enterprise Servers)
+#### ![Intel x64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD x64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For servers with /dev/ipmi0 (Dell, Supermicro, ASRock, Tyan, Lenovo):
+```bash
+wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/pankha-agent-ipmi-linux_x64
+chmod +x pankha-agent
+./pankha-agent --setup
+./pankha-agent --start
+```
+
+### ![SHA256](https://img.shields.io/badge/-SHA256-28A745?logo=gnuprivacyguard&logoColor=white&style=flat-square) Verify Download Integrity
+```bash
+wget -O checksums.txt https://github.com/Anexgohan/pankha/releases/download/{{VERSION}}/checksums.txt
+sha256sum -c checksums.txt
+```
+
+## ![Docs](https://img.shields.io/badge/-Documentation-8CA1AF?logo=readthedocs&logoColor=white&style=flat-square)
+
+- [Installation Guide](https://github.com/Anexgohan/pankha/wiki/Installation)
+- [Agent Setup Guide](https://github.com/Anexgohan/pankha/wiki/Agent-Setup)
+- [Configuration](https://github.com/Anexgohan/pankha/wiki/Configuration)
+- [API Documentation](https://github.com/Anexgohan/pankha/wiki/API-Reference)
+- [Troubleshooting](https://github.com/Anexgohan/pankha/wiki/Troubleshooting)

--- a/.github/input/release-notes.md
+++ b/.github/input/release-notes.md
@@ -1,0 +1,32 @@
+<!-- HOW THIS FILE WORKS:
+     Edit sections below as you work toward a release. Delete the ones you don't need.
+     If this file is empty or contains only this template (comments + empty headings),
+     the release will use pure auto-generated categorised notes with no highlights block.
+
+     Images: drop files into .github/input/images/ and reference them here as
+       ![Caption](./images/your-screenshot.png)
+     The workflow uploads each image as a release asset and rewrites the URL to
+     the permanent releases/download/... URL automatically.
+
+     After a release is published, this file resets to this template
+     automatically and .github/input/images/ is cleared. The full body is
+     preserved on the GitHub Release page; git log of this file preserves
+     the authored prose per release. -->
+
+## Highlights
+
+<!-- Lead with 1-3 big things. Example:
+- **IPMI Support (Alpha)**: Pankha now talks to /dev/ipmi0 on enterprise BMC servers.
+  Currently supports Supermicro and Dell; HP is read-only. -->
+
+## Breaking Changes
+
+<!-- List behaviour changes for existing users. If none, write "None" or delete this section. -->
+
+## Screenshots
+
+<!-- ![Caption](./images/example.png) -->
+
+## Notes
+
+<!-- Migration steps, known issues, anything else worth calling out. -->

--- a/.github/scripts/compose-release-notes.sh
+++ b/.github/scripts/compose-release-notes.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# compose-release-notes.sh — Build the GitHub Release body for a given version.
+#
+# Usage: compose-release-notes.sh <version>
+#   <version> — tag name, e.g. v0.4.24 or v0.4.24-beta1
+#
+# Outputs:
+#   body.md in $PWD
+#   GITHUB_OUTPUT: body, has_images, release_type
+#
+# Requires: git, gh, jq, sed (all available on ubuntu-latest GitHub runners)
+
+set -euo pipefail
+
+VERSION="${1:?usage: $0 <version>}"
+REPO="${GITHUB_REPOSITORY:-Anexgohan/pankha}"
+INPUT_NOTES=".github/input/release-notes.md"
+INPUT_TEMPLATE=".github/input/release-body-template.md"
+INPUT_IMAGES=".github/input/images"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve diff base (asymmetric: stable vs pre-release)
+#    Works whether VERSION already exists as a tag (tag-push trigger) or not
+#    (workflow_dispatch trigger before the tag is created).
+# ---------------------------------------------------------------------------
+ALL_TAGS=$(git tag --sort=-version:refname || true)
+if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  RELEASE_TYPE="Release"
+  CANDIDATES=$(echo "$ALL_TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+else
+  RELEASE_TYPE="Pre-release"
+  CANDIDATES="$ALL_TAGS"
+fi
+# Insert VERSION into the candidate list, version-sort descending, take the tag
+# that lands immediately after VERSION in that order = the previous tag.
+PREV=$( { echo "$VERSION"; echo "$CANDIDATES"; } | sort -V -r | grep -A1 "^${VERSION}$" | tail -1 || true)
+[ "$PREV" = "$VERSION" ] && PREV=""
+[ -z "$PREV" ] && PREV=$(git rev-list --max-parents=0 HEAD | head -1)
+echo "Diff base: $PREV..$VERSION ($RELEASE_TYPE)"
+
+# ---------------------------------------------------------------------------
+# 2. Highlights priority: file (non-empty after stripping) > tag annotation > none
+# ---------------------------------------------------------------------------
+HIGHLIGHTS=""
+if [ -f "$INPUT_NOTES" ]; then
+  RAW=$(cat "$INPUT_NOTES")
+  STRIPPED=$(echo "$RAW" \
+    | sed -E ':a;N;$!ba;s/<!--[^-]*(-[^-]+)*-->//g' \
+    | sed -E '/^[[:space:]]*$/d; /^#/d')
+  [ -n "$STRIPPED" ] && HIGHLIGHTS="$RAW"
+fi
+if [ -z "$HIGHLIGHTS" ]; then
+  TAG_MSG=$(git tag -l --format='%(contents)' "$VERSION" 2>/dev/null | sed '/^$/d' || true)
+  # Skip boilerplate annotations like "Release v0.4.23" auto-set by release-public.yml.
+  # Only treat as highlights if the annotation is substantive (>1 line OR doesn't
+  # match the boilerplate pattern).
+  LINE_COUNT=$(echo "$TAG_MSG" | wc -l)
+  if [ -n "$TAG_MSG" ] && ! { [ "$LINE_COUNT" -le 1 ] && echo "$TAG_MSG" | grep -qE "^Release v[0-9]+\.[0-9]+\.[0-9]+"; }; then
+    HIGHLIGHTS="$TAG_MSG"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Rewrite image refs in highlights (./images/foo.png → release asset URL)
+# ---------------------------------------------------------------------------
+if [ -n "$HIGHLIGHTS" ]; then
+  IMG_BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+  HIGHLIGHTS=$(echo "$HIGHLIGHTS" | sed -E "s|\]\(\./images/([^)]+)\)|](${IMG_BASE}/\1)|g")
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Pull PRs in the commit range
+#    If VERSION already exists as a tag (real tag-push path, or local testing
+#    of a historical release), use it as the upper bound — this lets the
+#    script run accurately from main without a detached-HEAD checkout.
+#    Otherwise (workflow_dispatch path with the tag not yet created), use HEAD.
+# ---------------------------------------------------------------------------
+if git rev-parse --verify "$VERSION" >/dev/null 2>&1; then
+  UPPER="$VERSION"
+else
+  UPPER="HEAD"
+fi
+COMMIT_MSGS=$(git log "${PREV}..${UPPER}" --pretty=format:'%s' 2>/dev/null || true)
+PR_NUMS=$(echo "$COMMIT_MSGS" | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)
+
+echo "[]" > /tmp/prs.json
+for n in $PR_NUMS; do
+  pr=$(gh pr view "$n" --repo "$REPO" --json number,title,author,labels 2>/dev/null || true)
+  if [ -n "$pr" ]; then
+    jq --argjson p "$pr" '. + [$p]' /tmp/prs.json > /tmp/prs.json.tmp \
+      && mv /tmp/prs.json.tmp /tmp/prs.json
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 5. Categorise PRs (labels themselves are dynamic; only tier rules hardcoded)
+#    TOP:    breaking-change > feature > fix
+#    MIDDLE: any other label, alphabetical
+#    FOLD:   dependencies | ci | devops | chore (collapsed <details>)
+#    OTHER:  no labels (trailing "Other Changes")
+# ---------------------------------------------------------------------------
+jq '
+  def category:
+    .labels | map(.name) as $L
+    | (["ci","devops","chore"]) as $FOLD_OTHER
+    | if   ($L | index("breaking-change")) then "breaking-change"
+      elif ($L | index("feature"))         then "feature"
+      elif ($L | index("fix"))             then "fix"
+      # dependencies always folds (after top-tier intent labels), even when
+      # Dependabot also tags it with area labels like "backend" or "rust".
+      elif ($L | index("dependencies"))    then "_fold"
+      elif ($L | length) == 0              then "_other"
+      else
+        # Pick the first real category label (ignoring ci/devops/chore noise).
+        ($L | map(select(. as $l | $FOLD_OTHER | index($l) | not)) | sort) as $real
+        | if ($real | length) > 0 then $real[0]
+          else "_fold"
+          end
+      end;
+  map(. + {_cat: category}) | group_by(._cat) | map({k:.[0]._cat, v:.})
+' /tmp/prs.json > /tmp/grouped.json
+
+# Render a section with capitalised heading
+render_section() {
+  local cat="$1"
+  local items
+  items=$(jq -r --arg c "$cat" '.[] | select(.k==$c) | .v[] | "- " + .title + " by @" + .author.login + " in #" + (.number|tostring)' /tmp/grouped.json)
+  [ -z "$items" ] && return
+  local title
+  # Title-case each hyphen-separated word: "agent-linux" -> "Agent Linux"
+  title=$(echo "$cat" | awk -F'-' '{for(i=1;i<=NF;i++)$i=toupper(substr($i,1,1)) substr($i,2);print}' OFS=' ')
+  case "$cat" in
+    breaking-change) title="Breaking Changes" ;;
+    feature)         title="Features" ;;
+    fix)             title="Bug Fixes" ;;
+    _other)          title="Other Changes" ;;
+  esac
+  echo "### $title"
+  echo "$items"
+  echo ""
+}
+
+{
+  for cat in breaking-change feature fix; do render_section "$cat"; done
+  jq -r '.[] | select(.k | startswith("_") | not)
+        | select(.k as $k | (["breaking-change","feature","fix"] | index($k)) | not)
+        | .k' /tmp/grouped.json | sort -u | while read -r cat; do
+    [ -n "$cat" ] && render_section "$cat"
+  done
+  render_section "_other"
+
+  fold_items=$(jq -r '.[] | select(.k=="_fold") | .v[] | "- " + .title + " by @" + .author.login + " in #" + (.number|tostring)' /tmp/grouped.json)
+  if [ -n "$fold_items" ]; then
+    echo "<details>"
+    echo "<summary>Dependencies, CI, and chores</summary>"
+    echo ""
+    echo "$fold_items"
+    echo ""
+    echo "</details>"
+    echo ""
+  fi
+} > /tmp/categorised.md
+
+# ---------------------------------------------------------------------------
+# 6. Compose final body
+# ---------------------------------------------------------------------------
+TEMPLATE=$(sed "s/{{VERSION}}/$VERSION/g; s/{{RELEASE_TYPE}}/$RELEASE_TYPE/g" "$INPUT_TEMPLATE")
+HAS_CHANGES=false
+[ -s /tmp/categorised.md ] && HAS_CHANGES=true
+
+{
+  if [ -n "$HIGHLIGHTS" ]; then
+    echo "$HIGHLIGHTS"
+    echo ""
+  fi
+  if [ "$HAS_CHANGES" = "true" ]; then
+    echo "## What's Changed"
+    echo ""
+    cat /tmp/categorised.md
+  fi
+  echo "$TEMPLATE"
+  echo ""
+  echo "**Full Changelog**: https://github.com/${REPO}/compare/${PREV}...${VERSION}"
+} > body.md
+
+# ---------------------------------------------------------------------------
+# 7. Export for workflow
+# ---------------------------------------------------------------------------
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "body<<PANKHA_EOF"
+    cat body.md
+    echo "PANKHA_EOF"
+  } >> "$GITHUB_OUTPUT"
+  echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+
+  if [ -d "$INPUT_IMAGES" ] && ls -A "$INPUT_IMAGES" 2>/dev/null | grep -qv '^\.gitkeep$'; then
+    echo "has_images=true" >> "$GITHUB_OUTPUT"
+  else
+    echo "has_images=false" >> "$GITHUB_OUTPUT"
+  fi
+fi
+
+echo "Composed body.md ($(wc -l < body.md) lines)"

--- a/.github/scripts/reset-release-notes.sh
+++ b/.github/scripts/reset-release-notes.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# reset-release-notes.sh — Restore .github/input/release-notes.md to its pristine
+# template state after a release has been published. Called by the reset step
+# in release-public.yml after a successful release.
+
+set -euo pipefail
+
+cat > .github/input/release-notes.md << 'TEMPLATE_EOF'
+<!-- HOW THIS FILE WORKS:
+     Edit sections below as you work toward a release. Delete the ones you don't need.
+     If this file is empty or contains only this template (comments + empty headings),
+     the release will use pure auto-generated categorised notes with no highlights block.
+
+     Images: drop files into .github/input/images/ and reference them here as
+       ![Caption](./images/your-screenshot.png)
+     The workflow uploads each image as a release asset and rewrites the URL to
+     the permanent releases/download/... URL automatically.
+
+     After a release is published, this file resets to this template
+     automatically and .github/input/images/ is cleared. The full body is
+     preserved on the GitHub Release page; git log of this file preserves
+     the authored prose per release. -->
+
+## Highlights
+
+<!-- Lead with 1-3 big things. Example:
+- **IPMI Support (Alpha)**: Pankha now talks to /dev/ipmi0 on enterprise BMC servers.
+  Currently supports Supermicro and Dell; HP is read-only. -->
+
+## Breaking Changes
+
+<!-- List behaviour changes for existing users. If none, write "None" or delete this section. -->
+
+## Screenshots
+
+<!-- ![Caption](./images/example.png) -->
+
+## Notes
+
+<!-- Migration steps, known issues, anything else worth calling out. -->
+TEMPLATE_EOF
+
+echo "Reset .github/input/release-notes.md to template"

--- a/.github/workflows/configs/labeler.yml
+++ b/.github/workflows/configs/labeler.yml
@@ -39,7 +39,11 @@ docker:
 
 documentation:
   - changed-files:
-    - any-glob-to-any-file: ['documentation/**/*', '*.md', 'LICENSE']
+    - any-glob-to-any-file:
+      - 'documentation/**/*'
+      - '*.md'
+      - 'LICENSE'
+      - '.github/input/**'
 
 ci:
   - changed-files:
@@ -50,7 +54,9 @@ devops:
     - any-glob-to-any-file:
       - '.github/**/*'
       - '!.github/workflows/release-public.yml'
+      - '!.github/workflows/release-notes.yml'
       - '!.github/workflows/ci.yml'
+      - '!.github/input/**'
       - '.gitignore'
       - '.mailmap'
       - 'release.json'
@@ -69,4 +75,9 @@ vendor-profiles:
 
 dependencies:
   - changed-files:
-    - any-glob-to-any-file: ['**/package.json', '**/package-lock.json']
+    - any-glob-to-any-file:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/packages.lock.json'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'

--- a/.github/workflows/configs/labeler.yml
+++ b/.github/workflows/configs/labeler.yml
@@ -39,11 +39,7 @@ docker:
 
 documentation:
   - changed-files:
-    - any-glob-to-any-file:
-      - 'documentation/**/*'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/input/**'
+    - any-glob-to-any-file: ['documentation/**/*', '*.md', 'LICENSE']
 
 ci:
   - changed-files:
@@ -56,7 +52,6 @@ devops:
       - '!.github/workflows/release-public.yml'
       - '!.github/workflows/release-notes.yml'
       - '!.github/workflows/ci.yml'
-      - '!.github/input/**'
       - '.gitignore'
       - '.mailmap'
       - 'release.json'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,66 @@
+# REPO: pankha (public) | Composes the GitHub Release body for a tag.
+# Called via workflow_call from release-public.yml during the release pipeline,
+# or via workflow_dispatch to refresh notes on an existing release without
+# rebuilding agents/Docker.
+name: release-notes
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    outputs:
+      body:
+        description: 'Composed GitHub Release body markdown'
+        value: ${{ jobs.compose.outputs.body }}
+      has_images:
+        description: 'true if .github/input/images/ contains user-supplied files'
+        value: ${{ jobs.compose.outputs.has_images }}
+      release_type:
+        description: 'Release or Pre-release'
+        value: ${{ jobs.compose.outputs.release_type }}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v0.4.24) — must already exist as a tag'
+        required: true
+      update_existing_release:
+        description: 'Apply the composed body to the existing GitHub Release in place'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  compose:
+    runs-on: ubuntu-latest
+    outputs:
+      body: ${{ steps.compose.outputs.body }}
+      has_images: ${{ steps.compose.outputs.has_images }}
+      release_type: ${{ steps.compose.outputs.release_type }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + all tags for diff base resolution
+
+      - name: Compose release notes
+        id: compose
+        run: bash .github/scripts/compose-release-notes.sh "${{ inputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Preview body (logs)
+        run: |
+          echo "::group::Composed body.md"
+          cat body.md
+          echo "::endgroup::"
+
+      - name: Update existing release body (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.update_existing_release
+        run: gh release edit "${{ inputs.version }}" --notes-file body.md --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-public.yml
+++ b/.github/workflows/release-public.yml
@@ -266,9 +266,16 @@ jobs:
           cache-from: type=registry,ref=anexgohan/pankha:buildcache-${{ matrix.tag_suffix }}
           cache-to: type=registry,ref=anexgohan/pankha:buildcache-${{ matrix.tag_suffix }},mode=max
 
-  # Job 5: Create multi-arch manifest and release
-  release:
+  # Job 5: Compose release notes (reusable workflow)
+  compose-notes:
     needs: [build-rust-agents, build-ipmi-agent, build-windows-agent, build-docker]
+    uses: ./.github/workflows/release-notes.yml
+    with:
+      version: ${{ github.event.inputs.version || github.ref_name }}
+
+  # Job 6: Create multi-arch manifest and release
+  release:
+    needs: [build-rust-agents, build-ipmi-agent, build-windows-agent, build-docker, compose-notes]
     runs-on: ubuntu-22.04
 
     steps:
@@ -345,6 +352,11 @@ jobs:
           # Copy Docker deployment files
           cp compose.yml release-assets/
           cp .env release-assets/example.env
+
+          # Copy user-supplied screenshots referenced from .github/input/release-notes.md
+          if [ -d .github/input/images ]; then
+            find .github/input/images -type f ! -name '.gitkeep' -exec cp {} release-assets/ \;
+          fi
 
           # Make binaries executable
           chmod +x release-assets/pankha-agent-*linux_* 2>/dev/null || true
@@ -437,7 +449,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          generate_release_notes: true
           files: |
             release-assets/pankha-agent-linux_x64
             release-assets/pankha-agent-linux_arm64
@@ -447,85 +458,40 @@ jobs:
             release-assets/compose.yml
             release-assets/example.env
             release-assets/checksums.txt
-          body: |
-            ## Pankha Fan Control (पंखा) ${{ steps.version.outputs.is_prerelease == 'true' && '- Pre-release' || '- Release' }} ${{ steps.version.outputs.version }}
-
-            ### Instructions:
-              1. Deploy the Pankha Server Docker Container
-              2. Deploy the Pankha Agents to your client devices
-              3. Access the Pankha Web Interface at `http://<server-ip>:<port>`
-
-            ## ![Docker](https://img.shields.io/badge/-Docker-0db7ed?logo=docker&logoColor=white&style=flat-square) Quick Start (Pankha Server)
-            **Docker Compose Method (Recommended):**
-            ```bash
-            # Download Docker Compose files from release
-            wget -O compose.yml https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/compose.yml
-            wget -O .env https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/example.env
-
-            # Edit .env with your settings, then start
-            docker compose up -d
-            ```
-
-            **Docker Run Method:**
-            ```bash
-            # Specific version (recommended for production)
-            docker run -d --name pankha anexgohan/pankha:${{ steps.version.outputs.version }}
-
-            # Latest version
-            docker run -d --name pankha anexgohan/pankha:latest
-            ```
-
-            ## Quick Start (Pankha Agents)
-            
-            ### ![Linux](https://img.shields.io/badge/-Linux-FCC624?logo=linux&logoColor=black&style=flat-square) Linux Agents
-            #### ![Intel x64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD x64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For x64 systems:
-            ```bash
-            wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/pankha-agent-linux_x64
-            chmod +x pankha-agent
-            ./pankha-agent --setup
-            ./pankha-agent --start
-            ```
-
-            #### ![ARM64](https://img.shields.io/badge/CPU-ARM64-0091BD?logo=arm&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For ARM64 systems (Raspberry Pi 5):
-            ```bash
-            wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/pankha-agent-linux_arm64
-            chmod +x pankha-agent
-            ./pankha-agent --setup
-            ./pankha-agent --start
-            ```
-
-            ### [![Windows](https://img.shields.io/badge/CPU-x64-0078D4?logo=windows&logoColor=white&style=flat-square&labelColor=333&logoSize=auto)](https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/pankha-agent-windows_x64.msi) Windows Agent
-            #### ![Intel 64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD 64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For x64 systems:
-            ```bash
-            # Download MSI form release assets below, then run it
-            wget -O pankha-agent-windows_x64.msi https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/pankha-agent-windows_x64.msi
-            ```
-
-            ### ![Linux](https://img.shields.io/badge/-Linux-FCC624?logo=linux&logoColor=black&style=flat-square) IPMI Host Agent (Enterprise Servers)
-            #### ![Intel x64](https://img.shields.io/badge/CPU-x64-0071C5?logo=intel&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) ![AMD x64](https://img.shields.io/badge/CPU-x64-ED1C24?logo=amd&logoColor=white&style=flat-square&labelColor=333&logoSize=auto) For servers with /dev/ipmi0 (Dell, Supermicro, ASRock, Tyan, Lenovo):
-            ```bash
-            wget -O pankha-agent https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/pankha-agent-ipmi-linux_x64
-            chmod +x pankha-agent
-            ./pankha-agent --setup
-            ./pankha-agent --start
-            ```
-
-            ### ![SHA256](https://img.shields.io/badge/-SHA256-28A745?logo=gnuprivacyguard&logoColor=white&style=flat-square) Verify Download Integrity
-            ```bash
-            wget -O checksums.txt https://github.com/Anexgohan/pankha/releases/download/${{ steps.version.outputs.version }}/checksums.txt
-            sha256sum -c checksums.txt
-            ```
-
-            ## ![Docs](https://img.shields.io/badge/-Documentation-8CA1AF?logo=readthedocs&logoColor=white&style=flat-square)
-
-            - [Installation Guide](https://github.com/Anexgohan/pankha/wiki/Installation)
-            - [Agent Setup Guide](https://github.com/Anexgohan/pankha/wiki/Agent-Setup)
-            - [Configuration](https://github.com/Anexgohan/pankha/wiki/Configuration)
-            - [API Documentation](https://github.com/Anexgohan/pankha/wiki/API-Reference)
-            - [Troubleshooting](https://github.com/Anexgohan/pankha/wiki/Troubleshooting)
-
+            release-assets/*.png
+            release-assets/*.jpg
+            release-assets/*.jpeg
+            release-assets/*.gif
+            release-assets/*.webp
+          body: ${{ needs.compose-notes.outputs.body }}
           draft: false
           prerelease: ${{ steps.version.outputs.is_prerelease == 'true' }}
+
+      # Reset .github/input/release-notes.md to its template and clear images/
+      # so the next release starts from a clean slate. Commit back to main.
+      # (The published GitHub Release page is the canonical archive; git log of
+      # release-notes.md preserves the authored prose per release.)
+      - name: Reset release notes input
+        if: success()
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Switch to latest main for the cleanup commit
+          git fetch origin main
+          git checkout -B main origin/main
+
+          bash .github/scripts/reset-release-notes.sh
+          find .github/input/images -type f ! -name '.gitkeep' -delete 2>/dev/null || true
+
+          git config user.name "Anexgohan"
+          git config user.email "monish05m@gmail.com"
+          git add .github/input/release-notes.md .github/input/images
+          if git diff --cached --quiet; then
+            echo "No release-notes changes to commit"
+          else
+            git commit -m "chore: reset release-notes input after ${VERSION}"
+            git push origin main
+          fi
 
       # Summary
       - name: Release Summary


### PR DESCRIPTION
## What this does

Release pages now generate themselves. Open the next release and you'll see a clean, 
- categorised list of merged PRs grouped by label, 
- plus handwritten highlights at the top, 
- plus the usual install block at the bottom. 
- Less repeating the workflow YAML, more hand written actual notes.

## What you'll actually do for each release

Most of the time: nothing. Tag and push — auto-categorised notes appear.

For bigger releases when you want a headline:

1. Edit `.github/input/release-notes.md` — a small template with sections for highlights, breaking changes, screenshots, notes
2. Drop any screenshots into `.github/input/images/` and reference them as `./images/foo.png`
3. Commit, push, tag

The workflow uploads each screenshot as a release asset, rewrites the URLs so they render forever, publishes the release, and resets the input file so the next release starts clean. No drag-drop into draft
issues, no GitHub UI dance.

## What appears on the release page

[Authored highlights — only if you wrote them]

What's Changed

Features

Bug Fixes

Frontend / Backend / Agent Linux / Windows / etc.   (driven by PR labels, alphabetical)

[Install instructions — Docker, Linux x64, ARM64, Windows MSI, IPMI, checksums]

Full Changelog: v0.4.23...v0.4.24

Stable releases compare against the last stable (skipping all the alphas and betas in between). Pre-releases compare against the previous pre-release. So `v1.0.0` notes summarise everything since `v0.9.0`,
while `v1.0.0-beta3` only shows what's new since `v1.0.0-beta2`.

## Categorisation

Driven entirely by labels already applied by the `pr-labeler` action — no hardcoded label list. Adding a new label later automatically gets its own section without touching the script.

- Top: `breaking-change`, `feature`, `fix`
- Middle: any other label, alphabetical
- Folded into `<details>`: `dependencies` (always), and PRs labelled only with `ci`/`devops`/`chore`

## Side-fixes included

- Windows badge in the install block was rendering as "CPU x64" — fixed to match the Linux pattern
- Cargo dep bumps weren't getting tagged `dependencies` by the labeler — broadened the glob to catch `Cargo.toml`, `Cargo.lock`, and `packages.lock.json`
