### PR TITLE
feat: fan recovery on reconnect & excluding sensors from failsafe calculations

### DIFF
--- a/agents/clients/linux/rust/src/config/setup.rs
+++ b/agents/clients/linux/rust/src/config/setup.rs
@@ -187,6 +187,7 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
             hysteresis_temp: 3.0,
             emergency_temp: 85.0,
             failsafe_speed,
+            excluded_sensors: Vec::new(),
         },
         logging: LoggingSettings {
             enable_file_logging: true,

--- a/agents/clients/linux/rust/src/config/types.rs
+++ b/agents/clients/linux/rust/src/config/types.rs
@@ -36,6 +36,12 @@ pub struct HardwareSettings {
     pub emergency_temp: f64,         // 70-100°C - used for local failsafe mode
     #[serde(default = "default_failsafe_speed")]
     pub failsafe_speed: u8,          // 0-100% - fan speed during failsafe mode
+    // Backend-pushed list of sensor IDs the user has hidden. Honored by the
+    // offline failsafe so hiding a sensor in the UI also excludes it from the
+    // local emergency calc when the backend is unreachable. #[serde(default)]
+    // makes this non-breaking for existing v0.5.2 config.json files.
+    #[serde(default)]
+    pub excluded_sensors: Vec<String>,
 }
 
 pub fn default_failsafe_speed() -> u8 { 70 }
@@ -81,6 +87,7 @@ impl Default for AgentConfig {
                 hysteresis_temp: 3.0,
                 emergency_temp: 85.0,
                 failsafe_speed: 70,
+                excluded_sensors: Vec::new(),
             },
             logging: LoggingSettings {
                 enable_file_logging: true,

--- a/agents/clients/linux/rust/src/websocket/client.rs
+++ b/agents/clients/linux/rust/src/websocket/client.rs
@@ -56,7 +56,7 @@ impl WebSocketClient {
         let failsafe_speed = config.hardware.failsafe_speed;
         drop(config);
 
-        warn!("⚠️ ENTERING FAILSAFE MODE - Backend disconnected");
+        warn!("ENTERING FAILSAFE MODE - Backend disconnected");
         warn!("Setting all fans to {}% (failsafe speed)", failsafe_speed);
 
         // Set all fans to failsafe speed
@@ -101,20 +101,32 @@ impl WebSocketClient {
     }
 
     /// Check emergency temperature while in failsafe mode
-    /// If any sensor >= emergency_temp, set all fans to 100%
+    /// If any sensor >= emergency_temp, set all fans to 100%. Excludes any
+    /// sensor IDs the user has hidden (pushed by the backend, persisted in
+    /// config) so hide selection is honored even when the backend is gone.
     async fn check_emergency_temp(&self) -> Result<()> {
-        let config = self.config.read().await;
-        let emergency_temp = config.hardware.emergency_temp;
-        drop(config);
+        let (emergency_temp, excluded) = {
+            let config = self.config.read().await;
+            (config.hardware.emergency_temp, config.hardware.excluded_sensors.clone())
+        };
 
-        // Read current sensor temps
         let sensors = self.hardware_monitor.discover_sensors().await?;
-        let max_temp = sensors.iter()
+        let excluded_set: std::collections::HashSet<&String> = excluded.iter().collect();
+        let considered: Vec<_> = sensors.iter()
+            .filter(|s| !excluded_set.contains(&s.id))
+            .collect();
+
+        if considered.is_empty() {
+            warn!("All discovered sensors are excluded - failsafe cannot detect emergency. \
+                   Holding failsafe_speed without escalation.");
+            return Ok(());
+        }
+
+        let max_temp = considered.iter()
             .map(|s| s.temperature)
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap_or(0.0);
 
-        // If emergency temp reached, override to 100%
         if max_temp >= emergency_temp {
             warn!("🚨 FAILSAFE EMERGENCY: {:.1}°C >= {:.1}°C threshold - ALL FANS TO 100%",
                   max_temp, emergency_temp);

--- a/agents/clients/linux/rust/src/websocket/commands.rs
+++ b/agents/clients/linux/rust/src/websocket/commands.rs
@@ -150,6 +150,20 @@ impl super::client::WebSocketClient {
                     (false, Some("Missing or invalid name".to_string()), serde_json::json!({}))
                 }
             }
+            "setExcludedSensors" => {
+                if let Some(arr) = payload.get("excludedSensors").and_then(|v| v.as_array()) {
+                    let excluded: Vec<String> = arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    let count = excluded.len();
+                    match self.set_excluded_sensors(excluded).await {
+                        Ok(_) => (true, None, serde_json::json!({"count": count})),
+                        Err(e) => (false, Some(e.to_string()), serde_json::json!({})),
+                    }
+                } else {
+                    (false, Some("Missing or invalid excludedSensors".to_string()), serde_json::json!({}))
+                }
+            }
             "selfUpdate" => {
                 // Extract version from payload for comparison
                 let target_version = payload.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
@@ -253,7 +267,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Fan Step changed → {}%", step);
+        info!("Fan Step changed → {}%", step);
         Ok(())
     }
 
@@ -277,7 +291,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Hysteresis changed → {}°C", hysteresis);
+        info!("Hysteresis changed → {}°C", hysteresis);
         Ok(())
     }
 
@@ -302,7 +316,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Emergency Temp changed → {}°C", temp);
+        info!("Emergency Temp changed → {}°C", temp);
         Ok(())
     }
 
@@ -346,11 +360,11 @@ impl super::client::WebSocketClient {
 
         if let Some(handle) = RELOAD_HANDLE.get() {
             match handle.reload(EnvFilter::new(filter)) {
-                Ok(_) => info!("✏️  Log Level changed: {} → {}", old_level, level.to_uppercase()),
+                Ok(_) => info!("Log Level changed: {} → {}", old_level, level.to_uppercase()),
                 Err(e) => error!("Failed to reload log level filter: {}", e),
             }
         } else {
-            warn!("✏️  Log Level changed: {} → {} (filter reload unavailable)", old_level, level.to_uppercase());
+            warn!("Log Level changed: {} → {} (filter reload unavailable)", old_level, level.to_uppercase());
         }
 
         Ok(())
@@ -378,7 +392,24 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Failsafe Speed changed: {}% → {}%", old_speed, speed);
+        info!("Failsafe Speed changed: {}% → {}%", old_speed, speed);
+        Ok(())
+    }
+
+    pub(crate) async fn set_excluded_sensors(&self, excluded: Vec<String>) -> Result<()> {
+        let count = excluded.len();
+        {
+            let mut config = self.config.write().await;
+            config.hardware.excluded_sensors = excluded;
+        }
+
+        let config_path = std::env::current_exe()?
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine executable directory"))?
+            .join("config.json");
+        save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
+
+        info!("Excluded sensors updated: {} sensor(s)", count);
         Ok(())
     }
 
@@ -401,7 +432,7 @@ impl super::client::WebSocketClient {
 
         let status = if enabled { "enabled" } else { "disabled" };
         let old_status = if old_enabled { "enabled" } else { "disabled" };
-        info!("✏️  Fan Control changed: {} → {}", old_status, status);
+        info!("Fan Control changed: {} → {}", old_status, status);
         Ok(())
     }
 
@@ -431,7 +462,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Agent Name changed: {} → {}", old_name, trimmed_name);
+        info!("Agent Name changed: {} → {}", old_name, trimmed_name);
         Ok(())
     }
 }

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
@@ -185,6 +185,7 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
             hysteresis_temp: 3.0,
             emergency_temp: 85.0,
             failsafe_speed,
