### PR TITLE
feat: add NVIDIA GPU monitoring and fan control support via NVML

### DIFF
--- a/agents/clients/linux/rust/Cargo.lock
+++ b/agents/clients/linux/rust/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -89,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -110,21 +110,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -138,9 +138,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -247,6 +247,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,9 +292,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -273,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -300,10 +332,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
@@ -383,15 +415,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -402,18 +432,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -434,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -473,10 +494,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -485,9 +506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -504,13 +523,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -521,16 +539,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "lock_api"
@@ -543,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "match_cfg"
@@ -564,15 +586,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -599,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -619,6 +641,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -645,6 +690,7 @@ dependencies = [
  "glob",
  "hostname",
  "libc",
+ "nvml-wrapper",
  "serde",
  "serde_json",
  "sysinfo",
@@ -701,16 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -811,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -831,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -875,12 +911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -946,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -968,19 +998,25 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -996,9 +1032,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,11 +1058,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1051,12 +1107,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -1068,15 +1123,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1084,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1226,26 +1281,20 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1261,11 +1310,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1290,27 +1339,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1321,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1331,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1344,45 +1384,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1391,14 +1397,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1587,112 +1593,36 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "wrapcenum-derive"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1701,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/agents/clients/linux/rust/Cargo.toml
+++ b/agents/clients/linux/rust/Cargo.toml
@@ -50,6 +50,9 @@ time = { version = "0.3", features = ["local-offset", "formatting"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 # Linux-specific dependencies
 libc = "0.2"
+# NVIDIA GPU monitoring + fan control via NVML (libnvidia-ml). Loaded at runtime
+# (dlopen) by nvml-wrapper; never bundled. Absent driver -> NvmlSource::try_init() = None.
+nvml-wrapper = "0.12"
 
 [build-dependencies]
 serde_json = "1.0"

--- a/agents/clients/linux/rust/src/hardware.rs
+++ b/agents/clients/linux/rust/src/hardware.rs
@@ -30,6 +30,15 @@ pub trait HardwareMonitor: Send + Sync {
     /// Emergency stop - set all fans to maximum
     async fn emergency_stop(&self) -> Result<()>;
 
+    /// Hand a fan back to hardware/driver automatic control.
+    ///
+    /// Returns `Ok(true)` if this backend owns the fan and restored it (e.g. an NVIDIA
+    /// GPU fan via NVML), `Ok(false)` if the fan is not auto-restorable here (sysfs/IPMI)
+    /// so the caller should apply `failsafe_speed` instead. Default: not owned.
+    async fn restore_fan_to_auto(&self, _fan_id: &str) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Invalidate hardware cache (call on startup/reconnection to force rediscovery)
     async fn invalidate_cache(&self);
 

--- a/agents/clients/linux/rust/src/hardware/linux.rs
+++ b/agents/clients/linux/rust/src/hardware/linux.rs
@@ -8,3 +8,5 @@ pub mod sensors;
 pub mod fans;
 #[cfg(target_os = "linux")]
 pub mod diagnostics;
+#[cfg(target_os = "linux")]
+pub(crate) mod nvidia;

--- a/agents/clients/linux/rust/src/hardware/linux/monitor.rs
+++ b/agents/clients/linux/rust/src/hardware/linux/monitor.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, warn};
 use crate::config::types::HardwareSettings;
 use crate::hardware::types::*;
 use crate::hardware::HardwareMonitor;
+use super::nvidia::NvmlSource;
 
 #[cfg(target_os = "linux")]
 pub(crate) struct FanInfo {
@@ -52,6 +53,8 @@ pub struct LinuxHardwareMonitor {
     pub(crate) cpu_brand: String,
     pub(crate) motherboard_name: String,
     pub(crate) storage_cache: Arc<RwLock<HashMap<String, String>>>,
+    /// Optional NVIDIA GPU source (NVML). `None` on non-NVIDIA hosts.
+    pub(crate) nvml: Option<NvmlSource>,
 }
 
 #[cfg(target_os = "linux")]
@@ -97,6 +100,7 @@ impl LinuxHardwareMonitor {
             cpu_brand,
             motherboard_name: String::new(),
             storage_cache: Arc::new(RwLock::new(HashMap::new())),
+            nvml: NvmlSource::try_init(),
         };
 
         // Initialize other static hardware names
@@ -268,7 +272,7 @@ impl HardwareMonitor for LinuxHardwareMonitor {
         let cached_count = *self.cached_hwmon_count.read().await;
         let cache_empty = self.discovered_sensors.read().await.is_empty();
 
-        let sensors = if current_hwmon_count != cached_count || cache_empty {
+        let mut sensors = if current_hwmon_count != cached_count || cache_empty {
             // Hardware changed or cache empty - full rediscovery
             debug!("Sensor discovery triggered: hwmon_count {} -> {} (cache_empty: {})",
                    cached_count, current_hwmon_count, cache_empty);
@@ -307,12 +311,24 @@ impl HardwareMonitor for LinuxHardwareMonitor {
             self.read_sensors_from_cache().await?
         };
 
+        // Append NVIDIA GPU temperature sensor(s) via NVML. Read fresh each cycle - never
+        // inserted into the hwmon path-cache, which reuses `source` as the sysfs file path.
+        if let Some(nvml) = &self.nvml {
+            sensors.extend(nvml.discover_sensors());
+        }
+
         Ok(sensors)
     }
 
     async fn discover_fans(&self) -> Result<Vec<Fan>> {
         // Always perform fresh fan discovery (no caching)
-        let fans = self.discover_hwmon_fans().await?;
+        let mut fans = self.discover_hwmon_fans().await?;
+
+        // Append NVIDIA GPU fan(s) via NVML (sysfs exposes no writable pwm for them).
+        if let Some(nvml) = &self.nvml {
+            fans.extend(nvml.discover_fans());
+        }
+
         Ok(fans)
     }
 
@@ -347,6 +363,14 @@ impl HardwareMonitor for LinuxHardwareMonitor {
     }
 
     async fn set_fan_speed(&self, fan_id: &str, speed: u8) -> Result<()> {
+        // Route NVIDIA GPU fans to NVML (sysfs exposes no writable pwm for them).
+        if NvmlSource::owns_fan(fan_id) {
+            return match &self.nvml {
+                Some(nvml) => nvml.set_fan_speed(fan_id, speed),
+                None => anyhow::bail!("GPU fan {} requested but NVML is unavailable", fan_id),
+            };
+        }
+
         let speed = speed.min(100);
         let pwm_value = (speed as f32 / 100.0 * 255.0) as u8;
 
@@ -412,16 +436,28 @@ impl HardwareMonitor for LinuxHardwareMonitor {
     }
 
     async fn emergency_stop(&self) -> Result<()> {
-        let fan_map = self.discovered_fans.read().await;
+        // Use the full fan list (sysfs + NVML GPU) so emergency covers the GPU too;
+        // set_fan_speed routes each id to the correct backend.
+        let fans = self.discover_fans().await?;
 
-        for (fan_id, _) in fan_map.iter() {
-            if let Err(e) = self.set_fan_speed(fan_id, 100).await {
-                error!("Failed to set fan {} to 100%: {}", fan_id, e);
+        for fan in &fans {
+            if let Err(e) = self.set_fan_speed(&fan.id, 100).await {
+                error!("Failed to set fan {} to 100%: {}", fan.id, e);
             }
         }
 
         warn!("EMERGENCY STOP: All fans set to 100%");
         Ok(())
+    }
+
+    async fn restore_fan_to_auto(&self, fan_id: &str) -> Result<bool> {
+        if NvmlSource::owns_fan(fan_id) {
+            if let Some(nvml) = &self.nvml {
+                nvml.restore_to_auto(fan_id)?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     async fn invalidate_cache(&self) {

--- a/agents/clients/linux/rust/src/hardware/linux/nvidia.rs
+++ b/agents/clients/linux/rust/src/hardware/linux/nvidia.rs
@@ -1,0 +1,177 @@
+//! NVIDIA GPU monitoring + fan control via NVML (`libnvidia-ml`).
+//!
+//! Additive source inside `LinuxHardwareMonitor`: appends GPU temperature sensors and
+//! one logical fan per GPU to the sysfs discovery results. NVML is loaded at runtime by
+//! `nvml-wrapper` (dlopen); if the NVIDIA driver/NVML is absent, `try_init()` returns
+//! `None` and every GPU path is a no-op, so non-NVIDIA hosts are unaffected.
+//!
+//! Fan writes require root (NVML returns "Insufficient Permissions" otherwise); the agent
+//! already runs as a root systemd daemon. The GPU is never put under manual control at
+//! discovery - it stays on the driver's auto curve until the backend issues `set_fan_speed`.
+
+use anyhow::{Context, Result};
+use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
+use nvml_wrapper::Nvml;
+use tracing::{debug, warn};
+
+use crate::hardware::types::{Fan, Sensor};
+
+/// Optional NVML-backed GPU source. Present only when the NVIDIA driver/NVML is available.
+pub(crate) struct NvmlSource {
+    nvml: Nvml,
+}
+
+impl NvmlSource {
+    /// Returns `None` (not an error) when NVML/driver is absent, so AMD-only or GPU-less
+    /// machines degrade gracefully. Also returns `None` if NVML loads but reports no devices.
+    pub(crate) fn try_init() -> Option<Self> {
+        match Nvml::init() {
+            Ok(nvml) => match nvml.device_count() {
+                Ok(0) | Err(_) => {
+                    debug!("NVML initialized but no usable NVIDIA devices found");
+                    None
+                }
+                Ok(count) => {
+                    debug!("NVML initialized: {} NVIDIA device(s)", count);
+                    Some(Self { nvml })
+                }
+            },
+            Err(e) => {
+                debug!("NVML not available (no NVIDIA driver?): {}", e);
+                None
+            }
+        }
+    }
+
+    /// True if `fan_id` is an NVML-owned GPU fan (id form: `nvidia_gpu<idx>_fan`).
+    pub(crate) fn owns_fan(fan_id: &str) -> bool {
+        fan_id.starts_with("nvidia_gpu") && fan_id.ends_with("_fan")
+    }
+
+    /// Parse the GPU index out of an id like `nvidia_gpu0_fan` / `nvidia_gpu0_temp`.
+    fn index_from_id(id: &str) -> Option<u32> {
+        id.strip_prefix("nvidia_gpu")
+            .and_then(|rest| rest.split('_').next())
+            .and_then(|n| n.parse::<u32>().ok())
+    }
+
+    /// GPU temperature sensors (one per device). Read-only; never moves a fan. Per-device
+    /// errors are logged and skipped so a GPU hiccup never breaks sysfs telemetry.
+    pub(crate) fn discover_sensors(&self) -> Vec<Sensor> {
+        let mut out = Vec::new();
+        let count = self.nvml.device_count().unwrap_or(0);
+        for idx in 0..count {
+            let device = match self.nvml.device_by_index(idx) {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!("NVML device {} unavailable: {}", idx, e);
+                    continue;
+                }
+            };
+            let temp = match device.temperature(TemperatureSensor::Gpu) {
+                Ok(t) => t as f64,
+                Err(e) => {
+                    warn!("NVML temp read failed (gpu {}): {}", idx, e);
+                    continue;
+                }
+            };
+            let name = device
+                .name()
+                .unwrap_or_else(|_| format!("NVIDIA GPU {}", idx));
+            out.push(Sensor {
+                id: format!("nvidia_gpu{}_temp", idx),
+                name,
+                temperature: temp,
+                sensor_type: "gpu".to_string(),
+                max_temp: None, // TODO(P3): NVML temperature thresholds (slowdown/shutdown)
+                crit_temp: None,
+                chip: Some("gpu".to_string()),
+                hardware_name: None,
+                source: Some("nvidia_nvml".to_string()),
+            });
+        }
+        out
+    }
+
+    /// One logical fan per GPU (NVML may expose several fan indices per card; we collapse
+    /// to one Pankha fan and fan out on writes). Read-only.
+    pub(crate) fn discover_fans(&self) -> Vec<Fan> {
+        let mut out = Vec::new();
+        let count = self.nvml.device_count().unwrap_or(0);
+        for idx in 0..count {
+            let device = match self.nvml.device_by_index(idx) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            let num = device.num_fans().unwrap_or(0);
+            if num == 0 {
+                continue;
+            }
+
+            // Honest capability probe (no fan movement): advertise control only if the
+            // driver genuinely exposes a writable fan-speed range for this card.
+            let has_pwm_control = device.min_max_fan_speed().is_ok();
+
+            // Representative readings from fan index 0.
+            let speed = device.fan_speed(0).unwrap_or(0).min(100) as u8;
+            let rpm = device.fan_speed_rpm(0).ok();
+            let name = device
+                .name()
+                .unwrap_or_else(|_| format!("NVIDIA GPU {}", idx));
+
+            out.push(Fan {
+                id: format!("nvidia_gpu{}_fan", idx),
+                name: format!("{} Fan", name),
+                rpm,
+                speed,
+                target_speed: speed,
+                status: if speed == 0 && rpm == Some(0) {
+                    "stopped".to_string()
+                } else {
+                    "ok".to_string()
+                },
+                has_pwm_control,
+                pwm_file: None,
+            });
+        }
+        out
+    }
+
+    /// Set the GPU fan to `pct`% (manual control). `set_fan_speed` takes manual control
+    /// implicitly; fans out over all NVML fan indices for this card.
+    pub(crate) fn set_fan_speed(&self, fan_id: &str, pct: u8) -> Result<()> {
+        let idx = Self::index_from_id(fan_id)
+            .with_context(|| format!("malformed NVML fan id: {}", fan_id))?;
+        let pct = pct.min(100) as u32;
+        let mut device = self
+            .nvml
+            .device_by_index(idx)
+            .with_context(|| format!("NVML device {} not found", idx))?;
+        let num = device.num_fans().unwrap_or(1).max(1);
+        for fan in 0..num {
+            device
+                .set_fan_speed(fan, pct)
+                .with_context(|| format!("NVML set_fan_speed gpu {} fan {} -> {}%", idx, fan, pct))?;
+        }
+        debug!("NVML: gpu {} all fans -> {}%", idx, pct);
+        Ok(())
+    }
+
+    /// Hand the GPU fan(s) back to the driver's automatic, temperature-driven curve.
+    pub(crate) fn restore_to_auto(&self, fan_id: &str) -> Result<()> {
+        let idx = Self::index_from_id(fan_id)
+            .with_context(|| format!("malformed NVML fan id: {}", fan_id))?;
+        let mut device = self
+            .nvml
+            .device_by_index(idx)
+            .with_context(|| format!("NVML device {} not found", idx))?;
+        let num = device.num_fans().unwrap_or(1).max(1);
+        for fan in 0..num {
+            device
+                .set_default_fan_speed(fan)
+                .with_context(|| format!("NVML set_default_fan_speed gpu {} fan {}", idx, fan))?;
+        }
+        debug!("NVML: gpu {} fans restored to driver auto", idx);
+        Ok(())
+    }
+}

--- a/agents/clients/linux/rust/src/main.rs
+++ b/agents/clients/linux/rust/src/main.rs
@@ -316,6 +316,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Keep a handle to restore GPU fans to driver-auto on shutdown (no-op for sysfs/IPMI).
+    let hw_for_shutdown = Arc::clone(&hardware_monitor);
+
     // Create and run WebSocket client
     let client = WebSocketClient::new(config, hardware_monitor);
     let client = Arc::new(client);
@@ -359,11 +362,34 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Setup signal handler with proper cancellation
+    // Setup signal handler with proper cancellation (SIGINT + SIGTERM).
+    // SIGTERM matters here: `systemctl stop` / `--stop` send it, and without trapping it
+    // the process would exit via the kernel default and leave a manually-controlled GPU
+    // fan pinned. Trapping it lets us restore the GPU to the driver's auto curve below.
     let client_clone = Arc::clone(&client);
     let shutdown_signal = tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        info!("Shutdown signal received (Ctrl+C)");
+        #[cfg(target_os = "linux")]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            match signal(SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => info!("Shutdown signal received (SIGINT)"),
+                        _ = sigterm.recv() => info!("Shutdown signal received (SIGTERM)"),
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to setup SIGTERM handler ({}); SIGINT only", e);
+                    tokio::signal::ctrl_c().await.ok();
+                    info!("Shutdown signal received (SIGINT)");
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            tokio::signal::ctrl_c().await.ok();
+            info!("Shutdown signal received (Ctrl+C)");
+        }
         client_clone.stop().await;
     });
 
@@ -377,6 +403,19 @@ async fn main() -> Result<()> {
         _ = shutdown_signal => {
             info!("Shutdown signal handled");
         }
+    }
+
+    // On shutdown, hand any agent-controlled GPU fan back to the driver's auto curve.
+    // No-op for sysfs/IPMI fans; only NVML-owned GPU fans respond (Ok(true)).
+    match hw_for_shutdown.discover_fans().await {
+        Ok(fans) => {
+            for fan in &fans {
+                if let Err(e) = hw_for_shutdown.restore_fan_to_auto(&fan.id).await {
+                    warn!("Failed to restore fan {} to auto on shutdown: {}", fan.id, e);
+                }
+            }
+        }
+        Err(e) => warn!("Could not enumerate fans for shutdown restore: {}", e),
     }
 
     // Clean up PID file after shutdown

--- a/agents/clients/linux/rust/src/websocket/client.rs
+++ b/agents/clients/linux/rust/src/websocket/client.rs
@@ -70,10 +70,21 @@ impl WebSocketClient {
     /// Exit failsafe mode - backend connection restored
     async fn exit_failsafe_mode(&self) {
         let mut failsafe = self.failsafe_active.write().await;
-        if *failsafe {
-            *failsafe = false;
-            info!("✅ EXITING FAILSAFE MODE - Backend connection restored");
-            info!("Backend will resume fan control");
+        if !*failsafe {
+            return;
+        }
+        *failsafe = false;
+        drop(failsafe);
+        info!("✅ EXITING FAILSAFE MODE - Backend connection restored");
+        info!("Backend will resume fan control");
+
+        // Hand any GPU fan back to the driver's auto curve so an unassigned GPU isn't left
+        // pinned (e.g. at 100% after a failsafe emergency). The backend re-commands it
+        // within a cycle if a profile is assigned. No-op for sysfs/IPMI fans.
+        if let Ok(fans) = self.hardware_monitor.discover_fans().await {
+            for fan in &fans {
+                let _ = self.hardware_monitor.restore_fan_to_auto(&fan.id).await;
+            }
         }
     }
 
@@ -84,6 +95,22 @@ impl WebSocketClient {
         let mut fail_count = 0;
 
         for fan in fans.iter() {
+            // Hybrid failsafe: GPU / driver-auto-capable fans are handed back to their own
+            // driver curve (more trustworthy than a fixed %); all other fans get the
+            // configured failsafe speed. Mirrors the Windows agent's EnterFailsafeMode.
+            match self.hardware_monitor.restore_fan_to_auto(&fan.id).await {
+                Ok(true) => {
+                    debug!("Fan {} handed back to driver auto (failsafe)", fan.id);
+                    success_count += 1;
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => warn!(
+                    "restore_fan_to_auto({}) failed: {} - falling back to failsafe speed",
+                    fan.id, e
+                ),
+            }
+
             match self.hardware_monitor.set_fan_speed(&fan.id, speed).await {
                 Ok(_) => {
                     debug!("Set fan {} to {}%", fan.id, speed);


### PR DESCRIPTION
We've never been able to control NVIDIA GPU fans on Linux because the driver only exposes a
read-only temp in hwmon and no writable pwm, so sysfs is a dead end. This adds an NVML
backend (same library nvidia-smi uses) so the GPU shows up as a normal sensor and fan and
works with fan profiles like everything else.

A few things worth knowing:

- It's optional and loaded at runtime. No NVIDIA driver means it's a no-op, so nothing
  changes on AMD/Intel boxes. We don't ship NVML, it comes with the driver.
- The GPU is left on the driver's own curve until the backend actually tells it to do
  something.
- On disconnect the GPU goes back to driver-auto rather than the failsafe percent. The
  driver's own curve is more trustworthy than us pinning a number. emergency_temp still
  forces everything (GPU included) to 100%.
- Also added a SIGTERM handler so `systemctl stop` hands the GPU back to auto instead of
  leaving the fan stuck where we left it.

Windows already does this through NVAPI, so this is just the Linux side catching up. Needs
root (agent already runs as root) and a recent-ish driver.
