### PR TITLE
Feature/optimization scaling safety checks

### DIFF
--- a/backend/src/database/database.ts
+++ b/backend/src/database/database.ts
@@ -44,7 +44,7 @@ export class Database {
       max: 50,                        // Scale up to 50 under load
       idleTimeoutMillis: 30000,       // Drop idle connections after 30s
       connectionTimeoutMillis: 5000,  // Wait 5s before timeout (prevents pool exhaustion under burst)
-      // P3: abort any single query still running after 15s so a runaway/locked
+      // Abort any single query still running after 15s so a runaway or locked
       // query can't pin a pooled connection and starve the control loop. Well
       // above every control-loop/API query (all sub-second). Long maintenance
       // queries (schema migration, downsampling, retention cleanup) opt out
@@ -71,7 +71,7 @@ export class Database {
     const schema = fs.readFileSync(schemaPath, 'utf8');
 
     try {
-      // P3: run the schema (CREATE TABLE IF NOT EXISTS + migrations) with the
+      // Run the schema (CREATE TABLE IF NOT EXISTS + migrations) with the
       // pool-wide statement_timeout disabled for this transaction only - a
       // migration/ALTER on a large existing DB can legitimately exceed 15s.
       // SET LOCAL reverts when the transaction ends. The schema is

--- a/backend/src/database/database.ts
+++ b/backend/src/database/database.ts
@@ -6,6 +6,7 @@ import { log } from '../utils/logger';
 export class Database {
   private pool: Pool;
   private static instance: Database;
+  private poolMonitorInterval: NodeJS.Timeout | null = null;
 
   private constructor() {
     // Priority: Construct URL from individual env vars with URL-encoding (supports special chars)
@@ -57,6 +58,29 @@ export class Database {
     });
 
     log.info('Connected to PostgreSQL database', 'Database');
+
+    this.startPoolMonitor();
+  }
+
+  /**
+   * Periodically report connection-pool pressure. Warns only when requests are
+   * queued waiting for a free connection (waitingCount > 0) - the early sign of
+   * pool saturation, exactly the contention that stalls the control loop. Emits
+   * a quiet heartbeat at debug otherwise. The timer is unref'd so it never holds
+   * the process open during shutdown.
+   */
+  private startPoolMonitor(): void {
+    this.poolMonitorInterval = setInterval(() => {
+      const total = this.pool.totalCount;
+      const idle = this.pool.idleCount;
+      const waiting = this.pool.waitingCount;
+      if (waiting > 0) {
+        log.warn('PostgreSQL pool saturated: requests waiting for a connection', 'Database', { total, idle, waiting });
+      } else {
+        log.debug('PostgreSQL pool stats', 'Database', { total, idle, waiting });
+      }
+    }, 30000);
+    this.poolMonitorInterval.unref();
   }
 
   public static getInstance(): Database {
@@ -229,6 +253,10 @@ export class Database {
 
   // Close the pool
   public async close(): Promise<void> {
+    if (this.poolMonitorInterval) {
+      clearInterval(this.poolMonitorInterval);
+      this.poolMonitorInterval = null;
+    }
     try {
       await this.pool.end();
       log.info('Database connection pool closed', 'Database');

--- a/backend/src/database/database.ts
+++ b/backend/src/database/database.ts
@@ -44,6 +44,12 @@ export class Database {
       max: 50,                        // Scale up to 50 under load
       idleTimeoutMillis: 30000,       // Drop idle connections after 30s
       connectionTimeoutMillis: 5000,  // Wait 5s before timeout (prevents pool exhaustion under burst)
+      // P3: abort any single query still running after 15s so a runaway/locked
+      // query can't pin a pooled connection and starve the control loop. Well
+      // above every control-loop/API query (all sub-second). Long maintenance
+      // queries (schema migration, downsampling, retention cleanup) opt out
+      // per-transaction via `SET LOCAL statement_timeout = 0`.
+      statement_timeout: 15000,
     });
 
     this.pool.on('error', (err) => {
@@ -65,7 +71,24 @@ export class Database {
     const schema = fs.readFileSync(schemaPath, 'utf8');
 
     try {
-      await this.pool.query(schema);
+      // P3: run the schema (CREATE TABLE IF NOT EXISTS + migrations) with the
+      // pool-wide statement_timeout disabled for this transaction only - a
+      // migration/ALTER on a large existing DB can legitimately exceed 15s.
+      // SET LOCAL reverts when the transaction ends. The schema is
+      // transaction-safe (no CONCURRENTLY/VACUUM) and previously ran as one
+      // implicit transaction, so atomicity is unchanged.
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query('SET LOCAL statement_timeout = 0');
+        await client.query(schema);
+        await client.query('COMMIT');
+      } catch (schemaError) {
+        await client.query('ROLLBACK');
+        throw schemaError;
+      } finally {
+        client.release();
+      }
       log.info('Database schema initialized successfully', 'Database');
 
       // Load default profiles on first run

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,6 +37,29 @@ const app = express();
 // 3. 3143 (default fallback / brand port)
 const PORT = process.env.PORT || process.env.PANKHA_PORT || 3143;
 
+// Periodic heap-usage check. Warns only when heapUsed exceeds the threshold
+// (default 1024MB, tunable via MEMORY_WARN_THRESHOLD_MB) - high enough to stay
+// silent in normal operation, so a warning signals an abnormal climb (leak).
+// Emits a quiet heartbeat at debug otherwise. Unref'd so it never holds the
+// process open during shutdown.
+let memoryMonitorInterval: NodeJS.Timeout | null = null;
+
+function startMemoryMonitor(): void {
+  const thresholdMb = parseInt(process.env.MEMORY_WARN_THRESHOLD_MB || '1024', 10) || 1024;
+  memoryMonitorInterval = setInterval(() => {
+    const mem = process.memoryUsage();
+    const heapUsedMb = Math.round(mem.heapUsed / 1048576);
+    const heapTotalMb = Math.round(mem.heapTotal / 1048576);
+    const rssMb = Math.round(mem.rss / 1048576);
+    if (heapUsedMb > thresholdMb) {
+      log.warn('High heap usage (possible memory leak)', 'index', { heapUsedMb, heapTotalMb, rssMb, thresholdMb });
+    } else {
+      log.debug('Memory usage', 'index', { heapUsedMb, heapTotalMb, rssMb });
+    }
+  }, 60000);
+  memoryMonitorInterval.unref();
+}
+
 function parseCompressionThresholdBytes(value: string | undefined): number {
   if (!value) return 1024;
   const parsed = parseInt(value.trim(), 10);
@@ -300,6 +323,11 @@ app.post('/api/emergency-stop', async (req, res) => {
 process.on('SIGINT', async () => {
   log.info(' Shutting down Pankha backend...', 'index');
 
+  if (memoryMonitorInterval) {
+    clearInterval(memoryMonitorInterval);
+    memoryMonitorInterval = null;
+  }
+
   if (services) {
     try {
       services.fanProfileController.stop(); // Stop fan controller first
@@ -341,7 +369,9 @@ async function startServer() {
       log.info(` Health check: http://localhost:${PORT}/health`, 'index');
       log.info(` System overview: http://localhost:${PORT}/api/overview`, 'index');
     });
-    
+
+    startMemoryMonitor();
+
   } catch (error) {
     log.error(' Failed to start server:', 'index', error);
     process.exit(1);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -319,9 +319,12 @@ app.post('/api/emergency-stop', async (req, res) => {
   }
 });
 
-// Graceful shutdown handler
-process.on('SIGINT', async () => {
-  log.info(' Shutting down Pankha backend...', 'index');
+// Graceful shutdown - shared by SIGINT (Ctrl+C) and SIGTERM (docker stop / systemd).
+let shuttingDown = false;
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (shuttingDown) return; // ignore repeat/secondary signals once shutdown has begun
+  shuttingDown = true;
+  log.info(` Shutting down Pankha backend (${signal})...`, 'index');
 
   if (memoryMonitorInterval) {
     clearInterval(memoryMonitorInterval);
@@ -345,7 +348,10 @@ process.on('SIGINT', async () => {
   }
 
   process.exit(0);
-});
+}
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
 // Start server
 async function startServer() {

--- a/backend/src/license/LicenseValidator.ts
+++ b/backend/src/license/LicenseValidator.ts
@@ -16,6 +16,7 @@
  */
 
 import * as crypto from 'crypto';
+import { log } from '../utils/logger';
 
 /**
  * Offline grace window applied after a token's `exp`: the license stays valid
@@ -132,7 +133,7 @@ export class LicenseValidator {
    * Algorithm: ES256 (ECDSA P-256 + SHA-256)
    */
   async validate(licenseToken: string): Promise<ValidationResult> {
-    console.log(`[LicenseValidator] Validating license token...`);
+    log.debug('Validating license token', 'LicenseValidator');
 
     // ================================================================
     // OPTION C HYBRID: Uncomment to try API first, then fall back to JWT
@@ -148,7 +149,7 @@ export class LicenseValidator {
     try {
       // Check if public key is configured
       if (this.publicKey.includes('PLACEHOLDER')) {
-        console.warn('[LicenseValidator] Public key not configured yet');
+        log.warn('Public key not configured yet', 'LicenseValidator');
         return {
           valid: false,
           tier: 'free',
@@ -247,7 +248,7 @@ export class LicenseValidator {
       const expiresAt = isLifetime ? null : (payload.exp ? new Date(payload.exp * 1000) : null);
       const licenseId = payload.lid || payload.sub;
       
-      console.log(`[LicenseValidator] License valid: ${payload.tier} tier (${billing}), expires ${isLifetime ? 'LIFETIME' : expiresAt?.toISOString()}`);
+      log.info(`License valid: ${payload.tier} tier (${billing}), expires ${isLifetime ? 'LIFETIME' : expiresAt?.toISOString()}`, 'LicenseValidator');
       
       return {
         valid: true,
@@ -264,7 +265,7 @@ export class LicenseValidator {
         periodCount: payload.period_count,
       };
     } catch (error) {
-      console.error('[LicenseValidator] Validation error:', error);
+      log.error('Validation error', 'LicenseValidator', error);
       return {
         valid: false,
         tier: 'free',

--- a/backend/src/license/routes.ts
+++ b/backend/src/license/routes.ts
@@ -15,6 +15,7 @@ import { Router, Request, Response } from 'express';
 import { licenseManager } from './LicenseManager';
 import { TIERS } from './tiers';
 import { LICENSE_API_URL } from './license-config';
+import { log } from '../utils/logger';
 
 const router = Router();
 
@@ -27,7 +28,7 @@ router.get('/', async (req: Request, res: Response) => {
     const licenseInfo = await licenseManager.getLicenseInfo();
     res.json(licenseInfo);
   } catch (error) {
-    console.error('[License API] Error getting license info:', error);
+    log.error('Error getting license info', 'License API', error);
     res.status(500).json({ error: 'Failed to get license info' });
   }
 });
@@ -76,7 +77,7 @@ router.get('/pricing', async (req: Request, res: Response) => {
     };
     res.json(pricing);
   } catch (error) {
-    console.error('[License API] Error getting pricing:', error);
+    log.error('Error getting pricing', 'License API', error);
     res.status(500).json({ error: 'Failed to get pricing info' });
   }
 });
@@ -113,7 +114,7 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
   } catch (error) {
-    console.error('[License API] Error setting license:', error);
+    log.error('Error setting license', 'License API', error);
     res.status(500).json({ 
       success: false, 
       error: 'Failed to validate license' 
@@ -141,7 +142,7 @@ router.post('/sync', async (req: Request, res: Response) => {
       res.json(result);
     }
   } catch (error) {
-    console.error('[License API] Sync error:', error);
+    log.error('Sync error', 'License API', error);
     res.status(500).json({
       success: false,
       error: 'Sync failed'
@@ -171,7 +172,7 @@ router.post('/renew', async (req: Request, res: Response) => {
       res.status(status).json(result);
     }
   } catch (error) {
-    console.error('[License API] Renew error:', error);
+    log.error('Renew error', 'License API', error);
     res.status(500).json({
       success: false,
       error: 'Renew failed',
@@ -197,7 +198,7 @@ router.get('/promo', async (req: Request, res: Response) => {
     const data = await r.json();
     res.json(data);
   } catch (error) {
-    console.error('[License API] Promo proxy error:', error);
+    log.error('Promo proxy error', 'License API', error);
     res.json({ offers: [], fetchedAt: null });
   }
 });
@@ -233,7 +234,7 @@ router.post('/checkout', async (req: Request, res: Response) => {
     const data = await r.json();
     res.status(r.status).json(data);
   } catch (error) {
-    console.error('[License API] Checkout proxy error:', error);
+    log.error('Checkout proxy error', 'License API', error);
     res.status(502).json({
       ok: false,
       error: 'dodo_error',
@@ -263,7 +264,7 @@ router.delete('/', async (req: Request, res: Response) => {
       });
     }
   } catch (error) {
-    console.error('[License API] Error removing license:', error);
+    log.error('Error removing license', 'License API', error);
     res.status(500).json({ 
       success: false, 
       error: 'Failed to remove license' 

--- a/backend/src/services/DataAggregator.ts
+++ b/backend/src/services/DataAggregator.ts
@@ -361,7 +361,9 @@ export class DataAggregator extends EventEmitter {
    */
   private async bufferDataPoints(
     systemId: number,
-    data: AgentDataPacket
+    data: AgentDataPacket,
+    sensorIdByName?: Map<string, number>,
+    fanIdByName?: Map<string, number>
   ): Promise<void> {
     const timestamp = new Date(data.timestamp);
 
@@ -376,43 +378,50 @@ export class DataAggregator extends EventEmitter {
 
     const buffer = this.dataBuffer.get(systemId)!;
 
-    // Buffer sensor data points
+    // Buffer sensor data points. Reuse the DB id resolved during enrichment when
+    // the caller supplies it; only query for ids not supplied (e.g. a sensor
+    // seen for the first time this push, created just above by ensureSensorsExist,
+    // or any caller that passes no map - same query path as before).
     for (const sensor of data.sensors) {
-      const sensorRecord = await this.db.get(
-        "SELECT id FROM sensors WHERE system_id = $1 AND sensor_name = $2",
-        [systemId, sensor.id]
-      );
-
-      if (sensorRecord) {
-        if (!buffer.sensors.has(sensorRecord.id)) {
-          buffer.sensors.set(sensorRecord.id, []);
-        }
-
-        buffer.sensors.get(sensorRecord.id)!.push({
-          temperature: sensor.temperature,
-          timestamp: timestamp,
-        });
+      let sensorId = sensorIdByName?.get(sensor.id);
+      if (sensorId === undefined) {
+        const sensorRecord = await this.db.get(
+          "SELECT id FROM sensors WHERE system_id = $1 AND sensor_name = $2",
+          [systemId, sensor.id]
+        );
+        if (!sensorRecord) continue;
+        sensorId = sensorRecord.id as number;
       }
+
+      if (!buffer.sensors.has(sensorId)) {
+        buffer.sensors.set(sensorId, []);
+      }
+      buffer.sensors.get(sensorId)!.push({
+        temperature: sensor.temperature,
+        timestamp: timestamp,
+      });
     }
 
-    // Buffer fan data points
+    // Buffer fan data points (same id-reuse-with-query-fallback strategy).
     for (const fan of data.fans) {
-      const fanRecord = await this.db.get(
-        "SELECT id FROM fans WHERE system_id = $1 AND fan_name = $2",
-        [systemId, fan.id]
-      );
-
-      if (fanRecord) {
-        if (!buffer.fans.has(fanRecord.id)) {
-          buffer.fans.set(fanRecord.id, []);
-        }
-
-        buffer.fans.get(fanRecord.id)!.push({
-          speed: fan.speed,
-          rpm: fan.rpm,
-          timestamp: timestamp,
-        });
+      let fanId = fanIdByName?.get(fan.id);
+      if (fanId === undefined) {
+        const fanRecord = await this.db.get(
+          "SELECT id FROM fans WHERE system_id = $1 AND fan_name = $2",
+          [systemId, fan.id]
+        );
+        if (!fanRecord) continue;
+        fanId = fanRecord.id as number;
       }
+
+      if (!buffer.fans.has(fanId)) {
+        buffer.fans.set(fanId, []);
+      }
+      buffer.fans.get(fanId)!.push({
+        speed: fan.speed,
+        rpm: fan.rpm,
+        timestamp: timestamp,
+      });
     }
   }
 
@@ -821,6 +830,21 @@ export class DataAggregator extends EventEmitter {
       // Enrich with database information (adds dbId, isHidden flag to sensors)
       await this.enrichAggregatedData(aggregatedData);
 
+      // Reuse the sensor/fan DB ids enrichment just resolved so bufferDataPoints
+      // does not re-query for the same ids. Sensors/fans appearing for the first
+      // time this push are absent here (enrichment runs before ensureSensorsExist)
+      // and fall back to a query inside bufferDataPoints. Ids are stable within a
+      // push (ensure*Exist only upserts, never deletes), so a reused id cannot go
+      // stale mid-cycle.
+      const sensorIdByName = new Map<string, number>();
+      for (const s of aggregatedData.sensors) {
+        if (s.dbId !== undefined) sensorIdByName.set(s.id, s.dbId);
+      }
+      const fanIdByName = new Map<string, number>();
+      for (const f of aggregatedData.fans) {
+        if (f.dbId !== undefined) fanIdByName.set(f.id, f.dbId);
+      }
+
       this.aggregatedData.set(agentId, aggregatedData);
       log.debug(`Updated aggregated data`, "DataAggregator", {
         agentId,
@@ -835,7 +859,7 @@ export class DataAggregator extends EventEmitter {
         await this.ensureFansExist(system.id, dataPacket.fans);
 
         // Buffer data points for aggregation (raw data still sent to dashboard)
-        await this.bufferDataPoints(system.id, dataPacket);
+        await this.bufferDataPoints(system.id, dataPacket, sensorIdByName, fanIdByName);
 
         // Update current sensor readings
         await this.updateSensorReadings(system.id, dataPacket.sensors);

--- a/backend/src/services/DownsamplingService.ts
+++ b/backend/src/services/DownsamplingService.ts
@@ -173,6 +173,11 @@ export class DownsamplingService extends EventEmitter {
       // - Newer than 30 days (Tier 3 will handle those)
       // - Not already downsampled (we use a simple heuristic: if there's
       //   already a row at the 5-min boundary, skip)
+      // P3: exempt this maintenance txn from the pool-wide statement_timeout -
+      // the GROUP BY aggregation + bulk DELETE over the history table can run
+      // long at scale. SET LOCAL reverts when the txn ends, so the pooled
+      // connection's normal timeout is intact afterward.
+      await client.query("SET LOCAL statement_timeout = 0");
       const result = await client.query(`
         WITH time_buckets AS (
           SELECT 
@@ -232,10 +237,13 @@ export class DownsamplingService extends EventEmitter {
    */
   private async downsampleTier3(): Promise<{ processed: number; created: number }> {
     const client = await this.pool.connect();
-    
+
     try {
       await client.query("BEGIN");
-      
+      // P3: exempt this maintenance txn from the pool-wide statement_timeout
+      // (see downsampleTier2). SET LOCAL reverts when the txn ends.
+      await client.query("SET LOCAL statement_timeout = 0");
+
       const result = await client.query(`
         WITH time_buckets AS (
           SELECT 
@@ -290,11 +298,25 @@ export class DownsamplingService extends EventEmitter {
    * Retention days come from license tier (SST)
    */
   private async cleanupExpiredData(retentionDays: number): Promise<number> {
-    const result = await this.pool.query(`
-      DELETE FROM monitoring_data
-      WHERE "timestamp" < NOW() - INTERVAL '${retentionDays} days'
-    `);
-    
-    return result.rowCount || 0;
+    // P3: run the retention DELETE in its own txn with the pool-wide
+    // statement_timeout disabled - on a large history table this can run long.
+    // A bare pool.query() can't scope SET LOCAL, so we take a client. SET LOCAL
+    // reverts when the txn ends, leaving the pooled connection's timeout intact.
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SET LOCAL statement_timeout = 0");
+      const result = await client.query(`
+        DELETE FROM monitoring_data
+        WHERE "timestamp" < NOW() - INTERVAL '${retentionDays} days'
+      `);
+      await client.query("COMMIT");
+      return result.rowCount || 0;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 }

--- a/backend/src/services/DownsamplingService.ts
+++ b/backend/src/services/DownsamplingService.ts
@@ -173,9 +173,9 @@ export class DownsamplingService extends EventEmitter {
       // - Newer than 30 days (Tier 3 will handle those)
       // - Not already downsampled (we use a simple heuristic: if there's
       //   already a row at the 5-min boundary, skip)
-      // P3: exempt this maintenance txn from the pool-wide statement_timeout -
-      // the GROUP BY aggregation + bulk DELETE over the history table can run
-      // long at scale. SET LOCAL reverts when the txn ends, so the pooled
+      // Exempt this maintenance txn from the pool-wide statement_timeout - the
+      // GROUP BY aggregation + bulk DELETE over the history table can run long
+      // at scale. SET LOCAL reverts when the txn ends, so the pooled
       // connection's normal timeout is intact afterward.
       await client.query("SET LOCAL statement_timeout = 0");
       const result = await client.query(`
@@ -240,7 +240,7 @@ export class DownsamplingService extends EventEmitter {
 
     try {
       await client.query("BEGIN");
-      // P3: exempt this maintenance txn from the pool-wide statement_timeout
+      // Exempt this maintenance txn from the pool-wide statement_timeout
       // (see downsampleTier2). SET LOCAL reverts when the txn ends.
       await client.query("SET LOCAL statement_timeout = 0");
 
@@ -298,7 +298,7 @@ export class DownsamplingService extends EventEmitter {
    * Retention days come from license tier (SST)
    */
   private async cleanupExpiredData(retentionDays: number): Promise<number> {
-    // P3: run the retention DELETE in its own txn with the pool-wide
+    // Run the retention DELETE in its own txn with the pool-wide
     // statement_timeout disabled - on a large history table this can run long.
     // A bare pool.query() can't scope SET LOCAL, so we take a client. SET LOCAL
     // reverts when the txn ends, leaving the pooled connection's timeout intact.

--- a/backend/src/services/FanProfileController.ts
+++ b/backend/src/services/FanProfileController.ts
@@ -48,7 +48,7 @@ export class FanProfileController {
   private updateInterval: number = 2000; // Default 2 seconds
   private isRunning: boolean = false;
   private intervalTimer: NodeJS.Timeout | null = null;
-  private loopRunning: boolean = false; // P1: overlap guard for controlLoop()
+  private loopRunning: boolean = false; // prevents overlapping controlLoop() ticks
   private consecutiveErrors: number = 0;
   private maxConsecutiveErrors: number = 5;
 
@@ -363,9 +363,9 @@ export class FanProfileController {
    * Main control loop - runs every updateInterval milliseconds
    */
   private async controlLoop(): Promise<void> {
-    // P1: overlap guard - never start a new tick while the previous one is
-    // still running. Stops control loops stacking (and saturating the DB pool
-    // and the single event loop) once a tick exceeds the interval under load.
+    // Never start a new tick while the previous one is still running - once a
+    // tick exceeds the interval under load, overlapping loops would stack and
+    // saturate the DB pool and the single event loop.
     if (this.loopRunning) {
       log.trace('control loop still running, skipping tick', 'FanProfileController');
       return;
@@ -380,9 +380,9 @@ export class FanProfileController {
         return;
       }
 
-      // P2: batch-fetch curve points for every assigned profile in ONE query
-      // instead of one query per assignment (was an N+1: ~one query per fan
-      // each tick). Rebuilt fresh every tick, so there is no cache to invalidate.
+      // Fetch curve points for every assigned profile in one query rather than
+      // one query per assignment (the old N+1: ~one query per fan each tick).
+      // Rebuilt fresh every tick, so there is no cache to invalidate.
       const profileIds = [...new Set(assignments.map(a => a.profile_id))];
       const curvesByProfile = new Map<number, CurvePoint[]>();
       try {
@@ -556,7 +556,7 @@ export class FanProfileController {
         this.stop();
       }
     } finally {
-      // P1: always release the guard, even on throw, so a failed tick can never
+      // Always release the guard, even on throw, so a failed tick can never
       // freeze fan control permanently.
       this.loopRunning = false;
     }

--- a/backend/src/services/FanProfileController.ts
+++ b/backend/src/services/FanProfileController.ts
@@ -367,7 +367,7 @@ export class FanProfileController {
     // tick exceeds the interval under load, overlapping loops would stack and
     // saturate the DB pool and the single event loop.
     if (this.loopRunning) {
-      log.trace('control loop still running, skipping tick', 'FanProfileController');
+      log.trace('Control loop still running, skipping tick', 'FanProfileController');
       return;
     }
     this.loopRunning = true;

--- a/backend/src/services/FanProfileController.ts
+++ b/backend/src/services/FanProfileController.ts
@@ -48,6 +48,7 @@ export class FanProfileController {
   private updateInterval: number = 2000; // Default 2 seconds
   private isRunning: boolean = false;
   private intervalTimer: NodeJS.Timeout | null = null;
+  private loopRunning: boolean = false; // P1: overlap guard for controlLoop()
   private consecutiveErrors: number = 0;
   private maxConsecutiveErrors: number = 5;
 
@@ -230,25 +231,6 @@ export class FanProfileController {
   }
 
   /**
-   * Get fan profile curve points
-   */
-  private async getProfileCurvePoints(profileId: number): Promise<CurvePoint[]> {
-    try {
-      const points = await this.db.all(`
-        SELECT temperature, fan_speed
-        FROM fan_curve_points
-        WHERE profile_id = $1
-        ORDER BY point_order ASC
-      `, [profileId]);
-
-      return points;
-    } catch (error) {
-      log.error(`Error fetching curve points for profile ${profileId}`, 'FanProfileController', error);
-      return [];
-    }
-  }
-
-  /**
    * Send fan speed command to agent
    */
   private async sendFanSpeedCommand(
@@ -381,6 +363,14 @@ export class FanProfileController {
    * Main control loop - runs every updateInterval milliseconds
    */
   private async controlLoop(): Promise<void> {
+    // P1: overlap guard - never start a new tick while the previous one is
+    // still running. Stops control loops stacking (and saturating the DB pool
+    // and the single event loop) once a tick exceeds the interval under load.
+    if (this.loopRunning) {
+      log.trace('control loop still running, skipping tick', 'FanProfileController');
+      return;
+    }
+    this.loopRunning = true;
     try {
       // Get all active fan profile assignments
       const assignments = await this.getActiveFanAssignments();
@@ -388,6 +378,35 @@ export class FanProfileController {
       if (assignments.length === 0) {
         // No active assignments, nothing to do
         return;
+      }
+
+      // P2: batch-fetch curve points for every assigned profile in ONE query
+      // instead of one query per assignment (was an N+1: ~one query per fan
+      // each tick). Rebuilt fresh every tick, so there is no cache to invalidate.
+      const profileIds = [...new Set(assignments.map(a => a.profile_id))];
+      const curvesByProfile = new Map<number, CurvePoint[]>();
+      try {
+        const rows = await this.db.all(`
+          SELECT profile_id, temperature, fan_speed
+          FROM fan_curve_points
+          WHERE profile_id = ANY($1)
+          ORDER BY point_order ASC
+        `, [profileIds]);
+        for (const row of rows) {
+          let points = curvesByProfile.get(row.profile_id);
+          if (!points) {
+            points = [];
+            curvesByProfile.set(row.profile_id, points);
+          }
+          points.push({ temperature: row.temperature, fan_speed: row.fan_speed });
+        }
+      } catch (error) {
+        // On failure leave the map empty: each assignment then hits the existing
+        // "no curve points -> skip with warning" path and fans hold their last
+        // speed, self-healing next tick. Deliberately NOT falling back to
+        // per-assignment queries - that would refire the N+1 into an
+        // already-stressed pool.
+        log.error('Error batch-fetching curve points', 'FanProfileController', error);
       }
 
       // Zone deduplication: when multiple fans share a zone_id, only process once per zone.
@@ -450,8 +469,8 @@ export class FanProfileController {
           }
           this.sensorAvailabilityState.set(stateKey, true);
 
-          // Get fan profile curve points
-          const curvePoints = await this.getProfileCurvePoints(assignment.profile_id);
+          // Get fan profile curve points (from the per-tick batch fetched above)
+          const curvePoints = curvesByProfile.get(assignment.profile_id) ?? [];
 
           if (curvePoints.length === 0) {
             log.warn(
@@ -536,6 +555,10 @@ export class FanProfileController {
         );
         this.stop();
       }
+    } finally {
+      // P1: always release the guard, even on throw, so a failed tick can never
+      // freeze fan control permanently.
+      this.loopRunning = false;
     }
   }
 

--- a/backend/src/services/FanProfileManager.ts
+++ b/backend/src/services/FanProfileManager.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
 import Database from '../database/database';
 import { log } from '../utils/logger';
 import {
@@ -523,9 +525,6 @@ export class FanProfileManager extends EventEmitter {
     exists_in_db: boolean;
   }>> {
     try {
-      const fs = await import('fs');
-      const path = await import('path');
-      
       // Path to defaults file (in backend/src/config, copied to backend/config in Docker)
       const defaultsPath = path.resolve(__dirname, '../config/fan-profiles-defaults.json');
       
@@ -567,9 +566,6 @@ export class FanProfileManager extends EventEmitter {
     resolve_conflicts: 'skip' | 'rename' | 'overwrite';
   }): Promise<ImportResult> {
     try {
-      const fs = await import('fs');
-      const path = await import('path');
-      
       // Path to defaults file (in backend/src/config, copied to backend/config in Docker)
       const defaultsPath = path.resolve(__dirname, '../config/fan-profiles-defaults.json');
       

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -6,6 +6,7 @@ import { AgentManager } from "./AgentManager";
 import { CommandDispatcher } from "./CommandDispatcher";
 import { AgentCommunication } from "./AgentCommunication";
 import { DeltaComputer } from "./DeltaComputer";
+import Database from "../database/database";
 import type { AggregatedSystemData } from "../types/aggregatedData";
 import { licenseManager } from "../license";
 import { log } from "../utils/logger";
@@ -345,7 +346,6 @@ export class WebSocketHub extends EventEmitter {
         } else {
           this.agentManager.markAgentOffline(agentId);
 
-          const Database = (await import("../database/database")).default;
           const db = Database.getInstance();
           const presenceHeartbeatSeconds = Math.max(
             5,
@@ -647,7 +647,6 @@ export class WebSocketHub extends EventEmitter {
         );
 
         // Load saved configuration from database
-        const Database = (await import("../database/database")).default;
         const db = Database.getInstance();
         const system = await db.get(
           "SELECT config_data FROM systems WHERE agent_id = $1",

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -49,6 +49,11 @@ export class WebSocketHub extends EventEmitter {
   private static instance: WebSocketHub;
   private wss: WebSocketServer | null = null;
   private clients: Map<string, ClientConnection> = new Map();
+  // Reverse lookup of subscription -> subscribed clientIds, so broadcast() can
+  // reach a channel's subscribers without scanning every connection. Mirrors
+  // the per-client `subscriptions` Sets; keep them in sync only through
+  // add/removeClientSubscription and removeClientFromIndex.
+  private subscriptionIndex: Map<string, Set<string>> = new Map();
   private dataAggregator: DataAggregator;
   private agentManager: AgentManager;
   private commandDispatcher: CommandDispatcher;
@@ -387,6 +392,7 @@ export class WebSocketHub extends EventEmitter {
         log.info(` Frontend client disconnected: ${clientId}`, "WebSocketHub");
       }
 
+      this.removeClientFromIndex(client); // before removing the client itself
       this.clients.delete(clientId);
       this.emit("clientDisconnected", { clientId, client });
     }
@@ -561,7 +567,7 @@ export class WebSocketHub extends EventEmitter {
     if (!client) return;
 
     for (const subscription of subscriptions) {
-      client.subscriptions.add(subscription);
+      this.addClientSubscription(client, subscription);
     }
 
     log.info(
@@ -847,7 +853,7 @@ export class WebSocketHub extends EventEmitter {
     if (!client) return;
 
     for (const subscription of subscriptions) {
-      client.subscriptions.delete(subscription);
+      this.removeClientSubscription(client, subscription);
     }
 
     log.info(
@@ -1043,8 +1049,49 @@ export class WebSocketHub extends EventEmitter {
     }
   }
 
+  // The only places a client's subscriptions are mutated. Each updates the
+  // per-client Set and `subscriptionIndex` together so they stay consistent;
+  // route any new (un)subscribe path through these rather than touching
+  // `client.subscriptions` directly.
+
+  /** Add one subscription for a client, mirroring it into the index. */
+  private addClientSubscription(client: ClientConnection, subscription: string): void {
+    client.subscriptions.add(subscription);
+    let ids = this.subscriptionIndex.get(subscription);
+    if (!ids) {
+      ids = new Set();
+      this.subscriptionIndex.set(subscription, ids);
+    }
+    ids.add(client.id);
+  }
+
+  /** Remove one subscription for a client, mirroring it into the index. */
+  private removeClientSubscription(client: ClientConnection, subscription: string): void {
+    client.subscriptions.delete(subscription);
+    const ids = this.subscriptionIndex.get(subscription);
+    if (ids) {
+      ids.delete(client.id);
+      if (ids.size === 0) this.subscriptionIndex.delete(subscription); // drop empty channels (dynamic system:<id> ones accumulate otherwise)
+    }
+  }
+
+  /** Remove a client from every subscription set it belonged to (on disconnect). */
+  private removeClientFromIndex(client: ClientConnection): void {
+    for (const subscription of client.subscriptions) {
+      const ids = this.subscriptionIndex.get(subscription);
+      if (ids) {
+        ids.delete(client.id);
+        if (ids.size === 0) this.subscriptionIndex.delete(subscription);
+      }
+    }
+  }
+
   /**
-   * Broadcast message to all subscribed clients
+   * Broadcast a message to every client subscribed to any of the given
+   * channels. Recipient ids are resolved through `subscriptionIndex` and
+   * unioned into a Set, so a client subscribed to several of the target
+   * channels still receives a single copy. Each recipient is re-checked for an
+   * open socket, so a stale index entry is harmless.
    */
   private broadcast(type: string, data: any, subscriptions: string[]): void {
     const message = {
@@ -1056,27 +1103,30 @@ export class WebSocketHub extends EventEmitter {
     const messageStr = JSON.stringify(message);
     let sentCount = 0;
 
-    for (const [clientId, client] of this.clients.entries()) {
-      if (client.websocket.readyState !== WebSocket.OPEN) {
+    // Union the clientIds across all target subscriptions (dedup => one send each).
+    const recipientIds = new Set<string>();
+    for (const subscription of subscriptions) {
+      const ids = this.subscriptionIndex.get(subscription);
+      if (ids) {
+        for (const id of ids) recipientIds.add(id);
+      }
+    }
+
+    for (const clientId of recipientIds) {
+      const client = this.clients.get(clientId);
+      // Skip vanished or closing connections (stale index entries are harmless).
+      if (!client || client.websocket.readyState !== WebSocket.OPEN) {
         continue;
       }
-
-      // Check if client is subscribed to any of the relevant subscriptions
-      const isSubscribed = subscriptions.some((sub) =>
-        client.subscriptions.has(sub)
-      );
-
-      if (isSubscribed) {
-        try {
-          client.websocket.send(messageStr);
-          sentCount++;
-        } catch (error) {
-          log.error(
-            `Error broadcasting to client ${clientId}`,
-            "WebSocketHub",
-            error
-          );
-        }
+      try {
+        client.websocket.send(messageStr);
+        sentCount++;
+      } catch (error) {
+        log.error(
+          `Error broadcasting to client ${clientId}`,
+          "WebSocketHub",
+          error
+        );
       }
     }
 
@@ -1352,6 +1402,7 @@ export class WebSocketHub extends EventEmitter {
     }
 
     this.clients.clear();
+    this.subscriptionIndex.clear();
 
     if (this.wss) {
       this.wss.close();


### PR DESCRIPTION
## What this does

Fan profile and control-sensor changes were taking minutes to actually reach agents once more than a handful were connected. This makes those changes land in seconds again, and tightens the backend so it stays responsive as the fleet grows.

## Why it was slow

The fan-control loop re-queried every fan's curve from the database on each pass, and nothing stopped a slow pass from stacking on top of the next one. At ~20 agents that meant ~100 redundant queries every few seconds, which backed up the database connection pool and delayed whichever fan was processed last - sometimes by minutes.

## What changed

- The control loop now fetches all the curve data it needs in a single query per pass, and skips a pass if the previous one is still running.
- WebSocket broadcasts go directly to the clients subscribed to a topic instead of scanning every open connection - this is what keeps it fast as agent count climbs.
- Smaller hardening: a database query timeout so one stuck query can't hold a connection, graceful shutdown on `docker stop`, and lightweight pool/memory warnings so saturation shows up in the logs early.

## Scope

No API, database schema, or WebSocket message changes - same behavior, just faster and steadier under load. Verified against a 20-agent setup; profile changes now apply in seconds.

Closes #49