+            excluded_sensors: Vec::new(),
         },
         logging: LoggingSettings {
             enable_file_logging: true,

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/types.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/types.rs
@@ -36,6 +36,12 @@ pub struct HardwareSettings {
     pub emergency_temp: f64,         // 70-100°C - used for local failsafe mode
     #[serde(default = "default_failsafe_speed")]
     pub failsafe_speed: u8,          // 0-100% - fan speed during failsafe mode
+    // Backend-pushed list of sensor IDs the user has hidden. Honored by the
+    // offline failsafe so hiding a sensor in the UI also excludes it from the
+    // local emergency calc when the backend is unreachable. #[serde(default)]
+    // makes this non-breaking for existing v0.5.2 config.json files.
+    #[serde(default)]
+    pub excluded_sensors: Vec<String>,
 }
 
 pub fn default_failsafe_speed() -> u8 { 70 }
@@ -95,6 +101,7 @@ impl Default for AgentConfig {
                 hysteresis_temp: 3.0,
                 emergency_temp: 85.0,
                 failsafe_speed: 70,
+                excluded_sensors: Vec::new(),
             },
             logging: LoggingSettings {
                 enable_file_logging: true,

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
@@ -56,7 +56,7 @@ impl WebSocketClient {
         let failsafe_speed = config.hardware.failsafe_speed;
         drop(config);
 
-        warn!("⚠️ ENTERING FAILSAFE MODE - Backend disconnected");
+        warn!("ENTERING FAILSAFE MODE - Backend disconnected");
         warn!("Setting all fans to {}% (failsafe speed)", failsafe_speed);
 
         // Set all fans to failsafe speed
@@ -92,20 +92,32 @@ impl WebSocketClient {
     }
 
     /// Check emergency temperature while in failsafe mode
-    /// If any sensor >= emergency_temp, set all fans to 100%
+    /// If any sensor >= emergency_temp, set all fans to 100%. Excludes any
+    /// sensor IDs the user has hidden (pushed by the backend, persisted in
+    /// config) so hide selection is honored even when the backend is gone.
     async fn check_emergency_temp(&self) -> Result<()> {
-        let config = self.config.read().await;
-        let emergency_temp = config.hardware.emergency_temp;
-        drop(config);
+        let (emergency_temp, excluded) = {
+            let config = self.config.read().await;
+            (config.hardware.emergency_temp, config.hardware.excluded_sensors.clone())
+        };
 
-        // Read current sensor temps
         let sensors = self.hardware_monitor.discover_sensors().await?;
-        let max_temp = sensors.iter()
+        let excluded_set: std::collections::HashSet<&String> = excluded.iter().collect();
+        let considered: Vec<_> = sensors.iter()
+            .filter(|s| !excluded_set.contains(&s.id))
+            .collect();
+
+        if considered.is_empty() {
+            warn!("All discovered sensors are excluded - failsafe cannot detect emergency. \
+                   Holding failsafe_speed without escalation.");
+            return Ok(());
+        }
+
+        let max_temp = considered.iter()
             .map(|s| s.temperature)
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap_or(0.0);
 
-        // If emergency temp reached, override to 100%
         if max_temp >= emergency_temp {
             warn!("🚨 FAILSAFE EMERGENCY: {:.1}°C >= {:.1}°C threshold - ALL FANS TO 100%",
                   max_temp, emergency_temp);

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/commands.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/commands.rs
@@ -151,6 +151,20 @@ impl super::client::WebSocketClient {
                     (false, Some("Missing or invalid name".to_string()), serde_json::json!({}))
                 }
             }
+            "setExcludedSensors" => {
+                if let Some(arr) = payload.get("excludedSensors").and_then(|v| v.as_array()) {
+                    let excluded: Vec<String> = arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    let count = excluded.len();
+                    match self.set_excluded_sensors(excluded).await {
+                        Ok(_) => (true, None, serde_json::json!({"count": count})),
+                        Err(e) => (false, Some(e.to_string()), serde_json::json!({})),
+                    }
+                } else {
+                    (false, Some("Missing or invalid excludedSensors".to_string()), serde_json::json!({}))
+                }
+            }
             "selfUpdate" => {
                 // Extract version from payload for comparison
                 let target_version = payload.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
@@ -323,7 +337,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Fan Step changed → {}%", step);
+        info!("Fan Step changed → {}%", step);
         Ok(())
     }
 
@@ -347,7 +361,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Hysteresis changed → {}°C", hysteresis);
+        info!("Hysteresis changed → {}°C", hysteresis);
         Ok(())
     }
 
@@ -372,7 +386,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Emergency Temp changed → {}°C", temp);
+        info!("Emergency Temp changed → {}°C", temp);
         Ok(())
     }
 
@@ -416,11 +430,11 @@ impl super::client::WebSocketClient {
 
         if let Some(handle) = RELOAD_HANDLE.get() {
             match handle.reload(EnvFilter::new(filter)) {
-                Ok(_) => info!("✏️  Log Level changed: {} → {}", old_level, level.to_uppercase()),
+                Ok(_) => info!("Log Level changed: {} → {}", old_level, level.to_uppercase()),
                 Err(e) => error!("Failed to reload log level filter: {}", e),
             }
         } else {
-            warn!("✏️  Log Level changed: {} → {} (filter reload unavailable)", old_level, level.to_uppercase());
+            warn!("Log Level changed: {} → {} (filter reload unavailable)", old_level, level.to_uppercase());
         }
 
         Ok(())
@@ -448,7 +462,24 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Failsafe Speed changed: {}% → {}%", old_speed, speed);
+        info!("Failsafe Speed changed: {}% → {}%", old_speed, speed);
+        Ok(())
+    }
+
+    pub(crate) async fn set_excluded_sensors(&self, excluded: Vec<String>) -> Result<()> {
+        let count = excluded.len();
+        {
+            let mut config = self.config.write().await;
+            config.hardware.excluded_sensors = excluded;
+        }
+
+        let config_path = std::env::current_exe()?
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine executable directory"))?
+            .join("config.json");
+        save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
+
+        info!("Excluded sensors updated: {} sensor(s)", count);
         Ok(())
     }
 
@@ -471,7 +502,7 @@ impl super::client::WebSocketClient {
 
         let status = if enabled { "enabled" } else { "disabled" };
         let old_status = if old_enabled { "enabled" } else { "disabled" };
-        info!("✏️  Fan Control changed: {} → {}", old_status, status);
+        info!("Fan Control changed: {} → {}", old_status, status);
         Ok(())
     }
 
@@ -501,7 +532,7 @@ impl super::client::WebSocketClient {
 
         save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
 
-        info!("✏️  Agent Name changed: {} → {}", old_name, trimmed_name);
+        info!("Agent Name changed: {} → {}", old_name, trimmed_name);
         Ok(())
     }
 }

--- a/agents/clients/windows/varient-c/Core/CommandHandler.cs
+++ b/agents/clients/windows/varient-c/Core/CommandHandler.cs
@@ -68,6 +68,9 @@ public class CommandHandler
                 case "setAgentName":
                     return await HandleSetAgentNameAsync(commandId, payload);
 
+                case "setExcludedSensors":
+                    return HandleSetExcludedSensorsAsync(commandId, payload);
+
                 case "ping":
                     return CreateSuccessResponse(commandId, new { pong = true });
 
@@ -127,7 +130,7 @@ public class CommandHandler
         _config.Agent.UpdateInterval = interval;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Update Interval changed: {Old}s → {New}s", oldInterval, interval);
+        _logger.Information("Update Interval changed: {Old}s → {New}s", oldInterval, interval);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { interval }));
     }
