### PR TITLE
feat: implement autonomous license sync and update related component for real-time license status

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -115,6 +115,10 @@ async function initializeServices() {
     // Initialize license manager
     await licenseManager.initialize();
 
+    // Start the autonomous license sync loop so renewed tokens in D1 are pulled
+    // without an open browser, a manual Refresh, or a container restart.
+    licenseManager.startAutoSync();
+
     // Initialize WebSocket server (attached to HTTP server at /websocket)
     // server instance will be provided in startServer()
 
@@ -300,6 +304,7 @@ process.on('SIGINT', async () => {
     try {
       services.fanProfileController.stop(); // Stop fan controller first
       services.downsamplingService.stop(); // Stop downsampling scheduler
+      licenseManager.stopAutoSync(); // Stop background license sync loop
       services.commandDispatcher.cleanup();
       services.dataAggregator.cleanup();
       services.agentManager.cleanup();

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -8,13 +8,14 @@
  * - Convenience methods for checking tier limits
  */
 
-import { LicenseValidator, ValidationResult } from './LicenseValidator';
+import { LicenseValidator, ValidationResult, GRACE_PERIOD_SECONDS } from './LicenseValidator';
 import { TIERS, TierConfig, getTier } from './tiers';
 import { LICENSE_API_URL } from './license-config';
 import Database from '../database/database';
 import { log } from '../utils/logger';
+import { EventEmitter } from 'events';
 
-export class LicenseManager {
+export class LicenseManager extends EventEmitter {
   private validator: LicenseValidator;
   private cachedTier: TierConfig;
   private cacheExpiry: Date;
@@ -24,18 +25,24 @@ export class LicenseManager {
   private customerName: string | null = null;
   private customerEmail: string | null = null;
   private licenseId: string | null = null;  // License ID for /status lookups
-  private subscriptionId: string | null = null;  // From JWT `sid` claim — Dodo subscription identifier (subscriptions only)
+  private subscriptionId: string | null = null;  // From JWT `sid` claim - Dodo subscription identifier (subscriptions only)
   private customerId: string | null = null;  // Dodo persistent customer identifier (from /status sync)
-  private licenseKey: string | null = null;  // Raw JWT token — exposed read-only via getLicenseInfo for user copy/backup
+  private licenseKey: string | null = null;  // Raw JWT token - exposed read-only via getLicenseInfo for user copy/backup
   private nextBillingDate: Date | null = null;  // Next payment date (subscriptions)
   private discountCode: string | null = null;  // Applied promo code
   private discountCyclesRemaining: number | null = null;  // Remaining discounted renewals
-  private periodInterval: string | null = null;  // From JWT period_interval claim — billing cadence display ("Day"|"Week"|"Month"|"Year")
-  private periodCount: number | null = null;     // From JWT period_count claim — e.g. 1, 7
+  private periodInterval: string | null = null;  // From JWT period_interval claim - billing cadence display ("Day"|"Week"|"Month"|"Year")
+  private periodCount: number | null = null;     // From JWT period_count claim - e.g. 1, 7
   private lastSyncAt: Date | null = null;  // Last successful sync with license server
   private readonly CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+  // Autonomous background sync loop (self-rescheduling; see startAutoSync)
+  private autoSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  private autoSyncInProgress = false;        // guards against overlapping ticks
+  private autoSyncStopped = true;            // false only while the loop is running
+  private readonly AUTO_SYNC_IDLE_INTERVAL_MS = 6 * 60 * 60 * 1000; // re-check cadence when no paid token / expiry unknown
 
   constructor() {
+    super();
     this.validator = new LicenseValidator();
     this.cachedTier = TIERS.free;
     this.cacheExpiry = new Date(0); // Expired by default
@@ -50,7 +57,7 @@ export class LicenseManager {
 
   /**
    * Whether we have a stored token from a paid (non-lifetime) purchase.
-   * Drives sync eligibility independently of the current cached tier — so
+   * Drives sync eligibility independently of the current cached tier - so
    * a token that expired past grace can still recover via /status.
    */
   private hasPaidTokenOnFile(): boolean {
@@ -103,7 +110,7 @@ export class LicenseManager {
     }
 
     try {
-      // Save to database — reset last_sync_at so the fresh license starts
+      // Save to database - reset last_sync_at so the fresh license starts
       // with a clean sync history (prevents stale cooldown from prior token).
       await this.getPool().query(`
         INSERT INTO license_config (id, license_key, updated_at, last_sync_at)
@@ -114,6 +121,13 @@ export class LicenseManager {
       // Cache locally
       await this.cacheResult(key, result);
       this.lastSyncAt = null;
+
+      // Re-pace the background loop to the new token's expiry (no-op if not started)
+      this.scheduleNextAutoSync();
+
+      // Notify connected clients to refresh (covers manual activation AND the
+      // autonomous replacement path, which routes through here).
+      this.emit('licenseUpdated');
 
       return { success: true, tier: result.tier };
     } catch (error) {
@@ -148,6 +162,11 @@ export class LicenseManager {
       this.periodCount = null;
       this.lastSyncAt = null;
       this.cacheExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+      // Loop idles now that no paid token is on file (no-op if not started)
+      this.scheduleNextAutoSync();
+
+      this.emit('licenseUpdated');
 
       log.info('License removed, reverted to free tier', 'LicenseManager');
       return { success: true };
@@ -245,6 +264,7 @@ export class LicenseManager {
     apiAccess: string;
     showBranding: boolean;
     expiresAt: string | null;
+    graceExpiresAt: string | null;  // expiresAt + offline grace; UI derives the Grace badge/countdown from this
     activatedAt: string | null;
     nextBillingDate: string | null;
     discountCode: string | null;
@@ -273,6 +293,11 @@ export class LicenseManager {
       apiAccess: tier.apiAccess,
       showBranding: tier.showBranding,
       expiresAt: this.licenseExpiresAt ? this.licenseExpiresAt.toISOString() : null,
+      // Grace end = token exp + offline grace. Only meaningful for paid,
+      // non-lifetime tokens with a known expiry; null otherwise (lifetime/free).
+      graceExpiresAt: (this.licenseExpiresAt && this.licenseBilling && this.licenseBilling !== 'lifetime')
+        ? new Date(this.licenseExpiresAt.getTime() + GRACE_PERIOD_SECONDS * 1000).toISOString()
+        : null,
       activatedAt: this.licenseActivatedAt ? this.licenseActivatedAt.toISOString() : null,
       nextBillingDate: this.nextBillingDate ? this.nextBillingDate.toISOString() : null,
       discountCode: this.discountCode,
@@ -298,7 +323,7 @@ export class LicenseManager {
     error?: string;
   }> {
     // Skip sync for lifetime licenses or when no paid token is on file.
-    // Note: do NOT gate on cachedTier — a hard-expired paid token still
+    // Note: do NOT gate on cachedTier - a hard-expired paid token still
     // qualifies for sync so we can recover the renewed license from /status.
     if (!this.hasPaidTokenOnFile()) {
       return { success: true, changed: false };
@@ -352,7 +377,7 @@ export class LicenseManager {
 
       // Same-lid token refresh: D1 holds a fresher JWT for our existing license
       // (e.g. after a Dodo subscription.renewed UPDATEd the row in place, or
-      // after /renew). Identity-preserving — same lid, possibly new tier/billing
+      // after /renew). Identity-preserving - same lid, possibly new tier/billing
       // from a plan change. Worker enforces the lineage rules; trust the field.
       if (status.replacementToken) {
         log.info('Token replacement detected (same-lid refresh)', 'LicenseManager');
@@ -384,6 +409,8 @@ export class LicenseManager {
         this.licenseExpiresAt = serverExpiry;
         this.cacheExpiry = new Date(Date.now() + this.CACHE_DURATION_MS);
         log.info(`Expiry updated via sync: ${serverExpiry.toISOString()}`, 'LicenseManager');
+        // Renewal picked up without a token swap; tell clients to refresh.
+        this.emit('licenseUpdated');
       }
 
       // Update other fields
@@ -496,7 +523,7 @@ export class LicenseManager {
         };
       }
 
-      log.info('Renewal succeeded — applying new token', 'LicenseManager');
+      log.info('Renewal succeeded - applying new token', 'LicenseManager');
       const applyResult = await this.setLicenseKey(result.newToken);
       if (!applyResult.success) {
         return {
@@ -529,60 +556,114 @@ export class LicenseManager {
   }
 
   /**
-   * Check if auto-sync is needed based on time-to-expiry
-   * Progressive frequency: closer to expiry = more frequent syncs
+   * Progressive sync cadence. Returns the minimum spacing (ms) between license-
+   * server syncs for a given time-to-expiry: relaxed when far out, tightening as
+   * expiry nears so a renewal token is picked up promptly.
    *
    * Schedule:
-   * - 7+ days out: every 24 hours
-   * - 3-7 days out: every 24 hours
-   * - 2-3 days out: every 12 hours
-   * - 1-2 days out: every 6 hours
-   * - 12h-1 day out: every 1 hour
-   * - < 12 hours out: every 15 minutes
+   * - 3+ days out:     every 24 hours
+   * - 2-3 days out:    every 12 hours
+   * - 1-2 days out:    every 6 hours
+   * - 12h-1 day out:   every 1 hour
+   * - < 12 hours out:  every 15 minutes
+   *
+   * A negative timeToExpiry (already expired, in or past grace) falls into the
+   * tightest (< 12h) bucket so we recover as fast as possible. Single source of
+   * truth for both the lazy on-access path (checkAutoSync) and the autonomous
+   * background loop (scheduleNextAutoSync / autoSyncTick).
    */
-  private async checkAutoSync(): Promise<void> {
-    // Same gate as syncWithLicenseServer — paid (non-lifetime) token must
-    // be on file. Demoted-to-Free state with a hard-expired token still
-    // passes, allowing recovery via /status.
-    if (!this.hasPaidTokenOnFile()) {
-      return;
-    }
-
-    // Need expiry date to compute interval
-    if (!this.licenseExpiresAt) {
-      return;
-    }
-
-    const now = Date.now();
-    const expiryTime = this.licenseExpiresAt.getTime();
-    const timeToExpiry = expiryTime - now;
-    const lastSync = this.lastSyncAt?.getTime() || 0;
-    const timeSinceLastSync = now - lastSync;
-
-    // Calculate required sync interval based on time-to-expiry
-    let requiredInterval: number | null = null;
-
+  private computeSyncInterval(timeToExpiry: number): number {
     const HOUR = 60 * 60 * 1000;
     const DAY = 24 * HOUR;
+    if (timeToExpiry <= 12 * HOUR) return 15 * 60 * 1000; // 15 minutes
+    if (timeToExpiry <= 1 * DAY) return 1 * HOUR;          // 1 hour
+    if (timeToExpiry <= 2 * DAY) return 6 * HOUR;          // 6 hours
+    if (timeToExpiry <= 3 * DAY) return 12 * HOUR;         // 12 hours
+    return 24 * HOUR;                                      // 3+ days out: once per day
+  }
 
-    if (timeToExpiry <= 12 * HOUR) {
-      requiredInterval = 15 * 60 * 1000; // 15 minutes
-    } else if (timeToExpiry <= 1 * DAY) {
-      requiredInterval = 1 * HOUR; // 1 hour
-    } else if (timeToExpiry <= 2 * DAY) {
-      requiredInterval = 6 * HOUR; // 6 hours
-    } else if (timeToExpiry <= 3 * DAY) {
-      requiredInterval = 12 * HOUR; // 12 hours
-    } else if (timeToExpiry <= 7 * DAY) {
-      requiredInterval = 24 * HOUR; // 24 hours
-    } else {
-      requiredInterval = 24 * HOUR; // 7+ days: sync once per day
-    }
+  /**
+   * Sync if the progressive interval has elapsed since the last sync. Invoked
+   * from getLicenseInfo() (lazy, on-access) and from the background loop.
+   */
+  private async checkAutoSync(): Promise<void> {
+    // Paid (non-lifetime) token must be on file. A demoted-to-Free state with a
+    // hard-expired token still passes, allowing recovery via /status.
+    if (!this.hasPaidTokenOnFile()) return;
+    if (!this.licenseExpiresAt) return; // need expiry to compute interval
 
-    // Sync if interval exceeded
-    if (requiredInterval && timeSinceLastSync >= requiredInterval) {
+    const now = Date.now();
+    const timeToExpiry = this.licenseExpiresAt.getTime() - now;
+    const timeSinceLastSync = now - (this.lastSyncAt?.getTime() || 0);
+    const requiredInterval = this.computeSyncInterval(timeToExpiry);
+
+    if (timeSinceLastSync >= requiredInterval) {
+      const HOUR = 60 * 60 * 1000;
       log.info(`Auto-sync triggered (${Math.round(timeToExpiry / HOUR)}h to expiry, ${Math.round(timeSinceLastSync / 60000)}min since last sync)`, 'LicenseManager');
       await this.syncWithLicenseServer();
+    }
+  }
+
+  /**
+   * Start the autonomous background sync loop. Self-rescheduling: each tick
+   * sleeps exactly the progressive interval for the current time-to-expiry, so a
+   * healthy license is checked ~once/day and only ramps to every 15 min in the
+   * final 12h before expiry. This is what lets a renewed token in D1 be picked
+   * up with no open browser, no manual Refresh, and no container restart.
+   * Idempotent - safe to call once at startup.
+   */
+  startAutoSync(): void {
+    if (!this.autoSyncStopped) return; // already running
+    this.autoSyncStopped = false;
+    this.scheduleNextAutoSync();
+    log.info('License auto-sync loop started', 'LicenseManager');
+  }
+
+  /** Stop the background sync loop (graceful shutdown). */
+  stopAutoSync(): void {
+    this.autoSyncStopped = true;
+    if (this.autoSyncTimer) {
+      clearTimeout(this.autoSyncTimer);
+      this.autoSyncTimer = null;
+    }
+  }
+
+  /**
+   * Arm the timer for the next sync. Delay = progressive interval when a paid
+   * token with a known expiry is on file; otherwise a relaxed idle re-check so a
+   * later activation is still picked up. No fixed-interval polling.
+   */
+  private scheduleNextAutoSync(): void {
+    if (this.autoSyncStopped) return;
+    if (this.autoSyncTimer) {
+      clearTimeout(this.autoSyncTimer);
+      this.autoSyncTimer = null;
+    }
+
+    const delay = (this.hasPaidTokenOnFile() && this.licenseExpiresAt)
+      ? this.computeSyncInterval(this.licenseExpiresAt.getTime() - Date.now())
+      : this.AUTO_SYNC_IDLE_INTERVAL_MS;
+
+    this.autoSyncTimer = setTimeout(() => { void this.autoSyncTick(); }, delay);
+    // Never keep the event loop alive solely for this background timer.
+    this.autoSyncTimer.unref?.();
+  }
+
+  /** One background sync attempt (guarded against overlap), then reschedule. */
+  private async autoSyncTick(): Promise<void> {
+    this.autoSyncTimer = null;
+    if (this.autoSyncInProgress) {
+      this.scheduleNextAutoSync();
+      return;
+    }
+    this.autoSyncInProgress = true;
+    try {
+      await this.checkAutoSync();
+    } catch (error) {
+      log.error('Auto-sync tick failed', 'LicenseManager', error);
+    } finally {
+      this.autoSyncInProgress = false;
+      this.scheduleNextAutoSync();
     }
   }
 

--- a/backend/src/license/LicenseValidator.ts
+++ b/backend/src/license/LicenseValidator.ts
@@ -17,19 +17,27 @@
 
 import * as crypto from 'crypto';
 
+/**
+ * Offline grace window applied after a token's `exp`: the license stays valid
+ * (tier enforced) for this long past expiry so transient renewal-sync failures
+ * don't lock out a paying customer. Single source of truth, consumed by
+ * validate() and surfaced to the UI as a grace-end timestamp via LicenseManager.
+ */
+export const GRACE_PERIOD_SECONDS = 3 * 24 * 60 * 60; // 3 days
+
 export interface ValidationResult {
   valid: boolean;
   tier: string;
   billing?: 'monthly' | 'yearly' | 'lifetime';
   licenseId?: string;
-  subscriptionId?: string;    // From JWT `sid` claim — Dodo subscription identifier; absent for lifetime/one-time
+  subscriptionId?: string;    // From JWT `sid` claim - Dodo subscription identifier; absent for lifetime/one-time
   expiresAt: Date | null;
   isGracePeriod: boolean;      // New field: true if currently in 3-day buffer
   activatedAt: Date | null;  // When license was issued
   customerName?: string;
   customerEmail?: string;
-  periodInterval?: string;   // From JWT period_interval claim — "Day" | "Week" | "Month" | "Year"; absent for lifetime/legacy tokens
-  periodCount?: number;      // From JWT period_count claim — e.g. 1, 7
+  periodInterval?: string;   // From JWT period_interval claim - "Day" | "Week" | "Month" | "Year"; absent for lifetime/legacy tokens
+  periodCount?: number;      // From JWT period_count claim - e.g. 1, 7
   error?: string;
 }
 
@@ -41,7 +49,7 @@ interface LicensePayload {
   name?: string;   // Customer name
   oid?: string;    // Order ID
   sid?: string;    // Dodo subscription ID (subscription products only)
-  period_interval?: string;  // "Day"|"Week"|"Month"|"Year" — Dodo payment_frequency_interval; absent for lifetime/pre-2026-05-11 tokens
+  period_interval?: string;  // "Day"|"Week"|"Month"|"Year" - Dodo payment_frequency_interval; absent for lifetime/pre-2026-05-11 tokens
   period_count?: number;     // Dodo payment_frequency_count
 
   // Core fields (both v1 and v2)
@@ -196,7 +204,6 @@ export class LicenseValidator {
       const payload: LicensePayload = JSON.parse(payloadJson);
 
       // Check expiration with 3-day grace period for offline users
-      const GRACE_PERIOD_SECONDS = 3 * 24 * 60 * 60; // 3 days
       const now = Math.floor(Date.now() / 1000);
       const isLifetime = payload.exp === 0;
       const isHardExpired = !isLifetime && !!payload.exp && (payload.exp + GRACE_PERIOD_SECONDS) < now;

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -229,6 +229,13 @@ export class WebSocketHub extends EventEmitter {
         "commands:all",
       ]);
     });
+
+    // License changed (autonomous renewal pickup, manual activate/remove): tell
+    // clients to refetch /api/license so an always-open screen updates without a
+    // reload. Same push channel the dashboard already uses for live data.
+    licenseManager.on("licenseUpdated", () => {
+      this.broadcast("licenseUpdated", {}, ["systems:all"]);
+    });
   }
 
   /**

--- a/frontend/src/hooks/useWebSocketData.ts
+++ b/frontend/src/hooks/useWebSocketData.ts
@@ -37,6 +37,20 @@ export function subscribeToSystemDelta(
   };
 }
 
+// Module-level pub/sub for the backend's `licenseUpdated` push, so the
+// LicenseProvider (outside this hook) can refresh without owning a socket.
+type LicenseUpdatedListener = () => void;
+const licenseUpdatedListeners = new Set<LicenseUpdatedListener>();
+
+export function subscribeToLicenseUpdated(
+  listener: LicenseUpdatedListener
+): () => void {
+  licenseUpdatedListeners.add(listener);
+  return () => {
+    licenseUpdatedListeners.delete(listener);
+  };
+}
+
 interface UseWebSocketDataReturn {
   systems: SystemData[];
   isConnected: boolean;
@@ -469,6 +483,9 @@ export function useWebSocketData(): UseWebSocketDataReturn {
     wsRef.current.on("agentConfigUpdated", (data: unknown) =>
       handleAgentConfigUpdated(data as { agentId: string; config: any })
     );
+    wsRef.current.on("licenseUpdated", () => {
+      for (const listener of licenseUpdatedListeners) listener();
+    });
 
     // Connect
     wsRef.current

--- a/frontend/src/license/LicenseContext.tsx
+++ b/frontend/src/license/LicenseContext.tsx
@@ -2,8 +2,9 @@
  * License Context - Provides license tier information throughout the app
  */
 
-import React, { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { getLicense } from '../services/api';
+import { subscribeToLicenseUpdated } from '../hooks/useWebSocketData';
 
 export interface LicenseInfo {
   tier: string;
@@ -11,7 +12,7 @@ export interface LicenseInfo {
   customerName: string | null;
   customerEmail: string | null;
   licenseId: string | null;
-  subscriptionId: string | null;  // JWT `sid` claim — Dodo subscription identifier; null for lifetime/free
+  subscriptionId: string | null;  // JWT `sid` claim - Dodo subscription identifier; null for lifetime/free
   customerId: string | null;      // Dodo persistent customer identifier (from /status sync); null if not yet synced
   token: string | null;           // Raw JWT for user-visible reveal/copy field; null on free tier
   agentLimit: number;
@@ -21,12 +22,13 @@ export interface LicenseInfo {
   apiAccess: string;
   showBranding: boolean;
   expiresAt: string | null;
+  graceExpiresAt: string | null;  // Token exp + offline grace; drives the Grace badge/countdown. null for lifetime/free.
   activatedAt: string | null;
   nextBillingDate: string | null;
   discountCode: string | null;
   discountCyclesRemaining: number | null;
-  periodInterval: string | null;  // From JWT period_interval claim — "Day"|"Week"|"Month"|"Year"; null falls back to billing enum for badge display
-  periodCount: number | null;     // From JWT period_count claim — e.g. 1, 7
+  periodInterval: string | null;  // From JWT period_interval claim - "Day"|"Week"|"Month"|"Year"; null falls back to billing enum for badge display
+  periodCount: number | null;     // From JWT period_count claim - e.g. 1, 7
   lastSyncAt: string | null;
 }
 
@@ -48,9 +50,11 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refreshLicense = async () => {
+  // Loading state is shown only on the initial fetch (license === null at mount).
+  // Background refetches (tab focus, network resume, manual Sync/Activate) update
+  // the data silently: no spinner flash, no reset of in-progress edits.
+  const refreshLicense = useCallback(async () => {
     try {
-      setIsLoading(true);
       setError(null);
       const data = await getLicense();
       setLicense(data);
@@ -74,6 +78,7 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
         apiAccess: 'none',
         showBranding: true,
         expiresAt: null,
+        graceExpiresAt: null,
         activatedAt: null,
         nextBillingDate: null,
         discountCode: null,
@@ -85,11 +90,28 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     refreshLicense();
-  }, []);
+
+    // Re-pull when the user returns to the tab or the browser regains network,
+    // so an autonomous backend renewal is reflected without a manual reload.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refreshLicense();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('online', refreshLicense);
+    // Backend pushes `licenseUpdated` over the dashboard WebSocket whenever the
+    // license changes (e.g. autonomous renewal pickup), so an always-open screen
+    // reflects it without waiting for a tab-focus or network event.
+    const unsubscribeLicensePush = subscribeToLicenseUpdated(refreshLicense);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('online', refreshLicense);
+      unsubscribeLicensePush();
+    };
+  }, [refreshLicense]);
 
   return (
     <LicenseContext.Provider value={{ license, isLoading, error, refreshLicense }}>

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -65,7 +65,7 @@ interface PricingData {
   enterprise: TierPricing;
 }
 
-// Advertised discount data — populated from /api/license/promo (Worker → Dodo)
+// Advertised discount data - populated from /api/license/promo (Worker → Dodo)
 interface PromoOffer {
   code: string;
   name: string;
@@ -138,7 +138,7 @@ function formatDateTooltip(dateInput: string | null, fallback = ''): string {
   const local = new Intl.DateTimeFormat('en-US', { ...fmt, timeZone: userTz }).format(d);
   const utc = new Intl.DateTimeFormat('en-US', { ...fmt, timeZone: 'UTC' }).format(d);
 
-  // Relative — pick the best unit so values like "in 8 hours" or "2 days ago" feel natural
+  // Relative - pick the best unit so values like "in 8 hours" or "2 days ago" feel natural
   const diffSec = (d.getTime() - Date.now()) / 1000;
   const absSec = Math.abs(diffSec);
   const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
@@ -887,7 +887,7 @@ const Settings: React.FC = () => {
     { name: 'Mistic Water', color: '#0FEEEE' },
   ];
 
-  // Temperature-themed presets per status level. Kept short on purpose —
+  // Temperature-themed presets per status level. Kept short on purpose -
   // these guide the user toward sane hues, not give every shade.
   const tempColorPresets: Record<'normal' | 'caution' | 'warning' | 'critical', { name: string; color: string }[]> = {
     normal: [
@@ -930,6 +930,20 @@ const Settings: React.FC = () => {
       setActiveTab('general');
     }
   }, [isDemoMode, activeTab]);
+
+  // Tick once a minute so the "Grace - <countdown>" badge stays current on an
+  // otherwise idle screen. Settings is React.memo'd (no longer re-renders on
+  // sensor deltas), so without this the countdown would only recompute on a
+  // license refetch. Runs only while a paid token hasn't fully expired (active
+  // approaching expiry, or in grace); the interval is already ticking before the
+  // time-based active->grace crossover, and unmounts with the Settings tab.
+  const [, setGraceTick] = useState(0);
+  useEffect(() => {
+    const graceEnd = license?.graceExpiresAt ? new Date(license.graceExpiresAt).getTime() : null;
+    if (graceEnd === null || Date.now() >= graceEnd) return; // lifetime/free, or fully expired: nothing to tick
+    const id = setInterval(() => setGraceTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [license?.expiresAt, license?.graceExpiresAt]);
 
   const scalePresets = [
     { label: '1h', value: 1 },
@@ -1090,7 +1104,7 @@ const Settings: React.FC = () => {
   };
 
   // Compose Account Details as plain text for the "Copy All" button. The token
-  // is intentionally excluded — users with paranoid clipboards / screen-share
+  // is intentionally excluded - users with paranoid clipboards / screen-share
   // contexts can copy it separately via the dedicated token copy button.
   const composeAccountDetails = (info: LicenseInfo): string => {
     const lines: string[] = ['Account Details'];
@@ -1235,7 +1249,7 @@ const Settings: React.FC = () => {
         if (result.upgraded) {
           message = 'License renewed! Your subscription is active again.';
         } else if (result.changed) {
-          message = 'License updated — new expiry applied.';
+          message = 'License updated - new expiry applied.';
         } else if (wasExpired) {
           message = 'No renewal available yet. If you paid recently, give it a minute and try again, or check your email for the renewal token.';
         } else {
@@ -1266,7 +1280,7 @@ const Settings: React.FC = () => {
 
   /**
    * Force-renew license via worker /renew (vendor-independent recovery).
-   * Used when Sync alone can't recover the license — e.g., Dodo's webhook
+   * Used when Sync alone can't recover the license - e.g., Dodo's webhook
    * never fired but the customer paid. Subject to 15min cooldown + 3/day cap.
    */
   const handleRenewLicense = async () => {
@@ -1307,7 +1321,7 @@ const Settings: React.FC = () => {
   // Renew is enabled when the local license is in a state Sync alone may not recover:
   //  1. Demoted to Free with a licenseId on file (hard-expired past 3-day grace)
   //  2. Token's exp has passed (covers the 3-day grace window before validator demotes)
-  // Disabled otherwise — Sync handles the normal path.
+  // Disabled otherwise - Sync handles the normal path.
   const canRenew = !!license?.licenseId && (
     license.tier === 'Free' ||
     (!!license.expiresAt && new Date(license.expiresAt).getTime() < Date.now())
@@ -1318,9 +1332,16 @@ const Settings: React.FC = () => {
   };
 
   /**
-   * Format remaining time dynamically and return urgency level
+   * Format remaining time dynamically and return urgency level. Three states:
+   *  - Active: time left until token exp (green/amber/red by closeness)
+   *  - Grace:  exp passed but still within the offline grace window (amber),
+   *            "Grace - <Xd/Xh/Xm left>", with a grace-end tooltip
+   *  - Expired: past grace (red)
    */
-  const formatRemaining = (expiresAt: string | null): { text: string; urgency: 'normal' | 'caution' | 'critical' } => {
+  const formatRemaining = (
+    expiresAt: string | null,
+    graceExpiresAt: string | null
+  ): { text: string; urgency: 'normal' | 'caution' | 'critical'; tooltip?: string } => {
     if (!expiresAt) {
       return { text: 'Lifetime', urgency: 'normal' };
     }
@@ -1328,8 +1349,24 @@ const Settings: React.FC = () => {
     const now = new Date();
     const expires = new Date(expiresAt);
     const diffMs = expires.getTime() - now.getTime();
-    
+
     if (diffMs <= 0) {
+      // Past token exp: still entitled while within grace, hard-expired after.
+      const graceEnd = graceExpiresAt ? new Date(graceExpiresAt) : null;
+      const graceMs = graceEnd ? graceEnd.getTime() - now.getTime() : 0;
+      if (graceEnd && graceMs > 0) {
+        const mins = Math.floor(graceMs / (1000 * 60));
+        const left = mins >= 1440
+          ? `${Math.floor(mins / 1440)}d left`
+          : mins >= 60
+            ? `${Math.floor(mins / 60)}h left`
+            : `${Math.max(1, mins)}m left`;
+        return {
+          text: `Grace - ${left}`,
+          urgency: 'caution',
+          tooltip: `Grace period ends ${formatDateTooltip(graceExpiresAt)}`,
+        };
+      }
       return { text: 'Expired', urgency: 'critical' };
     }
 
@@ -1611,7 +1648,7 @@ const Settings: React.FC = () => {
                     <div className="setting-info-wrapper">
                       <span className="setting-label">Accent Color</span>
                       <span className="setting-description">
-                        Primary brand color — buttons, focus rings, tab underlines, active states.
+                        Primary brand color - buttons, focus rings, tab underlines, active states.
                       </span>
                     </div>
                     <div className="appearance-color-control">
@@ -1704,7 +1741,7 @@ const Settings: React.FC = () => {
                     <div className="setting-info-wrapper">
                       <span className="setting-label">Secondary Font</span>
                       <span className="setting-description">
-                        Monospace face — temperatures, fan speeds, hex codes, code blocks.
+                        Monospace face - temperatures, fan speeds, hex codes, code blocks.
                       </span>
                     </div>
                     <div className="appearance-font-control">
@@ -1728,7 +1765,7 @@ const Settings: React.FC = () => {
                     </div>
                   </div>
 
-                  {/* Temperature Thresholds — wide row */}
+                  {/* Temperature Thresholds - wide row */}
                   {(() => {
                     const isTypeTab =
                       activeThresholdType === 'cpu' ||
@@ -1749,7 +1786,7 @@ const Settings: React.FC = () => {
                       } else if (activeThresholdType === 'global') {
                         updateTempThresholds(next);
                       }
-                      // 'customise' is a meta-tab — drag/edits are disabled until a type is picked.
+                      // 'customise' is a meta-tab - drag/edits are disabled until a type is picked.
                     };
 
                     const handleTabClick = (key: ThresholdTab) => {
@@ -1824,7 +1861,7 @@ const Settings: React.FC = () => {
                         />
 
                         <div className="appearance-threshold-chips">
-                          {/* Normal — color only */}
+                          {/* Normal - color only */}
                           <div className="appearance-threshold-chip" style={{ borderLeftColor: tempColors.normal }}>
                             <div className="appearance-threshold-chip-head">
                               <span className="threshold-color-dot" style={{ backgroundColor: tempColors.normal }} />
@@ -1890,14 +1927,14 @@ const Settings: React.FC = () => {
                         <div className="appearance-threshold-foot">
                           <span className="appearance-threshold-hint">
                             {activeThresholdType === 'global' && (
-                              <>Editing the <strong>Global</strong> baseline — applies to all sensors.</>
+                              <>Editing the <strong>Global</strong> baseline - applies to all sensors.</>
                             )}
                             {isCustomiseTab && (
-                              <>Per-type overrides <strong>enabled</strong> — pick a sensor type to edit its thresholds.</>
+                              <>Per-type overrides <strong>enabled</strong> - pick a sensor type to edit its thresholds.</>
                             )}
                             {isTypeTab && (
                               <>
-                                Editing override for <strong>{activeThresholdType.toUpperCase()}</strong> — falls back to Global where unset.
+                                Editing override for <strong>{activeThresholdType.toUpperCase()}</strong> - falls back to Global where unset.
                               </>
                             )}
                           </span>
@@ -1959,7 +1996,7 @@ const Settings: React.FC = () => {
                 {/* Tier benefits, agent limits, retention, and prices below all flow from
                     backend/src/license/tiers.ts via /api/license/pricing. The `|| N` price
                     fallbacks only render during the brief loading window before the API
-                    responds — keep them in sync with tiers.ts pricing if you change it. */}
+                    responds - keep them in sync with tiers.ts pricing if you change it. */}
                 <div className="pricing-section">
                   {promo && promo.offers.length > 0 && (
                     <>
@@ -2014,7 +2051,7 @@ const Settings: React.FC = () => {
                           else barUrgency = 'normal';
                         }
 
-                        // Stamp tier — drives the big "%" amount color so it
+                        // Stamp tier - drives the big "%" amount color so it
                         // matches the rarity color of the highest tier this
                         // discount applies to. Highest rarity wins:
                         // lifetime > enterprise > pro.
@@ -2419,7 +2456,7 @@ const Settings: React.FC = () => {
                         </div>
                       </div>
                     )}
-                    <div className="limit-item" title={formatDateTooltip(license.expiresAt, 'Lifetime — never expires')}>
+                    <div className="limit-item" title={formatDateTooltip(license.expiresAt, 'Lifetime - never expires')}>
                       <span className="limit-label">Expires</span>
                       <div className="limit-value-group">
                         <span className="limit-value">
@@ -2431,10 +2468,11 @@ const Settings: React.FC = () => {
                       </div>
                     </div>
                     {(() => {
-                      const remaining = formatRemaining(license.expiresAt);
-                      const remainingTooltip = license.billing === 'lifetime'
-                        ? 'Lifetime — unlimited access'
-                        : formatDateTooltip(license.nextBillingDate, 'No upcoming renewal scheduled');
+                      const remaining = formatRemaining(license.expiresAt, license.graceExpiresAt);
+                      const remainingTooltip = remaining.tooltip
+                        ?? (license.billing === 'lifetime'
+                          ? 'Lifetime - unlimited access'
+                          : formatDateTooltip(license.nextBillingDate, 'No upcoming renewal scheduled'));
                       return (
                         <div className={`limit-item remaining-${remaining.urgency}`} title={remainingTooltip}>
                           <span className="limit-label">Remaining</span>
@@ -2698,7 +2736,7 @@ const Settings: React.FC = () => {
                         <div className="license-field license-field--full">
                           <div className="license-field-header">
                             <span className="license-field-label">License Token</span>
-                            <span className="license-field-hint">Keep this secret — it authenticates your client.</span>
+                            <span className="license-field-hint">Keep this secret - it authenticates your client.</span>
                           </div>
                           <div className="license-field-input license-field-input--token">
                             <span className="license-field-value license-field-value--mono license-field-value--token">
@@ -2751,4 +2789,8 @@ const Settings: React.FC = () => {
   );
 };
 
-export default Settings;
+// Memoized: Settings takes no props, so this prevents the every-~3s re-render it
+// would otherwise inherit from SystemsPage on each live sensor delta. It still
+// re-renders on context changes (license/dashboard-settings) and its own state
+// (including the grace tick above).
+export default React.memo(Settings);


### PR DESCRIPTION
## Problem

  A paid instance could silently fall back to the Free tier even with an active subscription. After a renewal, the instance only refreshed its license on a page load, a hard refresh, or the manual Sync button.
  If none of those happened (a tab left open, or no browser open at all), the renewed license was never picked up and the instance enforced Free limits.

  The root cause was that license refresh only ever ran in response to a user action; there was no automatic refresh on its own.

  ## Fix

  - **Automatic background refresh:** the backend now re-checks the license server on its own schedule (frequent as expiry approaches, infrequent when far away), so a renewal is picked up with no browser open
  and no manual action.
  - **Live UI updates:** when the license changes, the backend notifies connected clients over the existing WebSocket, and the frontend also refreshes on tab focus and network reconnect. An open dashboard now
  reflects a renewal without a reload.
  - **Clearer status:** the license badge now shows Active, a "Grace" state with a countdown while a renewal is briefly pending, or Expired, instead of jumping straight to "Expired" during a normal renewal
  window.

  ## Notes

  - `Settings` is memoized to drop an unnecessary periodic re-render; a small timer keeps the grace countdown current.
  - No changes to tiers, pricing, or the grace-period length.

  ## Testing

  - Typecheck passes for both workspaces; no new lint issues.
  - Verified the license refreshes automatically (no page interaction), an open tab updates on a license change, and the badge renders Active / Grace / Expired correctly.
