### PR TITLE
fix: improve fan speed deduplication logic and verify state and apply correction case study raspberry pi 5 RPi5

### DIFF
--- a/agents/clients/linux/rust/src/hardware/linux/monitor.rs
+++ b/agents/clients/linux/rust/src/hardware/linux/monitor.rs
@@ -354,11 +354,15 @@ impl HardwareMonitor for LinuxHardwareMonitor {
         let fan_info = fan_map.get(fan_id)
             .ok_or_else(|| anyhow::anyhow!("Fan not found: {}", fan_id))?;
 
-        // DEDUPLICATION: Check if value unchanged
+        // DEDUPLICATION: skip only if the ACTUAL hardware pwm matches. Comparing
+        // against our last *intended* write would wrongly skip a re-assert when
+        // an external controller (see cooling-device note below) moved the pin.
+        // Reading it back makes the agent self-correcting; on read error, write.
         {
-            let last_value = fan_info.last_pwm_value.read().await;
-            if *last_value == Some(pwm_value) {
-                debug!("Fan {} already at PWM {}, skipping write", fan_id, pwm_value);
+            let actual = self.read_file(&fan_info.pwm_path).await.ok()
+                .and_then(|s| s.parse::<u8>().ok());
+            if actual == Some(pwm_value) {
+                debug!("Fan {} already at PWM {} (hardware), skipping write", fan_id, pwm_value);
                 return Ok(());
             }
         }
@@ -376,6 +380,11 @@ impl HardwareMonitor for LinuxHardwareMonitor {
             *last_time = now;
         }
 
+        // NOTE: on some systems (e.g. RPi5) this PWM is also a kernel thermal
+        // cooling device; its governor writes the same register on temp-trip
+        // crossings and overrides us (symptom: fan won't hold high / "snaps back"
+        // near 100%). pwm_enable=1 (manual) does NOT prevent it. x86 Super I/O
+        // fans aren't cooling devices, so this doesn't occur there.
         // Enable manual PWM mode if needed (with deduplication)
         if let Some(enable_path) = &fan_info.pwm_enable_path {
             let current_enable = self.read_file(enable_path).await.ok();

--- a/agents/clients/windows/varient-c/Hardware/LibreHardwareAdapter.cs
+++ b/agents/clients/windows/varient-c/Hardware/LibreHardwareAdapter.cs
@@ -592,8 +592,10 @@ public class LibreHardwareAdapter : IHardwareMonitor
             return;
         }
 
-        // Deduplication: skip if same value
-        if (fan.LastPwmValue == speed)
+        // Deduplication: compare against ACTUAL speed (fan.Speed, refreshed each
+        // update), NOT our last command - so an external mover (EC, GPU auto-curve)
+        // doesn't get a re-assert wrongly skipped.
+        if (fan.Speed == speed)
         {
             _logger.Debug("Skipping duplicate fan speed for {FanId} (already {Speed}%)", fanId, speed);
             return;

--- a/backend/src/services/FanProfileController.ts
+++ b/backend/src/services/FanProfileController.ts
@@ -26,6 +26,10 @@ interface CurvePoint {
   fan_speed: number;
 }
 
+// Re-assert tolerance (% points of duty). Ignore gaps this small (pwm<->percent
+// rounding + noise); real external-controller drags are far larger.
+const REASSERT_TOLERANCE_PERCENT = 5;
+
 /**
  * Fan Profile Controller
  *
@@ -345,8 +349,16 @@ export class FanProfileController {
       // Need to decrease speed
       nextSpeed = Math.max(currentSpeed - fanStep, targetSpeed);
     } else {
-      // Already at target
-      return;
+      // At target: re-assert only if the reported ACTUAL speed diverged past
+      // tolerance - catches an external controller (e.g. RPi kernel thermal
+      // governor) moving the fan out from under us. See REASSERT_TOLERANCE_PERCENT.
+      const reported = this.dataAggregator.getSystemData(agentId)?.fans
+        ?.find(f => f.id === fanName || f.zone === fanName)?.speed;
+      if (reported === undefined ||
+          Math.abs(reported - targetSpeed) <= REASSERT_TOLERANCE_PERCENT) {
+        return; // in sync (or no telemetry yet) - nothing to do
+      }
+      nextSpeed = targetSpeed; // diverged - re-send the held target (no re-step)
     }
 
     // Apply the speed change


### PR DESCRIPTION
## Problem

Fan speed commands did not reliably hold. The visible case: setting a high speed (e.g. profile `test-100`) on a Raspberry Pi 5 dropped to ~29% as it
approached 100% and stayed there. More generally, anything that writes the fan PWM besides Pankha could move the fan and we would never correct it.

## Root cause

Two gaps left the fan wherever an external controller put it:
- The backend went silent once it believed the fan was at target, so it never re-asserted after an override.
- Agents deduplicated against their last *intended* write, so a re-sent command was skipped even though the hardware had been moved.

The RPi5 case makes this concrete: its fan PWM is registered as a kernel thermal cooling device bound to `cpu-thermal` under the `step_wise` governor,
which rewrites the same PWM register on temperature trip crossings and overrides the agent in both directions. `pwm_enable=1` (manual mode) does not
stop it. Confirmed independently of Pankha via kernel ftrace (`thermal:cdev_update`) with the agent stopped: a manually written 255 was stepped down 255 -> 175 -> 125 -> 75 by the governor.

The same blind spot covers other external movers (EC, GPU auto-curve, a write that silently did not take, post-reconnect drift). This is not RPi-only; the
governor is just where it surfaced. On x86, fans are Super I/O hwmon PWMs that are not cooling devices, so the governor cools via CPU throttling and never touches the fan.

## Fix

A general "keep reported actual matching intent" reconciliation, with the logic in the backend and the agents kept as faithful executors:

- **Backend (`FanProfileController`)**: in the at-target branch, re-send the target when the agent-reported actual speed diverges by more than   `REASSERT_TOLERANCE_PERCENT` (5% of duty). Snaps back to target without re-stepping. Ramp / emergency / failsafe unchanged.
- **Linux agent (`monitor.rs`)**: deduplicate against the actual PWM read-back, not the cached intent.
- **Windows agent (`LibreHardwareAdapter.cs`)**: deduplicate against actual `fan.Speed`, not `LastPwmValue` (covers EC / GPU auto-curve reverts).

Where a kernel thermal governor co-owns the PWM, it stays armed; we cooperate by reassertion rather than disabling vendor thermal safety.

## Scope / safety

- No extra command traffic at steady state (only re-sends on real divergence),   so it is safe at fleet scale.
- Self-silences for IPMI agents (they report commanded, not actual, speed).
- Boundary: converges the PWM setpoint (what agents report as speed); does not detect a physically stuck fan that is correctly commanded (RPM health is a   separate concern).