@@ -146,7 +149,7 @@ public class CommandHandler
         _config.Hardware.FanStepPercent = step;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Fan Step changed: {Old}% → {New}%", oldStep, step);
+        _logger.Information("Fan Step changed: {Old}% → {New}%", oldStep, step);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { step }));
     }
@@ -165,7 +168,7 @@ public class CommandHandler
         _config.Hardware.HysteresisTemp = hysteresis;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Hysteresis changed: {Old}°C → {New}°C", oldHysteresis, hysteresis);
+        _logger.Information("Hysteresis changed: {Old}°C → {New}°C", oldHysteresis, hysteresis);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { hysteresis }));
     }
@@ -184,7 +187,7 @@ public class CommandHandler
         _config.Hardware.EmergencyTemp = temp;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Emergency Temp changed: {Old}°C → {New}°C", oldTemp, temp);
+        _logger.Information("Emergency Temp changed: {Old}°C → {New}°C", oldTemp, temp);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { temp = temp }));
     }
@@ -220,7 +223,7 @@ public class CommandHandler
         // Update the global LoggingLevelSwitch - this dynamically changes ALL loggers
         Pankha.WindowsAgent.Program.LogLevelSwitch.MinimumLevel = serilogLevel;
 
-        _logger.Information("✏️ Log Level changed: {Old} → {New}", oldLevel, upperLevel);
+        _logger.Information("Log Level changed: {Old} → {New}", oldLevel, upperLevel);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { level = upperLevel }));
     }
