### PR TITLE
fix: release-qol-hotfix

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,3 +16,47 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/workflows/configs/labeler.yml
         sync-labels: true # Removes labels if files are removed from PR
+
+    # Apply intent label (feature / fix / breaking-change) from branch name or
+    # PR title prefix. The categoriser in compose-release-notes.sh promotes these
+    # above the area labels (dependencies, ci, devops) and avoids feature PRs
+    # being folded under "Dependencies, CI, and chores".
+    - name: Apply intent label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_REF: ${{ github.head_ref }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        set -eu
+        intent=""
+
+        # 1. Branch-name prefix (primary signal: project convention)
+        case "$HEAD_REF" in
+          feature/*|feat/*)            intent="feature" ;;
+          fix/*|bugfix/*|hotfix/*)     intent="fix" ;;
+          breaking/*|break/*)          intent="breaking-change" ;;
+        esac
+
+        # 2. PR title prefix (fallback: Conventional Commits)
+        if [ -z "$intent" ]; then
+          case "$PR_TITLE" in
+            'feat!:'*|'feat('*')!:'*)  intent="breaking-change" ;;
+            'fix!:'*|'fix('*')!:'*)    intent="breaking-change" ;;
+            'feat:'*|'feat('*'):'*)    intent="feature" ;;
+            'fix:'*|'fix('*'):'*)      intent="fix" ;;
+          esac
+        fi
+
+        # 3. Body trailer override (Conventional Commits BREAKING CHANGE footer)
+        if [ -n "${PR_BODY:-}" ] && printf '%s' "$PR_BODY" | grep -qE '(^|[[:space:]])BREAKING CHANGE:'; then
+          intent="breaking-change"
+        fi
+
+        if [ -n "$intent" ]; then
+          echo "Applying intent label: $intent"
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$intent"
+        else
+          echo "No intent prefix detected on branch ($HEAD_REF) or title ($PR_TITLE); skipping."
+        fi

--- a/frontend/src/deployment/components/DeploySummary.tsx
+++ b/frontend/src/deployment/components/DeploySummary.tsx
@@ -387,10 +387,24 @@ const DeploySummary: React.FC<DeploySummaryProps> = React.memo(({
 
       <section className="deployment-section release-notes-panel">
         <div className="release-notes-header">
-          <span className="release-notes-eyebrow">
-            <FileText size={12} aria-hidden="true" />
-            <span>Release notes</span>
-          </span>
+          <div className="release-notes-header-top">
+            <span className="release-notes-eyebrow">
+              <FileText size={12} aria-hidden="true" />
+              <span>Release notes</span>
+            </span>
+            {releaseTagForLink && (
+              <a
+                className="release-notes-full-link"
+                href={`${githubRepo}/releases/tag/${releaseTagForLink}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`Open ${releaseTagForLink} on GitHub`}
+              >
+                <ExternalLink size={12} aria-hidden="true" />
+                <span>Full changelog</span>
+              </a>
+            )}
+          </div>
           <div className="release-notes-meta">
             <span className={`release-notes-badge release-notes-badge-${channel}`}>
               <Tag size={10} aria-hidden="true" />
@@ -404,18 +418,6 @@ const DeploySummary: React.FC<DeploySummaryProps> = React.memo(({
               </>
             )}
           </div>
-          {releaseTagForLink && (
-            <a
-              className="release-notes-full-link"
-              href={`${githubRepo}/releases/tag/${releaseTagForLink}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`Open ${releaseTagForLink} on GitHub`}
-            >
-              <span>Full changelog</span>
-              <ExternalLink size={12} aria-hidden="true" />
-            </a>
-          )}
         </div>
         <div className="release-notes-body">
           {trimmedBody ? (

--- a/frontend/src/deployment/components/MaintenanceSection.tsx
+++ b/frontend/src/deployment/components/MaintenanceSection.tsx
@@ -59,7 +59,7 @@ const compareSemver = (a: string, b: string): number => {
     const nb = pb[i] || 0;
     if (na !== nb) return na - nb;
   }
-  return parsePreRelease(cleanA) - parsePreRelease(cleanB);
+  return (parsePreRelease(cleanA) - parsePreRelease(cleanB)) || 0;
 };
 
 const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({

--- a/frontend/src/deployment/styles/deployment.css
+++ b/frontend/src/deployment/styles/deployment.css
@@ -2655,11 +2655,15 @@
 
 .release-notes-header {
   display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.release-notes-header-top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-md);
-  flex-wrap: wrap;
-  row-gap: var(--spacing-xs);
 }
 
 .release-notes-eyebrow {
@@ -2683,9 +2687,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-sm);
-  flex: 1;
   min-width: 0;
-  flex-wrap: wrap;
 }
 
 .release-notes-badge {


### PR DESCRIPTION
- Refactor release notes header to use flexbox for better layout and spacing.
- Move "Full changelog" link into the header for improved accessibility and visibility. ci: auto-apply feature/fix/breaking-change intent labels

  Add an "Apply intent label" step to pr-labeler.yml that derives the
  intent label from the branch-name prefix (feature/, fix/, breaking/),
  the PR title (Conventional Commits feat:/fix:/feat!:/fix!:), or a
  BREAKING CHANGE: body trailer.

  Without this, feature PRs that incidentally touched a lockfile were
  auto-tagged 'dependencies' by the area labeler and folded under
  "Dependencies, CI, and chores" by compose-release-notes.sh (e.g. #36
  in v0.5.0). The categoriser already promotes these three intent
  labels above area labels - the labels just weren't being applied.
  
  fix: Adjust release notes header layout and link placement
- Refactor release notes header to use flexbox for better layout and spacing.
- Move "Full changelog" link into the header for improved accessibility and visibility.