@@ -239,7 +242,7 @@ public class CommandHandler
         _config.Hardware.FailsafeSpeed = speed;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Failsafe Speed changed: {Old}% → {New}%", oldSpeed, speed);
+        _logger.Information("Failsafe Speed changed: {Old}% → {New}%", oldSpeed, speed);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { speed }));
     }
@@ -254,7 +257,7 @@ public class CommandHandler
 
         var status = enabled ? "enabled" : "disabled";
         var oldStatus = oldEnabled ? "enabled" : "disabled";
-        _logger.Information("✏️ Fan Control changed: {Old} → {New}", oldStatus, status);
+        _logger.Information("Fan Control changed: {Old} → {New}", oldStatus, status);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { enabled }));
     }
@@ -280,9 +283,23 @@ public class CommandHandler
         _config.Agent.Name = trimmedName;
         _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
 
-        _logger.Information("✏️ Agent Name changed: {Old} → {New}", oldName, trimmedName);
+        _logger.Information("Agent Name changed: {Old} → {New}", oldName, trimmedName);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { name = trimmedName }));
+    }
+
+    private CommandResponse HandleSetExcludedSensorsAsync(string commandId, Dictionary<string, object> payload)
+    {
+        // List of sensor IDs the user has hidden in the UI. We persist it so
+        // the offline failsafe (GetMaxTemperatureAsync) honors hidden even
+        // when the backend is unreachable.
+        var excluded = GetPayloadValue<List<string>>(payload, "excludedSensors") ?? new List<string>();
+        _config.Hardware.ExcludedSensors = excluded;
+        _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
+
+        _logger.Information("Excluded sensors updated: {Count} sensor(s)", excluded.Count);
+
+        return CreateSuccessResponse(commandId, new { count = excluded.Count });
     }
 
     private async Task<CommandResponse> HandleGetDiagnosticsAsync(string commandId)

--- a/agents/clients/windows/varient-c/Hardware/LibreHardwareAdapter.cs
+++ b/agents/clients/windows/varient-c/Hardware/LibreHardwareAdapter.cs
@@ -166,6 +166,9 @@ public class LibreHardwareAdapter : IHardwareMonitor
             if (!sensor.Value.HasValue)
                 continue;
 
+            if (IsThresholdPseudoSensor(sensor.Name))
+                continue;
+
             var sensorModel = new Sensor
             {
                 Id = GenerateSensorId(hardware, sensor),
@@ -190,6 +193,17 @@ public class LibreHardwareAdapter : IHardwareMonitor
             sensorModel.UpdateStatus();
             sensors.Add(sensorModel);
         }
+    }
+
+    // LibreHardwareMonitor exposes device spec thresholds (NVMe WCTEMP/CCTEMP,
+    // GPU shutdown limits, etc.) as Temperature sensors. They are constants, not
+    // readings, and tripped a false 109C emergency on a real machine.
+    private static bool IsThresholdPseudoSensor(string sensorName)
+    {
+        if (string.IsNullOrEmpty(sensorName)) return false;
+        var n = sensorName.ToLowerInvariant();
+        return n.Contains("warning") || n.Contains("critical")
+            || n.Contains("limit") || n.Contains("throttle");
     }
 
     private string GenerateSensorId(IHardware hardware, ISensor sensor)
@@ -680,7 +694,7 @@ public class LibreHardwareAdapter : IHardwareMonitor
     public async Task EnterFailsafeModeAsync()
     {
         var failsafeSpeed = _settings.FailsafeSpeed;
-        _logger.Warning("⚠️ ENTERING FAILSAFE MODE - Backend disconnected");
+        _logger.Warning("ENTERING FAILSAFE MODE - Backend disconnected");
 
         var tasks = new List<Task>();
 
@@ -728,17 +742,30 @@ public class LibreHardwareAdapter : IHardwareMonitor
     }
 
     /// <summary>
-    /// Get the maximum temperature across all sensors
-    /// Used by ConnectionWatchdog for emergency temperature detection during failsafe mode
+    /// Max sensor temperature for the emergency_temp check that runs during
+    /// failsafe mode. Filters user-hidden sensors so hide is honored offline.
+    /// Single caller: ConnectionWatchdog. Not a general-purpose max getter.
     /// </summary>
     public async Task<double> GetMaxTemperatureAsync()
     {
-        // NOTE: Sensors are discovered fresh each call, no cache needed
         var sensors = await DiscoverSensorsAsync();
-        
         if (!sensors.Any())
             return 0.0;
-        
+
+        var excluded = _settings.ExcludedSensors;
+        if (excluded != null && excluded.Count > 0)
+        {
+            var excludedSet = new HashSet<string>(excluded, StringComparer.OrdinalIgnoreCase);
+            var filtered = sensors.Where(s => !excludedSet.Contains(s.Id)).ToList();
+            if (filtered.Count == 0)
+            {
+                _logger.Warning("All discovered sensors are excluded - failsafe cannot detect emergency. " +
+                                "Holding failsafe_speed without escalation.");
+                return 0.0;
+            }
+            return filtered.Max(s => s.Temperature);
+        }
+
         return sensors.Max(s => s.Temperature);
     }
 

--- a/agents/clients/windows/varient-c/Models/Configuration/HardwareSettings.cs
+++ b/agents/clients/windows/varient-c/Models/Configuration/HardwareSettings.cs
@@ -26,6 +26,12 @@ public class HardwareSettings
     [JsonProperty("emergency_temp")]
     public double EmergencyTemp { get; set; } = 85.0; // Celsius
 
+    // Backend-pushed list of sensor IDs the user has hidden. Honored by the
+    // offline failsafe so hiding a sensor in the UI also excludes it from the
+    // local emergency calc when the backend is unreachable.
+    [JsonProperty("excluded_sensors")]
+    public List<string> ExcludedSensors { get; set; } = new();
+
     public void Validate()
     {
         if (FailsafeSpeed < 0 || FailsafeSpeed > 100)

--- a/backend/src/routes/systems.ts
+++ b/backend/src/routes/systems.ts
@@ -1610,9 +1610,10 @@ router.put(
       }
 
       // Verify system exists
-      const system = await db.get("SELECT id FROM systems WHERE id = $1", [
-        systemId,
-      ]);
+      const system = await db.get(
+        "SELECT id, agent_id FROM systems WHERE id = $1",
+        [systemId]
+      );
       if (!system) {
         return res.status(404).json({ error: "System not found" });
       }
@@ -1627,6 +1628,10 @@ router.put(
         `Sensor ${sensorId} visibility updated: is_hidden=${is_hidden}`,
         "systems"
       );
+
+      if (system.agent_id) {
+        commandDispatcher.syncExcludedSensors(system.agent_id);
+      }
 
       res.json({
         message: "Sensor visibility updated successfully",
@@ -1654,9 +1659,10 @@ router.put(
       }
 
       // Verify system exists
-      const system = await db.get("SELECT id FROM systems WHERE id = $1", [
-        systemId,
-      ]);
+      const system = await db.get(
+        "SELECT id, agent_id FROM systems WHERE id = $1",
+        [systemId]
+      );
       if (!system) {
         return res.status(404).json({ error: "System not found" });
       }
@@ -1674,6 +1680,10 @@ router.put(
         `Sensor group ${groupName} visibility updated: is_hidden=${is_hidden}`,
         "systems"
       );
+
+      if (system.agent_id) {
+        commandDispatcher.syncExcludedSensors(system.agent_id);
+      }
 
       res.json({
         message: "Sensor group visibility updated successfully",

--- a/backend/src/services/AgentManager.ts
+++ b/backend/src/services/AgentManager.ts
@@ -328,7 +328,7 @@ export class AgentManager extends EventEmitter {
       }
     } else {
       log.info(
-        `⚠️  Agent status not found in memory for ${agentId}, skipping status update`,
+        `Agent (${agentId}) status not found in memory, skipping status update`,
         "AgentManager"
       );
       log.info(
@@ -469,7 +469,7 @@ export class AgentManager extends EventEmitter {
         await this.persistSystemPresence(agentId, "offline");
 
         log.info(
-          `⚠️  Agent ${agentId} marked as offline (last seen: ${status.lastSeen.toISOString()})`,
+          `Agent (${agentId}) marked as offline (last seen: ${status.lastSeen.toISOString()})`,
           "AgentManager"
         );
         this.emit("agentOffline", { agentId, status });

--- a/backend/src/services/CommandDispatcher.ts
+++ b/backend/src/services/CommandDispatcher.ts
@@ -4,6 +4,7 @@ import Database from "../database/database";
 import { FanControlCommand } from "../types/agent";
 import { AgentManager } from "./AgentManager";
 import { log } from "../utils/logger";
+import { deriveChipName } from "../utils/sensorUtils";
 import {
   validFanSteps,
   validHysteresis,
@@ -144,7 +145,7 @@ export class CommandDispatcher extends EventEmitter {
 
     if (safeSpeed !== speed) {
       log.warn(
-        `⚠️  Fan speed adjusted for safety: ${speed}% -> ${safeSpeed}% for fan ${fanId}`,
+        `Fan speed adjusted for safety: ${speed}% -> ${safeSpeed}% for fan ${fanId}`,
         "CommandDispatcher"
       );
     }
@@ -316,6 +317,74 @@ export class CommandDispatcher extends EventEmitter {
       { enabled },
       priority
     );
+  }
+
+  /**
+   * Build the effective hidden-sensor ID list for a system (sensor.is_hidden OR
+   * its chip group hidden). Mirrors DataAggregator.enrichAggregatedData.
+   */
+  private async getExcludedSensorsForAgent(agentId: string): Promise<string[]> {
+    const system = await this.db.get(
+      "SELECT id FROM systems WHERE agent_id = $1",
+      [agentId]
+    );
+    if (!system) return [];
+
+    const systemId = system.id;
+
+    const directRows = await this.db.all(
+      "SELECT sensor_name FROM sensors WHERE system_id = $1 AND is_hidden = true",
+      [systemId]
+    );
+    const excluded = new Set<string>(directRows.map((r: any) => r.sensor_name));
+
+    const hiddenGroups = await this.db.all(
+      "SELECT group_name FROM sensor_group_visibility WHERE system_id = $1 AND is_hidden = true",
+      [systemId]
+    );
+    if (hiddenGroups.length > 0) {
+      const hiddenGroupNames = new Set(hiddenGroups.map((g: any) => g.group_name));
+      const allSensors = await this.db.all(
+        "SELECT sensor_name FROM sensors WHERE system_id = $1",
+        [systemId]
+      );
+      for (const s of allSensors) {
+        if (hiddenGroupNames.has(deriveChipName(s.sensor_name))) {
+          excluded.add(s.sensor_name);
+        }
+      }
+    }
+
+    return Array.from(excluded);
+  }
+
+  /**
+   * Push the effective excluded-sensor list to an agent. The agent persists it
+   * to config.json and honors it in its offline failsafe max-temp calc, so a
+   * user-hidden sensor stays hidden even when the backend is unreachable.
+   * `sendCommand` already logs rejections internally, so the catch is silent
+   * here to avoid duplicate noise from pre-feature agents that don't know
+   * the command yet.
+   */
+  public async syncExcludedSensors(agentId: string): Promise<void> {
+    try {
+      const excludedSensors = await this.getExcludedSensorsForAgent(agentId);
+      log.debug(
+        `Syncing excluded sensors to agent ${agentId}: ${excludedSensors.length} sensor(s)`,
+        "CommandDispatcher"
+      );
+      await this.sendCommand(
+        agentId,
+        "setExcludedSensors",
+        { excludedSensors },
+        "normal"
+      ).catch(() => { /* logged by sendCommand */ });
+    } catch (error) {
+      log.warn(
+        `Failed to sync excluded sensors for ${agentId}: ${error instanceof Error ? error.message : String(error)}`,
+        "CommandDispatcher"
+      );
+    }
   }
 
   /**
@@ -578,6 +647,7 @@ export class CommandDispatcher extends EventEmitter {
       await this.logCommand(command, "sent");
     } catch (error) {
       log.error(`Failed to execute command`, "CommandDispatcher", {
+        agentId: command.agentId,
         commandId: command.commandId,
         commandType: command.type,
         error,
@@ -736,7 +806,7 @@ export class CommandDispatcher extends EventEmitter {
       });
     } else {
       log.error(
-        ` Command failed: ${pendingCommand.command.type} (${commandId}) - ${response.error}`,
+        `Agent (${pendingCommand.command.agentId}) command failed: ${pendingCommand.command.type} (${commandId}) - ${response.error}`,
         "CommandDispatcher"
       );
       pendingCommand.reject(new Error(response.error));
@@ -758,7 +828,7 @@ export class CommandDispatcher extends EventEmitter {
       // Retry command
       pendingCommand.retries++;
       log.warn(
-        `⏰ Command timeout, retrying (${pendingCommand.retries}/${this.maxRetries}): ${commandId}`,
+        `Agent (${pendingCommand.command.agentId}) command timeout, retrying (${pendingCommand.retries}/${this.maxRetries}): ${pendingCommand.command.type} (${commandId})`,
         "CommandDispatcher"
       );
 
@@ -771,7 +841,7 @@ export class CommandDispatcher extends EventEmitter {
     } else {
       // Max retries reached
       log.error(
-        ` Command timeout after ${this.maxRetries} retries: ${commandId}`,
+        `Agent (${pendingCommand.command.agentId}) command timeout after ${this.maxRetries} retries: ${pendingCommand.command.type} (${commandId})`,
         "CommandDispatcher"
       );
       this.pendingCommands.delete(commandId);

--- a/backend/src/services/FanProfileController.ts
+++ b/backend/src/services/FanProfileController.ts
@@ -307,20 +307,27 @@ export class FanProfileController {
       this.emergencyState.set(fanKey, false);
     }
 
-    // Get current state
-    const currentSpeed = this.lastAppliedSpeeds.get(fanKey) || 0;
-    const lastTemp = this.lastSignificantTemp.get(fanKey);
-
-    // Initialize if first run
-    if (currentSpeed === 0 && lastTemp === undefined) {
-      this.lastAppliedSpeeds.set(fanKey, targetSpeed);
+    // Get current state. On first loop / after reconnect we have no internal
+    // record, so seed from the agent's reported actual speed instead of 0 - a
+    // diverged fan (e.g. left at 100% by failsafe) is then stepped back down.
+    // A correct fan reports == target and the "already at target" branch below
+    // short-circuits without disturbing it.
+    const hasRecord = this.lastAppliedSpeeds.has(fanKey);
+    let currentSpeed: number;
+    if (hasRecord) {
+      currentSpeed = this.lastAppliedSpeeds.get(fanKey)!;
+    } else {
+      // For OS agents, fanName is the per-fan id. For IPMI agents, fanName is
+      // the zone_id; fans expose their parent zone via the `zone` field, and
+      // every fan in a zone shares the same Tier-3 speed, so picking any one
+      // gives the right value.
+      const systemData = this.dataAggregator.getSystemData(agentId);
+      const reportedFan =
+        systemData?.fans?.find(f => f.id === fanName) ??
+        systemData?.fans?.find(f => f.zone === fanName);
+      currentSpeed = reportedFan?.speed ?? 0;
+      this.lastAppliedSpeeds.set(fanKey, currentSpeed);
       this.lastSpeedChangeTime.set(fanKey, Date.now());
-      await this.sendFanSpeedCommand(agentId, fanName, targetSpeed);
-      log.debug(
-        `Fan ${fanName} initialized: temp=${currentTemp.toFixed(1)}°C, speed=${targetSpeed}%`,
-        'FanProfileController'
-      );
-      return;
     }
 
     // Note: Hysteresis is now handled in control loop before calling this method

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -172,7 +172,7 @@ export class WebSocketHub extends EventEmitter {
     // This ensures the first update after reconnection sends full state with all enriched data
     this.agentCommunication.on("agentDisconnected", (agentId: string) => {
       log.info(
-        `🔄 Agent disconnected, clearing delta state for: ${agentId}`,
+        `Agent disconnected, clearing delta state for: ${agentId}`,
         "WebSocketHub"
       );
       this.deltaComputer.clearAgentState(agentId);
@@ -318,7 +318,7 @@ export class WebSocketHub extends EventEmitter {
       if (client.metadata.isAgent && client.metadata.agentId) {
         const agentId = client.metadata.agentId;
         log.info(
-          `🔌 Agent disconnected via WebSocket: ${agentId} (${clientId})`,
+          `Agent disconnected via WebSocket: ${agentId} (${clientId})`,
           "WebSocketHub"
         );
 
@@ -800,6 +800,14 @@ export class WebSocketHub extends EventEmitter {
             }, 2000);
           }
         }
+
+        // Sync excluded-sensor list to agent so its offline failsafe respects
+        // the user's hide selection. Sent after registered confirmation so the
+        // agent has finished applying initial config first. Same 2000ms delay
+        // as the reloadProfile sync above for consistency.
+        setTimeout(() => {
+          this.commandDispatcher.syncExcludedSensors(agentId);
+        }, 2000);
 
         // Notify other clients about new agent
         this.broadcast("agentRegistered", agentConfig, ["agents:all"]);

--- a/backend/src/types/agent.ts
+++ b/backend/src/types/agent.ts
@@ -100,7 +100,8 @@ export interface FanControlCommand {
     | "selfUpdate"
     | "getDiagnostics"
     | "executeRawIpmi"
-    | "reloadProfile";
+    | "reloadProfile"
+    | "setExcludedSensors";
   payload: {
     fanId?: string;
     speed?: number;
@@ -121,6 +122,7 @@ export interface FanControlCommand {
     name?: string; // For setAgentName command
     version?: string | null; // For selfUpdate command (hub version, e.g., "v0.3.2")
     bytes?: string; // For executeRawIpmi command (hex bytes like "0x30 0x70 0x66")
+    excludedSensors?: string[]; // For setExcludedSensors command - sensor IDs to skip in failsafe
   };
   timestamp: number;
   priority: "low" | "normal" | "high" | "emergency";

--- a/frontend/src/systems/components/SensorItem.tsx
+++ b/frontend/src/systems/components/SensorItem.tsx
@@ -43,7 +43,7 @@ const SensorItem: React.FC<SensorItemProps> = ({
         <button
           className="rack-visibility"
           onClick={() => onToggleVisibility(sensor.id, sensor.dbId)}
-          title={isHidden ? "Show sensor" : "Hide sensor"}
+          title={isHidden ? "Show sensor" : "Hide sensor, Disables from Usage and Calculations"}
           aria-label={isHidden ? "Show sensor" : "Hide sensor"}
         >
           {/* {isHidden ? "🚫" : "🟢"} */}


### PR DESCRIPTION
- Introduced `excluded_sensors` field in HardwareSettings to store hidden sensor IDs.
- Updated setup wizards and configuration files to initialize excluded sensors.
- Implemented `setExcludedSensors` command to allow dynamic updates of excluded sensors.
- Enhanced emergency temperature checks to respect excluded sensors during failsafe mode.
- Updated logging to remove unnecessary emojis for consistency.

## Summary
  - **Windows agent:** Filters LibreHardwareMonitor threshold pseudo-sensors (`Warning Temperature`, `Critical Temperature`, etc.) from telemetry so device-spec constants no longer enter sensor calculations.  Linux agents are structurally immune.
  - **Backend:** `FanProfileController` now seeds `currentSpeed` from the agent's reported actual fan speed on first loop after reconnect (with an IPMI zone fallback), instead of defaulting to 0. Fixes fans  staying stuck at a non-zero speed after disconnect/reconnect cycles.
  - **All agents + backend:** New `setExcludedSensors` command propagates the user's hidden-sensor selection to the agent. Agents persist the list to `config.json` and skip those IDs in their offline emergency  check, so hiding a sensor honors user intent even when the backend is unreachable.
  - **Frontend:** Hide-sensor tooltip states the actual effect in plain words.
  - **Logging:** `CommandDispatcher` and `AgentManager` lines standardized to `Agent (<id>) <event>`. Emojis removed from emitted log lines.

  ## Non-breaking

  - Rust agents use `#[serde(default)]` on the new `excluded_sensors` field, so existing `config.json` files load unchanged.
  - WebSocket protocol: pre-feature agents reply "Unknown command" and the backend swallows the rejection silently.
  - No DB schema change. The push reuses existing `sensors.is_hidden` and `sensor_group_visibility.is_hidden`.