### PR TITLE
feat: menus rework

### DIFF
--- a/backend/src/routes/systems.ts
+++ b/backend/src/routes/systems.ts
@@ -1834,6 +1834,7 @@ const ALLOWED_SETTINGS = [
   'hardware_prune_days',
   'ui_font_primary',
   'ui_font_secondary',
+  'ui_font_scale',
   'hub_log_level',
 ] as const;
 

--- a/frontend/src/components/ControllerIntervalSelector.tsx
+++ b/frontend/src/components/ControllerIntervalSelector.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { getControllerStatus, setControllerInterval } from '../services/api';
 import { toast } from '../utils/toast';
 import { Loader2 } from 'lucide-react';
+import { Select } from './ui/Select';
+import type { SelectOption } from './ui/Select';
 
 interface ControllerIntervalOption {
   value: number;
@@ -17,6 +19,10 @@ const controllerIntervalOptions: ControllerIntervalOption[] = [
   { value: 5000, label: 'Slow (5s)', icon: 'clock' },
   { value: 10000, label: 'Very Slow (10s)', icon: 'history' }
 ];
+
+const selectOptions: SelectOption<number>[] = controllerIntervalOptions.map(
+  (option) => ({ value: option.value, label: option.label })
+);
 
 const ControllerIntervalSelector: React.FC = () => {
   const [currentInterval, setCurrentInterval] = useState<number>(2000); // Default 2s
@@ -35,9 +41,7 @@ const ControllerIntervalSelector: React.FC = () => {
     fetchStatus();
   }, []);
 
-  const handleIntervalChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const newInterval = parseInt(event.target.value);
-
+  const handleIntervalChange = async (newInterval: number) => {
     setLoading(true);
     try {
       await setControllerInterval(newInterval);
@@ -59,20 +63,15 @@ const ControllerIntervalSelector: React.FC = () => {
       <label htmlFor="controller-interval" className="controller-interval-label">
         System Responsiveness (CPU Load)
       </label>
-      <select
+      <Select
         id="controller-interval"
-        className="controller-interval-dropdown"
         value={currentInterval}
         onChange={handleIntervalChange}
+        options={selectOptions}
         disabled={loading}
-        aria-label="Select system responsiveness"
-      >
-        {controllerIntervalOptions.map(option => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+        width={180}
+        ariaLabel="Select system responsiveness"
+      />
       {loading && <Loader2 className="animate-spin" size={14} />}
     </div>
   );

--- a/frontend/src/components/ui/Select.css
+++ b/frontend/src/components/ui/Select.css
@@ -1,0 +1,298 @@
+/* Select (Design1) - in-house dropdown. Tokens only; light/dark via existing
+ * semantic vars. Class namespace pk-select-* (distinct from Design0's
+ * .select-engine / .select-display so both coexist during migration). */
+
+/* ---- Trigger (closed state) ---- */
+
+.pk-select-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  padding-right: 24px; /* room for the chevron (matches Design0 .select-display) */
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Chevron - same masked svg as Design0 (forms.css .stealth-select-wrapper::after) */
+.pk-select-trigger::after {
+  content: "";
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 6px;
+  background-color: var(--text-primary);
+  opacity: 0.6;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1L5 5L9 1' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat center;
+  mask-size: contain;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1L5 5L9 1' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat center;
+  -webkit-mask-size: contain;
+  pointer-events: none;
+  transition: all 0.2s ease;
+}
+
+/* Hover - Design0's accent treatment (forms.css stealth-select hover) */
+.pk-select-trigger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-hover-tint-dynamic) 8%, var(--bg-secondary));
+  border-color: var(--color-accent-dynamic);
+}
+
+.pk-select-trigger:hover:not(:disabled)::after {
+  opacity: 1;
+  background-color: var(--color-accent-dynamic);
+}
+
+/* Focus ring - same tokens as Design0 (.select-engine:focus) */
+.pk-select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-accent-dynamic);
+  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+}
+
+/* Accent ring while open, mouse or keyboard (Design0 engine-focus parity) */
+.pk-select-trigger[aria-expanded="true"] {
+  border-color: var(--color-accent-dynamic);
+  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+}
+
+.pk-select-trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pk-select-value {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.pk-select-placeholder {
+  color: var(--text-tertiary);
+}
+
+/* ---- Menu (desktop popover, open state) ---- */
+
+.pk-select-menu {
+  position: fixed;
+  z-index: 2100; /* above bulk-edit panel (2001) so a Select works inside it */
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 40px rgba(0, 0, 15, 0.35), 0 0 20px rgba(0, 0, 0, 0.2);
+  animation: pk-select-in 0.12s ease-out;
+}
+
+@keyframes pk-select-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Search input (searchable menus) - above the list */
+.pk-select-search {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.pk-select-search-icon {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.pk-select-search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  padding: 2px 0;
+}
+
+.pk-select-search-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.pk-select-empty {
+  padding: var(--spacing-sm);
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  user-select: none;
+}
+
+.pk-select-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--spacing-xs);
+  overflow-y: auto;
+  overscroll-behavior: contain; /* menu scroll must not chain to the page */
+  min-height: 0; /* let the sheet's flex column actually shrink the list */
+}
+
+/* Group headers - "bands + rail" design; rationale + rejected variants in
+ * task_12 taskfile. Text stays --text-primary (accent = selected/interactive) */
+.pk-select-group-label {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  /* Full bleed across the list's inner padding */
+  margin: var(--spacing-sm) calc(-1 * var(--spacing-xs)) 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  user-select: none;
+}
+
+/* No dead air at the very top of the list */
+.pk-select-group-label:first-child {
+  margin-top: calc(-1 * var(--spacing-xs));
+}
+
+.pk-select-option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Group rail - --border-light (--border-color = --bg-tertiary and vanishes);
+ * square left corners so hover/selection backgrounds meet the rail */
+.pk-select-option.in-group {
+  margin-left: var(--spacing-sm);
+  border-left: 1px solid var(--border-light);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.pk-select-option.active {
+  background: var(--bg-hover);
+}
+
+/* Selected row - accent left bar (inset shadow: no layout shift) + accent
+ * check; text stays full-contrast (accent text was hard to read) */
+.pk-select-option.selected {
+  box-shadow: inset 3px 0 0 0 var(--color-accent-dynamic);
+  /* square left corners so the bar isn't clipped by the radius */
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.pk-select-option.selected .pk-select-check {
+  color: var(--color-accent-dynamic);
+}
+
+.pk-select-option.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pk-select-check {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* ---- Mobile bottom sheet (open state, <768px) ---- */
+
+.pk-select-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2099;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+/* Mirrors the bulk-edit mobile sheet look; own classes, no feature coupling */
+.pk-select-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2100;
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  padding-bottom: env(safe-area-inset-bottom);
+  box-shadow: 0 -10px 40px rgba(0, 0, 15, 0.5);
+  animation: pk-select-sheet-up 0.35s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+@keyframes pk-select-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.pk-select-sheet .pk-select-list {
+  padding: var(--spacing-sm);
+}
+
+/* Thumb-friendly tap targets on mobile */
+.pk-select-sheet .pk-select-option {
+  min-height: 44px;
+}
+
+.pk-select-sheet .pk-select-search {
+  padding: var(--spacing-sm);
+}
+
+/* Sheet list pads wider (spacing-sm) - keep the band full-bleed */
+.pk-select-sheet .pk-select-group-label {
+  margin-left: calc(-1 * var(--spacing-sm));
+  margin-right: calc(-1 * var(--spacing-sm));
+  padding-left: var(--spacing-md, 12px);
+}
+
+.pk-select-sheet .pk-select-search-input {
+  min-height: 32px;
+}
+
+/* ---- Accessibility ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .pk-select-menu,
+  .pk-select-sheet {
+    animation: none;
+  }
+  .pk-select-trigger,
+  .pk-select-trigger::after {
+    transition: none;
+  }
+}

--- a/frontend/src/components/ui/Select.css
+++ b/frontend/src/components/ui/Select.css
@@ -1,6 +1,5 @@
 /* Select (Design1) - in-house dropdown. Tokens only; light/dark via existing
- * semantic vars. Class namespace pk-select-* (distinct from Design0's
- * .select-engine / .select-display so both coexist during migration). */
+ * semantic vars. Class namespace pk-select-*. */
 
 /* ---- Trigger (closed state) ---- */
 
@@ -10,7 +9,7 @@
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-sm);
-  padding-right: 24px; /* room for the chevron (matches Design0 .select-display) */
+  padding-right: 24px; /* room for the chevron */
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
@@ -22,7 +21,7 @@
   transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
-/* Chevron - same masked svg as Design0 (forms.css .stealth-select-wrapper::after) */
+/* Chevron - Design0's masked svg, preserved verbatim */
 .pk-select-trigger::after {
   content: "";
   position: absolute;
@@ -52,7 +51,7 @@
   background-color: var(--color-accent-dynamic);
 }
 
-/* Focus ring - same tokens as Design0 (.select-engine:focus) */
+/* Focus ring - Design0's tokens */
 .pk-select-trigger:focus-visible {
   outline: none;
   border-color: var(--color-accent-dynamic);

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -40,6 +40,7 @@ export interface SelectProps<V extends string | number = string> {
   menuMaxHeight?: number; // px; list scrolls past this (default 320)
   searchable?: boolean; // built-in filter input at the top of the menu
   align?: 'start' | 'end'; // menu edge alignment (default 'start')
+  menuClassName?: string; // extra class on the menu / sheet container
 
   // ---- double-representation (omit for a plain dropdown) ----
   renderTrigger?: (selected: SelectOption<V> | null) => React.ReactNode;
@@ -86,6 +87,7 @@ export function Select<V extends string | number = string>(props: SelectProps<V>
     menuMaxHeight = 320,
     searchable,
     align = 'start',
+    menuClassName,
     renderTrigger,
     renderOption,
   } = props;
@@ -536,7 +538,11 @@ export function Select<V extends string | number = string>(props: SelectProps<V>
       {open &&
         !isMobile &&
         createPortal(
-          <div ref={menuRef} className="pk-select-menu" style={menuStyle}>
+          <div
+            ref={menuRef}
+            className={menuClassName ? `pk-select-menu ${menuClassName}` : 'pk-select-menu'}
+            style={menuStyle}
+          >
             {searchBox}
             {list}
           </div>,
@@ -547,7 +553,11 @@ export function Select<V extends string | number = string>(props: SelectProps<V>
         isMobile &&
         createPortal(
           <div className="pk-select-backdrop">
-            <div ref={menuRef} className="pk-select-sheet" style={sheetStyle}>
+            <div
+              ref={menuRef}
+              className={menuClassName ? `pk-select-sheet ${menuClassName}` : 'pk-select-sheet'}
+              style={sheetStyle}
+            >
               {searchBox}
               {list}
             </div>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,559 @@
+import React, { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, Search } from 'lucide-react';
+import './Select.css';
+
+/**
+ * Select (Design1) - in-house dropdown replacing every native <select>.
+ * Own menu DOM (portal): below/above placement, scroll-lock, Esc consumed,
+ * type-ahead, optional search; desktop popover / mobile bottom sheet.
+ * Plain by default; renderTrigger/renderOption for rich content.
+ * Full spec: pankha-dev task_12_dropdown-menu-rework.md
+ */
+
+export interface SelectOption<V extends string | number = string> {
+  value: V;
+  label: string; // a11y name + type-ahead target + default render text
+  disabled?: boolean;
+  title?: string; // hover tooltip (replaces <option title>)
+  data?: unknown; // arbitrary payload for renderOption/renderTrigger
+}
+
+export interface SelectGroup<V extends string | number = string> {
+  label: string;
+  options: SelectOption<V>[];
+}
+
+export interface SelectProps<V extends string | number = string> {
+  value: V | null;
+  onChange: (value: V) => void;
+  options: SelectOption<V>[] | SelectGroup<V>[]; // flat OR grouped
+
+  id?: string; // lets <label htmlFor> target the trigger (native parity)
+  placeholder?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  className?: string;
+
+  // ---- presentation (length / breadth / width / contents) ----
+  width?: number | string; // trigger + menu width
+  menuMaxHeight?: number; // px; list scrolls past this (default 320)
+  searchable?: boolean; // built-in filter input at the top of the menu
+  align?: 'start' | 'end'; // menu edge alignment (default 'start')
+
+  // ---- double-representation (omit for a plain dropdown) ----
+  renderTrigger?: (selected: SelectOption<V> | null) => React.ReactNode;
+  renderOption?: (
+    opt: SelectOption<V>,
+    state: { active: boolean; selected: boolean }
+  ) => React.ReactNode;
+}
+
+type Row<V extends string | number> =
+  | { kind: 'group'; label: string }
+  // grouped/groupFirst/groupLast let the CSS draw group chrome (rail etc.)
+  | {
+      kind: 'option';
+      opt: SelectOption<V>;
+      index: number;
+      grouped: boolean;
+      groupFirst: boolean;
+      groupLast: boolean;
+    };
+
+function isGrouped<V extends string | number>(
+  options: SelectOption<V>[] | SelectGroup<V>[]
+): options is SelectGroup<V>[] {
+  return options.length > 0 && 'options' in options[0];
+}
+
+const MOBILE_BREAKPOINT = 768; // matches useContextualPanel
+const TYPEAHEAD_RESET_MS = 700;
+const MENU_GAP = 4; // px between trigger and menu
+const VIEWPORT_EDGE = 8; // px min distance from viewport edges
+
+export function Select<V extends string | number = string>(props: SelectProps<V>) {
+  const {
+    value,
+    onChange,
+    options,
+    id,
+    placeholder,
+    disabled,
+    ariaLabel,
+    className,
+    width,
+    menuMaxHeight = 320,
+    searchable,
+    align = 'start',
+    renderTrigger,
+    renderOption,
+  } = props;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [query, setQuery] = useState('');
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < MOBILE_BREAKPOINT);
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>();
+  // Mobile: lift + grow the sheet while the on-screen keyboard is up.
+  const [sheetStyle, setSheetStyle] = useState<React.CSSProperties>();
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const typeaheadRef = useRef({ buffer: '', time: 0 });
+  const listboxId = useId();
+
+  // Normalize flat|grouped options, apply search filter, flatten for
+  // keyboard nav; emptied groups drop their header too.
+  const { rows, flat } = useMemo(() => {
+    const groups: SelectGroup<V>[] = isGrouped(options) ? options : [{ label: '', options }];
+    const q = searchable && query ? query.toLowerCase() : null;
+    const rows: Row<V>[] = [];
+    const flat: SelectOption<V>[] = [];
+    for (const group of groups) {
+      const visible = q
+        ? group.options.filter((o) => o.label.toLowerCase().includes(q))
+        : group.options;
+      if (visible.length === 0) continue;
+      // Empty label = headerless group (plain top-level rows)
+      const grouped = Boolean(group.label);
+      if (grouped) rows.push({ kind: 'group', label: group.label });
+      visible.forEach((opt, i) => {
+        rows.push({
+          kind: 'option',
+          opt,
+          index: flat.length,
+          grouped,
+          groupFirst: grouped && i === 0,
+          groupLast: grouped && i === visible.length - 1,
+        });
+        flat.push(opt);
+      });
+    }
+    return { rows, flat };
+  }, [options, searchable, query]);
+
+  // Unfiltered lookup: the trigger keeps its value while search hides the row.
+  const selected = useMemo(() => {
+    const groups: SelectGroup<V>[] = isGrouped(options) ? options : [{ label: '', options }];
+    for (const group of groups) {
+      const match = group.options.find((o) => o.value === value);
+      if (match) return match;
+    }
+    return null;
+  }, [options, value]);
+  const optionId = (index: number) => `${listboxId}-opt-${index}`;
+
+  const firstEnabled = () => flat.findIndex((o) => !o.disabled);
+  const lastEnabled = () => {
+    for (let i = flat.length - 1; i >= 0; i--) if (!flat[i].disabled) return i;
+    return -1;
+  };
+
+  const openMenu = (initial?: 'first' | 'last') => {
+    if (disabled || flat.length === 0) return;
+    const selectedIndex = flat.findIndex((o) => o.value === value && !o.disabled);
+    setActiveIndex(
+      initial === 'first' ? firstEnabled()
+        : initial === 'last' ? lastEnabled()
+        : selectedIndex >= 0 ? selectedIndex : firstEnabled()
+    );
+    setOpen(true);
+  };
+
+  const closeMenu = (refocus = true) => {
+    setOpen(false);
+    setMenuStyle(undefined);
+    setQuery('');
+    typeaheadRef.current = { buffer: '', time: 0 };
+    if (refocus) triggerRef.current?.focus();
+  };
+
+  const commit = (v: V) => {
+    onChange(v);
+    closeMenu();
+  };
+
+  const moveActive = (dir: 1 | -1) => {
+    // Native reference: no wrap; skip disabled options.
+    let i = activeIndex;
+    do {
+      i += dir;
+    } while (i >= 0 && i < flat.length && flat[i].disabled);
+    if (i >= 0 && i < flat.length) setActiveIndex(i);
+  };
+
+  const typeahead = (char: string) => {
+    const now = Date.now();
+    if (now - typeaheadRef.current.time > TYPEAHEAD_RESET_MS) typeaheadRef.current.buffer = '';
+    typeaheadRef.current = { buffer: typeaheadRef.current.buffer + char.toLowerCase(), time: now };
+    const { buffer } = typeaheadRef.current;
+    // Single char cycles past active; longer prefixes re-match from active
+    const start = Math.max(activeIndex, 0) + (buffer.length === 1 ? 1 : 0);
+    for (let i = 0; i < flat.length; i++) {
+      const idx = (start + i) % flat.length;
+      if (!flat[idx].disabled && flat[idx].label.toLowerCase().startsWith(buffer)) {
+        setActiveIndex(idx);
+        return;
+      }
+    }
+  };
+
+  const isPrintable = (e: React.KeyboardEvent) =>
+    e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey;
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (!open) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        openMenu('first');
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        openMenu('last');
+      } else if (isPrintable(e)) {
+        openMenu();
+        // Searchable: typed char seeds the filter; otherwise type-ahead
+        if (searchable) handleQueryChange(e.key);
+        else typeahead(e.key);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActive(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActive(-1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(firstEnabled());
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(lastEnabled());
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex >= 0 && !flat[activeIndex]?.disabled) commit(flat[activeIndex].value);
+        break;
+      case 'Tab':
+        closeMenu(false); // let focus move on naturally
+        break;
+      default:
+        if (!searchable && isPrintable(e)) {
+          e.preventDefault();
+          typeahead(e.key);
+        }
+    }
+    // Esc: window capture listener below (consumed before parent panels)
+  };
+
+  // Search input keys: arrows/Enter drive the list, the rest edits the query
+  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActive(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActive(-1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (activeIndex >= 0 && !flat[activeIndex]?.disabled) commit(flat[activeIndex].value);
+        break;
+      case 'Tab':
+        closeMenu(false);
+        break;
+      // Esc: window capture listener
+    }
+  };
+
+  // Track the mobile breakpoint (same rule as useContextualPanel)
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Lock page scroll while open (native parity); pad for the lost scrollbar
+  useEffect(() => {
+    if (!open) return;
+    const body = document.body;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    const prevOverflow = body.style.overflow;
+    const prevPaddingRight = body.style.paddingRight;
+    body.style.overflow = 'hidden';
+    if (scrollbarWidth > 0) body.style.paddingRight = `${scrollbarWidth}px`;
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.paddingRight = prevPaddingRight;
+    };
+  }, [open]);
+
+  // Consume Esc at capture phase so parent panels' Esc handlers don't fire too
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      e.stopPropagation();
+      closeMenu();
+    };
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [open]);
+
+  // Pointerdown outside trigger+menu closes and is consumed; never close on
+  // blur (clicking the portaled menu blurs the trigger first)
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      closeMenu();
+    };
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
+  }, [open]);
+
+  // Close on resize - WIDTH changes only (mobile URL bar / keyboard resizes
+  // are height-only and must not close the sheet)
+  useEffect(() => {
+    if (!open) return;
+    const startWidth = window.innerWidth;
+    const handleResize = () => {
+      if (window.innerWidth !== startWidth) closeMenu(false);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [open]);
+
+  // On-screen keyboard: rest the sheet on its top edge and grow into the
+  // space above (the keyboard shrinks only the visual viewport)
+  useEffect(() => {
+    if (!open || !isMobile) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const update = () => {
+      const keyboard = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      if (keyboard > 50) {
+        setSheetStyle({ bottom: keyboard, maxHeight: Math.max(120, vv.height - 12) });
+      } else {
+        setSheetStyle(undefined);
+      }
+    };
+    update();
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    return () => {
+      vv.removeEventListener('resize', update);
+      vv.removeEventListener('scroll', update);
+      setSheetStyle(undefined);
+    };
+  }, [open, isMobile]);
+
+  // Desktop placement: below the trigger, flip above near the viewport bottom
+  useLayoutEffect(() => {
+    if (!open || isMobile) return;
+    const trigger = triggerRef.current;
+    const menu = menuRef.current;
+    if (!trigger || !menu) return;
+    const rect = trigger.getBoundingClientRect();
+    const menuWidth = menu.offsetWidth;
+    const menuHeight = menu.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let top = rect.bottom + MENU_GAP;
+    if (top + menuHeight > vh - VIEWPORT_EDGE) {
+      const above = rect.top - MENU_GAP - menuHeight;
+      top = above >= VIEWPORT_EDGE ? above : Math.max(VIEWPORT_EDGE, vh - VIEWPORT_EDGE - menuHeight);
+    }
+    let left = align === 'end' ? rect.right - menuWidth : rect.left;
+    left = Math.min(Math.max(left, VIEWPORT_EDGE), Math.max(VIEWPORT_EDGE, vw - VIEWPORT_EDGE - menuWidth));
+
+    setMenuStyle({ top, left, minWidth: rect.width });
+  }, [open, isMobile, align, flat.length]);
+
+  // Keep the active row visible - desktop only (on mobile this scrolled the
+  // page mid sheet-animation and killed the menu)
+  useEffect(() => {
+    if (!open || isMobile) return;
+    menuRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: 'nearest' });
+  }, [open, activeIndex, isMobile]);
+
+  // Autofocus the filter on open - desktop only (no surprise keyboard)
+  useEffect(() => {
+    if (open && searchable && !isMobile) searchRef.current?.focus();
+  }, [open, searchable, isMobile]);
+
+  // Reset active row here, not in an effect: options change identity on every
+  // live update and an effect would yank keyboard nav every few seconds
+  const handleQueryChange = (q: string) => {
+    setQuery(q);
+    const ql = q.toLowerCase();
+    const groups: SelectGroup<V>[] = isGrouped(options) ? options : [{ label: '', options }];
+    let idx = -1;
+    for (const group of groups) {
+      for (const opt of group.options) {
+        if (ql && !opt.label.toLowerCase().includes(ql)) continue;
+        idx++;
+        if (!opt.disabled) {
+          setActiveIndex(idx);
+          return;
+        }
+      }
+    }
+    setActiveIndex(-1);
+  };
+
+  const renderRows = () =>
+    rows.map((row) => {
+      if (row.kind === 'group') {
+        return (
+          <li key={`group-${row.label}`} className="pk-select-group-label" role="presentation">
+            {row.label}
+          </li>
+        );
+      }
+      const { opt, index } = row;
+      const isSelected = opt.value === value;
+      const isActive = index === activeIndex;
+      return (
+        <li
+          key={`${opt.value}`}
+          id={optionId(index)}
+          role="option"
+          aria-selected={isSelected}
+          aria-disabled={opt.disabled || undefined}
+          data-active={isActive || undefined}
+          title={opt.title}
+          className={[
+            'pk-select-option',
+            isActive && 'active',
+            isSelected && 'selected',
+            opt.disabled && 'disabled',
+            row.grouped && 'in-group',
+            row.groupFirst && 'group-first',
+            row.groupLast && 'group-last',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          // keep DOM focus on the trigger (a row press would blur it)
+          onPointerDown={(e) => e.preventDefault()}
+          onMouseEnter={() => !opt.disabled && setActiveIndex(index)}
+          onClick={() => !opt.disabled && commit(opt.value)}
+        >
+          {renderOption ? (
+            renderOption(opt, { active: isActive, selected: isSelected })
+          ) : (
+            <span className="pk-select-option-label">{opt.label}</span>
+          )}
+          {isSelected && <Check size={14} className="pk-select-check" aria-hidden="true" />}
+        </li>
+      );
+    });
+
+  const searchBox = searchable ? (
+    <div className="pk-select-search">
+      <Search size={13} aria-hidden="true" className="pk-select-search-icon" />
+      <input
+        ref={searchRef}
+        type="text"
+        className="pk-select-search-input"
+        value={query}
+        placeholder="Search..."
+        aria-label="Search options"
+        aria-controls={listboxId}
+        aria-activedescendant={activeIndex >= 0 ? optionId(activeIndex) : undefined}
+        onChange={(e) => handleQueryChange(e.target.value)}
+        onKeyDown={handleSearchKeyDown}
+      />
+    </div>
+  ) : null;
+
+  const list = (
+    <ul
+      id={listboxId}
+      role="listbox"
+      className="pk-select-list"
+      aria-label={ariaLabel}
+      style={!isMobile ? { maxHeight: menuMaxHeight } : undefined}
+    >
+      {rows.length === 0 ? (
+        <li className="pk-select-empty" role="presentation">
+          No matches
+        </li>
+      ) : (
+        renderRows()
+      )}
+    </ul>
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        id={id}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open && activeIndex >= 0 ? optionId(activeIndex) : undefined}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        title={selected?.title}
+        className={className ? `pk-select-trigger ${className}` : 'pk-select-trigger'}
+        style={width != null ? { width } : undefined}
+        onClick={() => (open ? closeMenu() : openMenu())}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        <span className="pk-select-value">
+          {renderTrigger ? (
+            renderTrigger(selected)
+          ) : selected ? (
+            selected.label
+          ) : (
+            <span className="pk-select-placeholder">{placeholder ?? 'Select...'}</span>
+          )}
+        </span>
+      </button>
+
+      {open &&
+        !isMobile &&
+        createPortal(
+          <div ref={menuRef} className="pk-select-menu" style={menuStyle}>
+            {searchBox}
+            {list}
+          </div>,
+          document.body
+        )}
+
+      {open &&
+        isMobile &&
+        createPortal(
+          <div className="pk-select-backdrop">
+            <div ref={menuRef} className="pk-select-sheet" style={sheetStyle}>
+              {searchBox}
+              {list}
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/frontend/src/contexts/DashboardSettingsContext.tsx
+++ b/frontend/src/contexts/DashboardSettingsContext.tsx
@@ -195,7 +195,7 @@ function ensureGoogleStylesheet(stylesheetId: string, googleQuery: string): void
   document.head.appendChild(link);
 }
 
-function ensureGoogleFontForOption(option: UIFontOption): void {
+export function ensureGoogleFontForOption(option: UIFontOption): void {
   if (option.source !== 'google') return;
   if (!option.stylesheetId || !option.googleQuery) return;
   ensureGoogleStylesheet(option.stylesheetId, option.googleQuery);

--- a/frontend/src/contexts/DashboardSettingsContext.tsx
+++ b/frontend/src/contexts/DashboardSettingsContext.tsx
@@ -148,6 +148,17 @@ const SECONDARY_FONT_MAP = new Map(
 const DEFAULT_PRIMARY_FONT: UIPrimaryFontChoice = 'outfit';
 const DEFAULT_SECONDARY_FONT: UISecondaryFontChoice = 'jetbrains-mono';
 
+// UI font scale (multiplies the --font-size-* tokens)
+export const FONT_SCALE_MIN = 0.8;
+export const FONT_SCALE_MAX = 1.3;
+export const FONT_SCALE_STEP = 0.05;
+
+function normalizeFontScale(raw: number): number {
+  if (!Number.isFinite(raw)) return 1;
+  const snapped = Math.round(raw * 20) / 20; // 0.05 steps, no float drift
+  return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, snapped));
+}
+
 function normalizeFontChoice<T extends string>(
   raw: unknown,
   fallback: T,
@@ -225,6 +236,8 @@ interface DashboardSettingsContextType {
   updatePrimaryFont: (font: UIPrimaryFontChoice) => Promise<void>;
   secondaryFont: UISecondaryFontChoice;
   updateSecondaryFont: (font: UISecondaryFontChoice) => Promise<void>;
+  fontScale: number;
+  updateFontScale: (scale: number) => Promise<void>;
   isLoading: boolean;
   timezone: string;
   // Temperature thresholds
@@ -294,6 +307,7 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
   const [hoverTintColor, setHoverTintColor] = useState<string>('#0FEEEE');
   const [primaryFont, setPrimaryFont] = useState<UIPrimaryFontChoice>(DEFAULT_PRIMARY_FONT);
   const [secondaryFont, setSecondaryFont] = useState<UISecondaryFontChoice>(DEFAULT_SECONDARY_FONT);
+  const [fontScale, setFontScale] = useState<number>(1);
   const [timezone, setTimezone] = useState<string>('UTC');
   const [isLoading, setIsLoading] = useState(true);
 
@@ -325,6 +339,7 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
         getSetting('ui_font_primary'),
         getSetting('ui_font_secondary'),
         getSetting('hub_log_level'),
+        getSetting('ui_font_scale'),
       ]);
 
       // Process graph scale
@@ -381,6 +396,11 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
       if (results[12].status === 'fulfilled' && results[12].value?.setting_value) {
         setHubLogLevel(results[12].value.setting_value);
       }
+
+      // Process font scale
+      if (results[13].status === 'fulfilled' && results[13].value?.setting_value) {
+        setFontScale(normalizeFontScale(parseFloat(results[13].value.setting_value)));
+      }
     } catch (err) {
       console.error('Failed to fetch dashboard settings:', err);
     } finally {
@@ -416,6 +436,11 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
       ensureGoogleFontForOption(secondaryOpt);
     }
   }, [primaryFont, secondaryFont]);
+
+  // Apply UI font scale to document root
+  useEffect(() => {
+    document.documentElement.style.setProperty('--font-scale', String(fontScale));
+  }, [fontScale]);
 
   // Apply temperature colors to document root
   useEffect(() => {
@@ -480,6 +505,17 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
       await updateSetting('ui_font_secondary', font);
     } catch (err) {
       console.error('Failed to update secondary font:', err);
+      fetchSettings();
+    }
+  };
+
+  const updateFontScale = async (scale: number) => {
+    const next = normalizeFontScale(scale);
+    setFontScale(next);
+    try {
+      await updateSetting('ui_font_scale', next);
+    } catch (err) {
+      console.error('Failed to update font scale:', err);
       fetchSettings();
     }
   };
@@ -598,7 +634,9 @@ export const DashboardSettingsProvider: React.FC<{ children: React.ReactNode }> 
       updatePrimaryFont,
       secondaryFont,
       updateSecondaryFont,
-      isLoading, 
+      fontScale,
+      updateFontScale,
+      isLoading,
       timezone,
       tempThresholds,
       updateTempThresholds,

--- a/frontend/src/deployment/components/IpmiProfileSelector.tsx
+++ b/frontend/src/deployment/components/IpmiProfileSelector.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Check, AlertCircle } from 'lucide-react';
 import { getProfileCatalog, type ProfileCatalog, type ProfileCatalogEntry } from '../../services/api';
 import { formatModelFamily } from '../../utils/formatters';
+import { Select } from '../../components/ui/Select';
 
 interface IpmiProfileSelectorProps {
   selectedProfileId: string | null;
@@ -11,7 +12,6 @@ interface IpmiProfileSelectorProps {
 /**
  * BMC Profile selector for IPMI deployment.
  * Fetches catalog from backend, shows vendor/model dropdowns + match preview.
- * Reuses .builder-group, .builder-label, .stealth-select-wrapper from existing CSS.
  */
 const IpmiProfileSelector: React.FC<IpmiProfileSelectorProps> = ({ selectedProfileId, onProfileSelect }) => {
   const [catalog, setCatalog] = useState<ProfileCatalog | null>(null);
@@ -59,46 +59,34 @@ const IpmiProfileSelector: React.FC<IpmiProfileSelectorProps> = ({ selectedProfi
       <div className="profile-selector-row">
         <div className="builder-group">
           <span className="builder-label">Vendor</span>
-          <div className="stealth-select-wrapper profile-select-wrapper">
-            <select
-              className="select-engine"
-              value={selectedVendor}
-              onChange={(e) => handleVendorChange(e.target.value)}
-            >
-              <option value="">Select vendor...</option>
-              {vendors.map(v => (
-                <option key={v.name} value={v.name}>{v.name}</option>
-              ))}
-            </select>
-            <div className="select-display">
-              {selectedVendor || 'Select vendor...'}
-            </div>
-          </div>
+          <Select
+            value={selectedVendor}
+            onChange={handleVendorChange}
+            options={[
+              { value: '', label: 'Select vendor...' },
+              ...vendors.map(v => ({ value: v.name, label: v.name })),
+            ]}
+            className="profile-select"
+            ariaLabel="Vendor"
+          />
         </div>
 
         <div className="builder-group">
           <span className="builder-label">Model</span>
-          <div className="stealth-select-wrapper profile-select-wrapper">
-            <select
-              className="select-engine"
-              value={selectedProfileId || ''}
-              onChange={(e) => handleModelChange(e.target.value)}
-              disabled={!selectedVendor}
-            >
-              <option value="">Select model...</option>
-              {models.map(m => (
-                <option key={m.profile_id} value={m.profile_id}>
-                  {(formatModelFamily(m.model_family) || m.profile_id.split('/')[1])}
-                  {` [${getTierLabel(m)}${m.is_monitor_only ? ', Monitor-only' : ''}]`}
-                </option>
-              ))}
-            </select>
-            <div className="select-display">
-              {selectedModel
-                ? `${formatModelFamily(selectedModel.model_family) || selectedModel.profile_id.split('/')[1]} [${getTierLabel(selectedModel)}${selectedModel.is_monitor_only ? ', Monitor-only' : ''}]`
-                : 'Select model...'}
-            </div>
-          </div>
+          <Select
+            value={selectedProfileId || ''}
+            onChange={handleModelChange}
+            options={[
+              { value: '', label: 'Select model...' },
+              ...models.map(m => ({
+                value: m.profile_id,
+                label: `${formatModelFamily(m.model_family) || m.profile_id.split('/')[1]} [${getTierLabel(m)}${m.is_monitor_only ? ', Monitor-only' : ''}]`,
+              })),
+            ]}
+            disabled={!selectedVendor}
+            className="profile-select"
+            ariaLabel="Model"
+          />
         </div>
       </div>
 

--- a/frontend/src/deployment/components/ProfileBuilder.tsx
+++ b/frontend/src/deployment/components/ProfileBuilder.tsx
@@ -12,6 +12,7 @@ import {
   Cpu,
 } from 'lucide-react';
 import { toast } from '../../utils/toast';
+import { Select } from '../../components/ui/Select';
 import {
   executeRawIpmi,
   saveCustomProfile,
@@ -610,32 +611,30 @@ const ProfileBuilder: React.FC<ProfileBuilderProps> = ({ systems }) => {
             <p className="profile-builder-hint">
               Select the bare IPMI agent deployed on your server.
             </p>
-            <div className="stealth-select-wrapper profile-select-wrapper" style={{ maxWidth: 400 }}>
-              <select
-                className="select-engine"
-                value={selectedSystemId ?? ''}
-                onChange={(e) =>
-                  setSelectedSystemId(e.target.value ? Number(e.target.value) : null)
-                }
-              >
-                <option value="">
-                  {onlineAgents.length === 0
+            <div style={{ maxWidth: 400 }}>
+              <Select
+                value={selectedSystemId != null ? String(selectedSystemId) : ''}
+                onChange={(v) => setSelectedSystemId(v ? Number(v) : null)}
+                options={[
+                  {
+                    value: '',
+                    label: onlineAgents.length === 0 ? 'No agents online' : 'Select agent...',
+                  },
+                  ...onlineAgents.map((s) => ({
+                    value: String(s.id),
+                    label: `${s.name || s.agent_id} (${s.agent_id})`,
+                  })),
+                ]}
+                renderTrigger={() =>
+                  selectedSystem
+                    ? `${selectedSystem.name || selectedSystem.agent_id}`
+                    : onlineAgents.length === 0
                     ? 'No agents online'
-                    : 'Select agent...'}
-                </option>
-                {onlineAgents.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.name || s.agent_id} ({s.agent_id})
-                  </option>
-                ))}
-              </select>
-              <div className="select-display">
-                {selectedSystem
-                  ? `${selectedSystem.name || selectedSystem.agent_id}`
-                  : onlineAgents.length === 0
-                  ? 'No agents online'
-                  : 'Select agent...'}
-              </div>
+                    : 'Select agent...'
+                }
+                className="profile-select"
+                ariaLabel="Target Agent"
+              />
             </div>
           </div>
 
@@ -648,28 +647,30 @@ const ProfileBuilder: React.FC<ProfileBuilderProps> = ({ systems }) => {
             <div className="profile-builder-metadata-grid">
               <div className="builder-group">
                 <span className="builder-label">Vendor</span>
-                <div className="stealth-select-wrapper profile-select-wrapper">
-                  <select
-                    className="select-engine"
-                    value={vendorSelection}
-                    onChange={(e) => { setVendorSelection(e.target.value); if (e.target.value !== '__custom__') setCustomVendor(''); }}
-                  >
-                    <option value="">Select vendor...</option>
-                    {KNOWN_VENDORS.map(v => (
-                      <option key={v} value={v}>
-                        {v}{VENDOR_HINTS[v]?.unsupported ? ' (unsupported)' : ''}
-                      </option>
-                    ))}
-                    <option value="__custom__">Custom...</option>
-                  </select>
-                  <div className="select-display">
-                    {vendorSelection === '__custom__'
+                <Select
+                  value={vendorSelection}
+                  onChange={(v) => {
+                    setVendorSelection(v);
+                    if (v !== '__custom__') setCustomVendor('');
+                  }}
+                  options={[
+                    { value: '', label: 'Select vendor...' },
+                    ...KNOWN_VENDORS.map(v => ({
+                      value: v,
+                      label: `${v}${VENDOR_HINTS[v]?.unsupported ? ' (unsupported)' : ''}`,
+                    })),
+                    { value: '__custom__', label: 'Custom...' },
+                  ]}
+                  renderTrigger={() =>
+                    vendorSelection === '__custom__'
                       ? (customVendor || 'Custom...')
                       : vendorSelection
                         ? `${vendorSelection}${hints?.unsupported ? ' (unsupported)' : ''}`
-                        : 'Select vendor...'}
-                  </div>
-                </div>
+                        : 'Select vendor...'
+                  }
+                  className="profile-select"
+                  ariaLabel="Vendor"
+                />
                 {vendorSelection === '__custom__' && (
                   <input
                     className="hub-url-input"

--- a/frontend/src/deployment/components/ReleaseHubCache.tsx
+++ b/frontend/src/deployment/components/ReleaseHubCache.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Bookmark, Zap, Trash2, Download, Check } from 'lucide-react';
 import type { HubStatus } from '../../services/api';
+import { Select } from '../../components/ui/Select';
 
 export type Channel = 'stable' | 'unstable';
 
@@ -100,64 +101,48 @@ const ReleaseHubCache: React.FC<ReleaseHubCacheProps> = React.memo(({
       <div className="hub-cache-picker-grid">
         <div className="hub-cache-picker-cell">
           <span className="builder-label">Stable version</span>
-          <div className="stealth-select-wrapper version-picker-wrapper">
-            <div className="select-display">
-              {selectedStableVersion || (latestStable ? latestStable.tag_name : 'No stable releases')}
-            </div>
-            <select
-              className="select-engine"
-              value={selectedStableVersion || ''}
-              onChange={(e) => {
-                const ver = e.target.value;
-                if (!ver) return;
-                onSelectStableVersion(ver);
-                sessionStorage.setItem('pankha-picker-stable', ver);
-                if (channel !== 'stable') onChannelChange('stable');
-              }}
-              disabled={isStaging || stableReleases.length === 0}
-            >
-              {stableReleases.length === 0 ? (
-                <option value="" disabled>No stable releases</option>
-              ) : (
-                stableReleases.map(r => (
-                  <option key={r.tag_name} value={r.tag_name}>
-                    {r.tag_name}{hubVersion === r.tag_name ? ' (Ready)' : ''}
-                  </option>
-                ))
-              )}
-            </select>
-          </div>
+          <Select
+            value={selectedStableVersion || ''}
+            onChange={(ver) => {
+              if (!ver) return;
+              onSelectStableVersion(ver);
+              sessionStorage.setItem('pankha-picker-stable', ver);
+              if (channel !== 'stable') onChannelChange('stable');
+            }}
+            options={stableReleases.map(r => ({
+              value: r.tag_name,
+              label: `${r.tag_name}${hubVersion === r.tag_name ? ' (Ready)' : ''}`,
+            }))}
+            renderTrigger={() =>
+              selectedStableVersion || (latestStable ? latestStable.tag_name : 'No stable releases')
+            }
+            disabled={isStaging || stableReleases.length === 0}
+            className="version-picker"
+            ariaLabel="Stable version"
+          />
         </div>
 
         <div className="hub-cache-picker-cell">
           <span className="builder-label">Pre-release version</span>
-          <div className="stealth-select-wrapper version-picker-wrapper">
-            <div className="select-display">
-              {selectedUnstableVersion || (latestUnstable ? latestUnstable.tag_name : 'No pre-releases')}
-            </div>
-            <select
-              className="select-engine"
-              value={selectedUnstableVersion || ''}
-              onChange={(e) => {
-                const ver = e.target.value;
-                if (!ver) return;
-                onSelectUnstableVersion(ver);
-                sessionStorage.setItem('pankha-picker-unstable', ver);
-                if (channel !== 'unstable') onChannelChange('unstable');
-              }}
-              disabled={isStaging || unstableReleases.length === 0}
-            >
-              {unstableReleases.length === 0 ? (
-                <option value="" disabled>No pre-releases</option>
-              ) : (
-                unstableReleases.map(r => (
-                  <option key={r.tag_name} value={r.tag_name}>
-                    {r.tag_name}{hubVersion === r.tag_name ? ' (Ready)' : ''}
-                  </option>
-                ))
-              )}
-            </select>
-          </div>
+          <Select
+            value={selectedUnstableVersion || ''}
+            onChange={(ver) => {
+              if (!ver) return;
+              onSelectUnstableVersion(ver);
+              sessionStorage.setItem('pankha-picker-unstable', ver);
+              if (channel !== 'unstable') onChannelChange('unstable');
+            }}
+            options={unstableReleases.map(r => ({
+              value: r.tag_name,
+              label: `${r.tag_name}${hubVersion === r.tag_name ? ' (Ready)' : ''}`,
+            }))}
+            renderTrigger={() =>
+              selectedUnstableVersion || (latestUnstable ? latestUnstable.tag_name : 'No pre-releases')
+            }
+            disabled={isStaging || unstableReleases.length === 0}
+            className="version-picker"
+            ariaLabel="Pre-release version"
+          />
         </div>
       </div>
 

--- a/frontend/src/deployment/styles/deployment.css
+++ b/frontend/src/deployment/styles/deployment.css
@@ -1207,12 +1207,12 @@
   flex: 1;
 }
 
-/* Version picker - reuses stealth-select, just widens for longer text */
-.version-picker-wrapper {
-  width: auto;
+/* Design1 trigger - old .version-picker-wrapper footprint */
+.pk-select-trigger.version-picker {
   min-width: 140px;
   height: 30px;
   padding: 4px 12px;
+  padding-right: 24px; /* chevron room */
 }
 
 .prep-manual-actions {
@@ -1525,16 +1525,15 @@
   }
 }
 
-.profile-select-wrapper {
+/* Design1 trigger - old .profile-select-wrapper footprint */
+.pk-select-trigger.profile-select {
   width: 100%;
   height: 36px;
   padding: var(--spacing-xs) var(--spacing-md);
+  padding-right: 24px; /* chevron room */
   background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  color: var(--text-primary);
 }
 
 .profile-error {
@@ -2178,7 +2177,7 @@
   min-width: 0;
 }
 
-.hub-cache-picker-cell .version-picker-wrapper {
+.hub-cache-picker-cell .pk-select-trigger.version-picker {
   width: 100%;
   min-width: 0;
 }

--- a/frontend/src/fan-profiles/components/FanCurveChart.tsx
+++ b/frontend/src/fan-profiles/components/FanCurveChart.tsx
@@ -64,8 +64,8 @@ const FanCurveChart: React.FC<FanCurveChartProps> = ({
   const pointsWithIndex = curvePoints.map((point, originalIndex) => ({ ...point, originalIndex }));
 
   let sortedPoints;
-  if (dragState.isDragging && dragState.dragStartOrder.length > 0) {
-    // Maintain the visual order from when drag started
+  // Length must match: a stale order after add/remove would index past the array
+  if (dragState.isDragging && dragState.dragStartOrder.length === pointsWithIndex.length) {
     sortedPoints = dragState.dragStartOrder.map(idx => pointsWithIndex[idx]);
   } else {
     // Normal sorting when not dragging
@@ -111,6 +111,8 @@ const FanCurveChart: React.FC<FanCurveChartProps> = ({
   // Drag event handlers
   const handleMouseDown = useCallback((event: React.MouseEvent, pointIndex: number) => {
     if (!interactive || !onPointChange) return;
+    // Left button only - a right-click (remove) must not enter drag state
+    if (event.button !== 0) return;
 
     event.preventDefault();
     const { x, y } = getSVGCoords(event.clientX, event.clientY);

--- a/frontend/src/fan-profiles/components/FanProfileEditor.tsx
+++ b/frontend/src/fan-profiles/components/FanProfileEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Check, X } from 'lucide-react';
+import { Plus, Check, X, Rocket, SlidersHorizontal, ChartLine, Thermometer, AlertTriangle } from 'lucide-react';
 import {
   createFanProfile,
   updateFanProfile,
@@ -20,6 +20,7 @@ import type { FanProfileType } from '../../services/fanProfileTypesApi';
 import FanCurveChart from './FanCurveChart';
 import FanProfileColorPicker from './FanProfileColorPicker';
 import { toast } from '../../utils/toast';
+import { Select } from '../../components/ui/Select';
 
 interface FanProfileEditorProps {
   profile?: FanProfile | null;
@@ -410,11 +411,11 @@ const FanProfileEditor: React.FC<FanProfileEditorProps> = ({
                 className="control-button add-point"
                 disabled={loading}
               >
-                ➕ Add Point
+                <Plus size={14} /> Add Point
               </button>
               <div className="curve-info">
-                <span>📊 {curvePoints.length} points</span>
-                <span>🌡️ {Math.min(...curvePoints.map(p => p.temperature))}°C - {Math.max(...curvePoints.map(p => p.temperature))}°C</span>
+                <span><ChartLine size={12} /> {curvePoints.length} points</span>
+                <span><Thermometer size={12} /> {Math.min(...curvePoints.map(p => p.temperature))}°C - {Math.max(...curvePoints.map(p => p.temperature))}°C</span>
               </div>
             </div>
           </div>
@@ -422,28 +423,28 @@ const FanProfileEditor: React.FC<FanProfileEditorProps> = ({
           <aside className="editor-sidebar">
             {/* Quick Start Segment */}
             <div className="sidebar-group">
-              <h3>🚀 Quick Start</h3>
+              <h3><Rocket size={12} /> Quick Start</h3>
               <div className="form-group">
                 <label htmlFor="templateSelect">Template</label>
-                <select
+                <Select
                   id="templateSelect"
                   className="template-dropdown"
                   value={selectedTemplateId}
-                  onChange={(e) => handleTemplateSelection(e.target.value)}
-                >
-                  <option value="">Starter Curve</option>
-                  {availableProfiles.map((template) => (
-                    <option key={template.id} value={template.id}>
-                      {template.profile_name}
-                    </option>
-                  ))}
-                </select>
+                  onChange={handleTemplateSelection}
+                  options={[
+                    { value: '', label: 'Starter Curve' },
+                    ...availableProfiles.map((template) => ({
+                      value: String(template.id),
+                      label: template.profile_name,
+                    })),
+                  ]}
+                />
               </div>
             </div>
 
             {/* Profile Details Segment */}
             <div className="sidebar-group fill">
-              <h3>📝 Configuration</h3>
+              <h3><SlidersHorizontal size={12} /> Configuration</h3>
               <div className="form-group">
                 <label htmlFor="profileName">Profile Name</label>
                 <input
@@ -500,23 +501,19 @@ const FanProfileEditor: React.FC<FanProfileEditorProps> = ({
                     </>
                   ) : (
                     <>
-                      <select
+                      <Select
                         id="profileType"
                         value={profileType}
-                        onChange={(e) => setProfileType(e.target.value)}
+                        onChange={setProfileType}
                         disabled={loading}
-                      >
-                        {profileTypes.map(t => (
-                          <option key={t.name} value={t.name}>
-                            {t.name}
-                          </option>
-                        ))}
-                        {/* If the loaded profile uses a type that's been deleted
-                            since, still render it so the select doesn't blank. */}
-                        {profileType && !profileTypes.some(t => t.name === profileType) && (
-                          <option value={profileType}>{profileType}</option>
-                        )}
-                      </select>
+                        options={[
+                          ...profileTypes.map(t => ({ value: t.name, label: t.name })),
+                          // Deleted-since type: keep a row so the trigger doesn't blank
+                          ...(profileType && !profileTypes.some(t => t.name === profileType)
+                            ? [{ value: profileType, label: profileType }]
+                            : []),
+                        ]}
+                      />
                       {/* Always-visible swatch for the selected type. Opens the
                           picker; PATCHes on Done, reverts on Cancel. Works for
                           both system and user types - recoloring is cosmetic. */}
@@ -573,7 +570,7 @@ const FanProfileEditor: React.FC<FanProfileEditorProps> = ({
 
         {error && (
           <div className="editor-error">
-            <span className="error-icon">⚠️</span>
+            <AlertTriangle size={18} className="error-icon" />
             {error}
           </div>
         )}

--- a/frontend/src/fan-profiles/components/ProfileImportExport.tsx
+++ b/frontend/src/fan-profiles/components/ProfileImportExport.tsx
@@ -22,6 +22,9 @@ import {
 } from 'lucide-react';
 import { getImportStatusColor } from '../../utils/statusColors';
 import { toast } from '../../utils/toast';
+import { Select } from '../../components/ui/Select';
+
+type ConflictStrategy = 'skip' | 'rename' | 'overwrite';
 
 interface ProfileImportExportProps {
   profiles: any[];
@@ -34,8 +37,8 @@ const ProfileImportExport: React.FC<ProfileImportExportProps> = ({ onImportCompl
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showDefaultsDialog, setShowDefaultsDialog] = useState(false);
-  const [resolveConflicts, setResolveConflicts] = useState<'skip' | 'rename' | 'overwrite'>('rename');
-  const [defaultResolveConflicts, setDefaultResolveConflicts] = useState<'skip' | 'rename' | 'overwrite'>('skip');
+  const [resolveConflicts, setResolveConflicts] = useState<ConflictStrategy>('rename');
+  const [defaultResolveConflicts, setDefaultResolveConflicts] = useState<ConflictStrategy>('skip');
   const [defaultProfiles, setDefaultProfiles] = useState<DefaultProfileInfo[]>([]);
   const [selectedDefaults, setSelectedDefaults] = useState<Set<string>>(new Set());
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -315,11 +318,17 @@ const ProfileImportExport: React.FC<ProfileImportExportProps> = ({ onImportCompl
               </div>
               <div className="dialog-options">
                 <label>Conflict Resolution Strategy:</label>
-                <select value={defaultResolveConflicts} onChange={(e) => setDefaultResolveConflicts(e.target.value as any)}>
-                  <option value="skip">Keep Existing (Skip)</option>
-                  <option value="rename">Keep Both (Rename)</option>
-                  <option value="overwrite">Replace Existing (Overwrite)</option>
-                </select>
+                <Select<ConflictStrategy>
+                  value={defaultResolveConflicts}
+                  onChange={setDefaultResolveConflicts}
+                  options={[
+                    { value: 'skip', label: 'Keep Existing (Skip)' },
+                    { value: 'rename', label: 'Keep Both (Rename)' },
+                    { value: 'overwrite', label: 'Replace Existing (Overwrite)' },
+                  ]}
+                  width={240}
+                  ariaLabel="Conflict resolution strategy"
+                />
               </div>
             </div>
             <div className="dialog-footer">
@@ -353,11 +362,17 @@ const ProfileImportExport: React.FC<ProfileImportExportProps> = ({ onImportCompl
               <div className="dialog-options">
                 <div className="option-row">
                   <label>Duplication Strategy:</label>
-                  <select value={resolveConflicts} onChange={(e) => setResolveConflicts(e.target.value as any)}>
-                    <option value="skip">Skip Internal Conflicts</option>
-                    <option value="rename">Automatic Renaming</option>
-                    <option value="overwrite">System Overwrite</option>
-                  </select>
+                  <Select<ConflictStrategy>
+                    value={resolveConflicts}
+                    onChange={setResolveConflicts}
+                    options={[
+                      { value: 'skip', label: 'Skip Internal Conflicts' },
+                      { value: 'rename', label: 'Automatic Renaming' },
+                      { value: 'overwrite', label: 'System Overwrite' },
+                    ]}
+                    width={240}
+                    ariaLabel="Duplication strategy"
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/fan-profiles/styles/profile-editor.css
+++ b/frontend/src/fan-profiles/styles/profile-editor.css
@@ -209,6 +209,9 @@
 
 .sidebar-group h3 {
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -257,7 +260,7 @@
   gap: var(--spacing-xs);
 }
 
-.profile-type-row select,
+.profile-type-row .pk-select-trigger,
 .profile-type-row input {
   flex: 1;
   min-width: 0;
@@ -285,7 +288,7 @@
 }
 
 .error-icon {
-  font-size: var(--font-size-lg);
+  flex-shrink: 0;
 }
 
 .editor-footer {
@@ -553,12 +556,21 @@
   border-top: 1px solid var(--border-color);
 }
 
+.chart-controls .control-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .curve-info {
   display: flex;
   gap: var(--spacing-xl);
 }
 
 .curve-info span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-tertiary);
@@ -576,25 +588,13 @@
   gap: var(--spacing-md);
 }
 
-.template-dropdown {
+/* Design0 footprint parity (task_12): full-width, spacing-md, radius-md */
+.pk-select-trigger.template-dropdown {
   width: 100%;
   padding: var(--spacing-md);
-  border: 1px solid var(--border-color);
+  padding-right: 24px;
   border-radius: var(--radius-md);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
   font-size: var(--font-size-base);
-  cursor: pointer;
-}
-
-.template-dropdown:hover {
-  border-color: var(--color-primary);
-}
-
-.template-dropdown:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.1);
 }
 
 .template-info {

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useLicense, type LicenseInfo } from '../../license';
-import { PRIMARY_FONT_OPTIONS, SECONDARY_FONT_OPTIONS, type UIPrimaryFontChoice, type UISecondaryFontChoice, ensureGoogleFontForOption, useDashboardSettings } from '../../contexts/DashboardSettingsContext';
+import { PRIMARY_FONT_OPTIONS, SECONDARY_FONT_OPTIONS, FONT_SCALE_MIN, FONT_SCALE_MAX, FONT_SCALE_STEP, type UIPrimaryFontChoice, type UISecondaryFontChoice, ensureGoogleFontForOption, useDashboardSettings } from '../../contexts/DashboardSettingsContext';
 import { Select, type SelectOption } from '../../components/ui/Select';
 import { setLicense, getPricing, deleteLicense, getSystems, getDiagnostics } from '../../services/api';
 import { formatDate, formatFriendlyDate, USER_TIMEZONE } from '../../utils/formatters';
@@ -34,24 +34,43 @@ import {
   Eye,
   EyeOff,
   Trash2,
-  RefreshCw
+  RefreshCw,
+  ChevronUp,
+  ChevronDown
 } from 'lucide-react';
 import '../styles/settings.css';
 
-// Font dropdowns: each option row previews its own typeface
+// Font dropdown rows: name in the UI font + a dimmed specimen in the option's
+// own typeface (slot-appropriate: pangram for primary, numeric for mono)
+interface FontOptionData {
+  stack: string;
+  specimen: string;
+}
+
+const PRIMARY_FONT_SPECIMEN = 'The quick brown fox jumps over the lazy dog';
+const SECONDARY_FONT_SPECIMEN = '42.7°C · 1800 RPM';
+
 const PRIMARY_FONT_SELECT_OPTIONS = PRIMARY_FONT_OPTIONS.map((o) => ({
   value: o.value,
   label: o.label,
-  data: o.stack,
+  data: { stack: o.stack, specimen: PRIMARY_FONT_SPECIMEN } as FontOptionData,
 }));
 const SECONDARY_FONT_SELECT_OPTIONS = SECONDARY_FONT_OPTIONS.map((o) => ({
   value: o.value,
   label: o.label,
-  data: o.stack,
+  data: { stack: o.stack, specimen: SECONDARY_FONT_SPECIMEN } as FontOptionData,
 }));
 
 function renderFontOption<V extends string>(opt: SelectOption<V>) {
-  return <span style={{ fontFamily: opt.data as string }}>{opt.label}</span>;
+  const data = opt.data as FontOptionData;
+  return (
+    <>
+      <span className="font-option-name">{opt.label}</span>
+      <span className="font-option-preview" style={{ fontFamily: data.stack }}>
+        {data.specimen}
+      </span>
+    </>
+  );
 }
 
 // Graph scale configuration constants
@@ -886,6 +905,7 @@ const Settings: React.FC = () => {
     hoverTintColor, updateHoverTintColor,
     primaryFont, updatePrimaryFont,
     secondaryFont, updateSecondaryFont,
+    fontScale, updateFontScale,
     tempThresholds, updateTempThresholds,
     tempColors, updateTempColors,
     perTypeEnabled, setPerTypeEnabled,
@@ -1742,10 +1762,12 @@ const Settings: React.FC = () => {
                         className="appearance-font-sample"
                         style={{ fontFamily: PRIMARY_FONT_OPTIONS.find((o) => o.value === primaryFont)?.stack }}
                       >
-                        The quick brown fox jumps over the lazy dog
+                        <span>THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG</span>
+                        <span>the quick brown fox jumps over the lazy dog</span>
                       </span>
                       <Select<UIPrimaryFontChoice>
                         className="font-select"
+                        menuClassName="font-select-menu"
                         value={primaryFont}
                         onChange={updatePrimaryFont}
                         options={PRIMARY_FONT_SELECT_OPTIONS}
@@ -1768,16 +1790,55 @@ const Settings: React.FC = () => {
                         className="appearance-font-sample"
                         style={{ fontFamily: SECONDARY_FONT_OPTIONS.find((o) => o.value === secondaryFont)?.stack }}
                       >
-                        42.7°C · 1800 RPM · 0xDEADBEEF
+                        <span>42.7°C · 1800 RPM · 0xDEADBEEF</span>
                       </span>
                       <Select<UISecondaryFontChoice>
                         className="font-select"
+                        menuClassName="font-select-menu"
                         value={secondaryFont}
                         onChange={updateSecondaryFont}
                         options={SECONDARY_FONT_SELECT_OPTIONS}
                         renderOption={renderFontOption}
                         ariaLabel="Secondary font"
                       />
+                    </div>
+                  </div>
+
+                  {/* Font Size */}
+                  <div className="setting-item">
+                    <div className="setting-info-wrapper">
+                      <span className="setting-label">Font Size</span>
+                      <span className="setting-description">
+                        Scales all interface text. Click the value to reset.
+                      </span>
+                    </div>
+                    <div className="font-scale-control">
+                      <button
+                        type="button"
+                        className="font-scale-btn"
+                        onClick={() => updateFontScale(fontScale - FONT_SCALE_STEP)}
+                        disabled={fontScale <= FONT_SCALE_MIN}
+                        aria-label="Decrease font size"
+                      >
+                        <ChevronDown size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        className="font-scale-value"
+                        onClick={() => updateFontScale(1)}
+                        title="Reset to 100%"
+                      >
+                        {Math.round(fontScale * 100)}%
+                      </button>
+                      <button
+                        type="button"
+                        className="font-scale-btn"
+                        onClick={() => updateFontScale(fontScale + FONT_SCALE_STEP)}
+                        disabled={fontScale >= FONT_SCALE_MAX}
+                        aria-label="Increase font size"
+                      >
+                        <ChevronUp size={14} />
+                      </button>
                     </div>
                   </div>
 

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -4,7 +4,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { useLicense, type LicenseInfo } from '../../license';
-import { PRIMARY_FONT_OPTIONS, SECONDARY_FONT_OPTIONS, type UIPrimaryFontChoice, type UISecondaryFontChoice, useDashboardSettings } from '../../contexts/DashboardSettingsContext';
+import { PRIMARY_FONT_OPTIONS, SECONDARY_FONT_OPTIONS, type UIPrimaryFontChoice, type UISecondaryFontChoice, ensureGoogleFontForOption, useDashboardSettings } from '../../contexts/DashboardSettingsContext';
+import { Select, type SelectOption } from '../../components/ui/Select';
 import { setLicense, getPricing, deleteLicense, getSystems, getDiagnostics } from '../../services/api';
 import { formatDate, formatFriendlyDate, USER_TIMEZONE } from '../../utils/formatters';
 import { toast } from '../../utils/toast';
@@ -36,6 +37,22 @@ import {
   RefreshCw
 } from 'lucide-react';
 import '../styles/settings.css';
+
+// Font dropdowns: each option row previews its own typeface
+const PRIMARY_FONT_SELECT_OPTIONS = PRIMARY_FONT_OPTIONS.map((o) => ({
+  value: o.value,
+  label: o.label,
+  data: o.stack,
+}));
+const SECONDARY_FONT_SELECT_OPTIONS = SECONDARY_FONT_OPTIONS.map((o) => ({
+  value: o.value,
+  label: o.label,
+  data: o.stack,
+}));
+
+function renderFontOption<V extends string>(opt: SelectOption<V>) {
+  return <span style={{ fontFamily: opt.data as string }}>{opt.label}</span>;
+}
 
 // Graph scale configuration constants
 const GRAPH_SCALE_MIN_HOURS = 1;
@@ -931,6 +948,11 @@ const Settings: React.FC = () => {
     }
   }, [isDemoMode, activeTab]);
 
+  // Load every font's stylesheet so the dropdown previews render honestly
+  useEffect(() => {
+    [...PRIMARY_FONT_OPTIONS, ...SECONDARY_FONT_OPTIONS].forEach(ensureGoogleFontForOption);
+  }, []);
+
   // Tick once a minute so the "Grace - <countdown>" badge stays current on an
   // otherwise idle screen. Settings is React.memo'd (no longer re-renders on
   // sensor deltas), so without this the countdown would only recompute on a
@@ -1722,17 +1744,14 @@ const Settings: React.FC = () => {
                       >
                         The quick brown fox jumps over the lazy dog
                       </span>
-                      <select
+                      <Select<UIPrimaryFontChoice>
                         className="font-select"
                         value={primaryFont}
-                        onChange={(e) => updatePrimaryFont(e.target.value as UIPrimaryFontChoice)}
-                      >
-                        {PRIMARY_FONT_OPTIONS.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
+                        onChange={updatePrimaryFont}
+                        options={PRIMARY_FONT_SELECT_OPTIONS}
+                        renderOption={renderFontOption}
+                        ariaLabel="Primary font"
+                      />
                     </div>
                   </div>
 
@@ -1751,17 +1770,14 @@ const Settings: React.FC = () => {
                       >
                         42.7°C · 1800 RPM · 0xDEADBEEF
                       </span>
-                      <select
+                      <Select<UISecondaryFontChoice>
                         className="font-select"
                         value={secondaryFont}
-                        onChange={(e) => updateSecondaryFont(e.target.value as UISecondaryFontChoice)}
-                      >
-                        {SECONDARY_FONT_OPTIONS.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
+                        onChange={updateSecondaryFont}
+                        options={SECONDARY_FONT_SELECT_OPTIONS}
+                        renderOption={renderFontOption}
+                        ariaLabel="Secondary font"
+                      />
                     </div>
                   </div>
 

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -929,29 +929,14 @@
   color: var(--color-error);
 }
 
-.font-select {
+/* Design0 footprint parity (task_12); hover/focus come from the pk baseline */
+.pk-select-trigger.font-select {
   width: 100%;
   padding: 6px 10px;
-  border: 1px solid var(--border-color);
+  padding-right: 24px;
   border-radius: var(--radius-md);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   font-family: var(--font-primary);
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-}
-
-.font-select:hover {
-  border-color: var(--color-accent-dynamic);
-  background: color-mix(in srgb, var(--color-hover-tint-dynamic) 4%, var(--bg-secondary));
-}
-
-.font-select:focus {
-  outline: none;
-  border-color: var(--color-accent-dynamic);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent-dynamic), transparent 80%);
 }
 
 .accent-swatches {

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -884,6 +884,30 @@
   color: var(--text-tertiary);
 }
 
+/* Phone: stack the row and let presets wrap instead of overflowing the screen */
+@media (max-width: 600px) {
+  .setting-item:has(.scale-control-wrapper) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-md);
+  }
+
+  .scale-control-wrapper {
+    justify-content: flex-start;
+  }
+
+  .scale-presets {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .scale-preset-btn {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+  }
+}
+
 /* Tier limit note in description */
 .tier-limit-note {
   color: var(--color-warning);

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -939,6 +939,82 @@
   font-family: var(--font-primary);
 }
 
+/* Font menu rows: name in UI font, dimmed specimen in the option's typeface.
+ * Desktop menu capped; the mobile sheet keeps its full width. */
+.pk-select-menu.font-select-menu {
+  max-width: min(420px, calc(100vw - 16px));
+}
+
+.font-option-name {
+  flex-shrink: 0;
+}
+
+.font-option-preview {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-secondary);
+}
+
+/* The specimen takes the check's auto margin (same pattern as sensor temps) */
+.pk-select-option:has(.font-option-preview) .pk-select-check {
+  margin-left: 0;
+}
+
+/* Font size stepper */
+.font-scale-control {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.font-scale-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+/* Explicit size: Firefox collapses attribute-sized svg flex items in buttons to 0 width */
+.font-scale-btn svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
+
+.font-scale-btn:hover:not(:disabled) {
+  border-color: var(--color-accent-dynamic);
+  color: var(--text-primary);
+}
+
+.font-scale-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.font-scale-value {
+  min-width: 48px;
+  text-align: center;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.font-scale-value:hover {
+  color: var(--color-accent-dynamic);
+}
+
 .accent-swatches {
     display: flex;
     gap: 0.5rem;
@@ -2784,19 +2860,29 @@
   justify-content: flex-end;
 }
 
+/* Two-line specimen (caps + lowercase); shrinks with ellipsis when space runs out */
 .appearance-font-sample {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
   font-size: var(--font-size-base);
   color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 320px;
   padding-right: var(--spacing-md);
   border-right: 1px solid var(--border-color-dimmed);
 }
 
-.appearance-font-control .font-select {
-  min-width: 200px;
+.appearance-font-sample > span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+/* Fixed trigger footprint - width:100% would squeeze the specimen out of the row */
+.appearance-font-control .pk-select-trigger.font-select {
+  width: 240px;
+  flex: none;
   margin: 0;
 }
 
@@ -3095,7 +3181,6 @@
   }
 
   .appearance-font-sample {
-    white-space: normal;
     max-width: 100%;
     padding: var(--spacing-xs) var(--spacing-sm);
     border-right: none;
@@ -3104,12 +3189,17 @@
     background: color-mix(in srgb, var(--color-accent-dynamic) 4%, transparent);
   }
 
+  .appearance-font-sample > span {
+    white-space: normal;
+    text-align: left; /* right-align reads wrong against the accent bar */
+  }
+
   .appearance-font-control {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .appearance-font-control .font-select {
+  .appearance-font-control .pk-select-trigger.font-select {
     width: 100%;
     min-height: 44px;
   }

--- a/frontend/src/styles/base/responsive.css
+++ b/frontend/src/styles/base/responsive.css
@@ -223,16 +223,6 @@
     flex-shrink: 0;
   }
 
-  .fan-dropdown {
-    flex: 1;
-    min-width: 0;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 12px;
-    box-sizing: border-box;
-  }
-
   /* Fan Profiles */
   .fan-profiles-section {
     padding: 0 !important; /* Remove section padding, container handles it */

--- a/frontend/src/styles/components/badges.css
+++ b/frontend/src/styles/components/badges.css
@@ -188,8 +188,3 @@
   cursor: not-allowed;
 }
 
-/* For stealth-select dropdowns, only dim the display layer, not the hidden select-engine */
-.system-card.read-only .stealth-select-wrapper {
-  opacity: 0.5;
-  cursor: not-allowed;
-}

--- a/frontend/src/styles/components/forms.css
+++ b/frontend/src/styles/components/forms.css
@@ -25,8 +25,7 @@
 }
 
 .form-group input,
-.form-group textarea,
-.form-group select {
+.form-group textarea {
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--border-color);
@@ -38,8 +37,7 @@
 }
 
 .form-group input:focus,
-.form-group textarea:focus,
-.form-group select:focus {
+.form-group textarea:focus {
   outline: none;
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.1);
@@ -59,45 +57,6 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-lg);
-}
-
-/* Dropdowns */
-.refresh-rate-dropdown,
-.agent-interval-select {
-  background: var(--bg-secondary);
-  border: 2px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  color: var(--text-primary);
-  font-size: var(--font-size-base);
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.refresh-rate-dropdown:hover,
-.agent-interval-select:hover {
-  border-color: var(--color-info);
-}
-
-.refresh-rate-dropdown:focus,
-.agent-interval-select:focus {
-  outline: none;
-  border-color: var(--color-info);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
-}
-
-.agent-interval-select {
-  border-width: 1px;
-  padding: 2px var(--spacing-sm);
-  font-size: var(--font-size-sm);
-  width: 60px;
-  min-width: 60px;
-  max-width: 80px;
-}
-
-.agent-interval-select:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 /* Sliders */
@@ -147,97 +106,6 @@
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-sm);
   font-size: var(--font-size-sm);
-}
-
-/* ===================================
-   Stealth-Overlay Dropdown Pattern
-   - Structural only. Visuals are inherited from original classes.
-   =================================== */
-
-.stealth-select-wrapper {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
-  border-radius: var(--radius-sm);
-  padding: 2px;
-}
-
-/* The native select - Invisible but handles interaction and OS picker */
-.select-engine {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  z-index: 2;
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
-  appearance: none;
-}
-
-/* The visible display layer - Adds the arrow and cleans up alignment */
-.select-display {
-  z-index: 1;
-  pointer-events: none;
-  white-space: nowrap;
-  display: flex !important;
-  align-items: center;
-  /* Reusing original padding logic + room for arrow */
-  padding-right: 24px !important; 
-  text-align: left;
-  border-radius: inherit;
-  transition: inherit;
-}
-
-/* Restoring the Chevron Arrow */
-.stealth-select-wrapper::after {
-  content: "";
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 10px;
-  height: 6px;
-  background-color: var(--text-primary);
-  opacity: 0.6;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1L5 5L9 1' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat center;
-  mask-size: contain;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1L5 5L9 1' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat center;
-  -webkit-mask-size: contain;
-  pointer-events: none;
-  z-index: 1;
-  transition: all 0.2s ease;
-}
-
-.stealth-select-wrapper:hover::after {
-  opacity: 1;
-  background-color: var(--color-accent-dynamic);
-}
-
-/* Option E: Soft Focus (Minimalist) */
-.stealth-select-wrapper:hover:not(:has(.select-engine:disabled)) {
-  background: color-mix(in srgb, var(--color-hover-tint-dynamic) 8%, var(--bg-secondary));
-  border-color: var(--color-accent-dynamic);
-}
-
-.stealth-select-wrapper::before {
-  display: none; /* Removed the extra bracket */
-}
-
-/* Ensure the display layer matches the wrapper's border */
-.select-engine:hover ~ .select-display {
-  border-color: var(--color-info) !important;
-}
-
-.select-engine:focus ~ .select-display {
-  border-color: var(--color-accent-dynamic) !important;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2) !important;
-}
-
-.select-engine:disabled ~ .select-display {
-  opacity: 0.6 !important;
-  background: var(--bg-secondary) !important;
-  transform: none !important;
 }
 
 /* ===================================

--- a/frontend/src/styles/tokens/typography.css
+++ b/frontend/src/styles/tokens/typography.css
@@ -10,18 +10,21 @@
   --font-secondary: var(--font-secondary-default);
   --font-mono: var(--font-secondary);
 
+  /* UI font scale (Settings > Appearance); 1 = designed size */
+  --font-scale: 1;
+
   /* Font Sizes */
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
-  --font-size-sm2: 13px;
-  --font-size-base: 14px;
-  --font-size-md: 15px;
-  --font-size-lg: 18px;
-  --font-size-lg2: 20px;
-  --font-size-xlg: 22px;
-  --font-size-xl: 26px;
-  --font-size-2xl: 32px;
-  --font-size-3xl: 48px;
+  --font-size-xs: calc(11px * var(--font-scale));
+  --font-size-sm: calc(12px * var(--font-scale));
+  --font-size-sm2: calc(13px * var(--font-scale));
+  --font-size-base: calc(14px * var(--font-scale));
+  --font-size-md: calc(15px * var(--font-scale));
+  --font-size-lg: calc(18px * var(--font-scale));
+  --font-size-lg2: calc(20px * var(--font-scale));
+  --font-size-xlg: calc(22px * var(--font-scale));
+  --font-size-xl: calc(26px * var(--font-scale));
+  --font-size-2xl: calc(32px * var(--font-scale));
+  --font-size-3xl: calc(48px * var(--font-scale));
 
   /* Font Weights */
   --font-weight-normal: 400;

--- a/frontend/src/systems/components/BmcProfilePicker.tsx
+++ b/frontend/src/systems/components/BmcProfilePicker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Check, AlertCircle } from 'lucide-react';
 import { getProfileCatalog, type ProfileCatalog, type ProfileCatalogEntry } from '../../services/api';
 import { formatModelFamily } from '../../utils/formatters';
+import { Select } from '../../components/ui/Select';
 
 interface BmcProfilePickerProps {
   selectedProfileId: string | null;
@@ -11,9 +12,8 @@ interface BmcProfilePickerProps {
 
 /**
  * Per-system BMC profile picker used inside SystemCard.
- * Reuses system-card design language (fan-control-row + control-label +
- * stealth-select-wrapper). Data/cascade logic mirrors the deployment-page
- * IpmiProfileSelector but renders inline-per-row instead of two-up.
+ * Data/cascade logic mirrors the deployment-page IpmiProfileSelector but
+ * renders inline-per-row (fan-control-row) instead of two-up.
  */
 const BmcProfilePicker: React.FC<BmcProfilePickerProps> = ({
   selectedProfileId,
@@ -81,44 +81,30 @@ const BmcProfilePicker: React.FC<BmcProfilePickerProps> = ({
       <div className="fan-controls">
         <div className="fan-control-row">
           <label className="control-label">Vendor:</label>
-          <div className="stealth-select-wrapper">
-            <div className="select-display">
-              {selectedVendor || 'Select vendor...'}
-            </div>
-            <select
-              className="select-engine"
-              value={selectedVendor}
-              onChange={(e) => handleVendorChange(e.target.value)}
-              disabled={disabled}
-            >
-              <option value="">Select vendor...</option>
-              {vendors.map(v => (
-                <option key={v.name} value={v.name}>{v.name}</option>
-              ))}
-            </select>
-          </div>
+          <Select
+            value={selectedVendor}
+            onChange={handleVendorChange}
+            options={[
+              { value: '', label: 'Select vendor...' },
+              ...vendors.map(v => ({ value: v.name, label: v.name })),
+            ]}
+            disabled={disabled}
+            ariaLabel="BMC vendor"
+          />
         </div>
 
         <div className="fan-control-row">
           <label className="control-label">Model:</label>
-          <div className="stealth-select-wrapper">
-            <div className="select-display">
-              {selectedModel ? renderModelLabel(selectedModel) : 'Select model...'}
-            </div>
-            <select
-              className="select-engine"
-              value={selectedProfileId || ''}
-              onChange={(e) => handleModelChange(e.target.value)}
-              disabled={disabled || !selectedVendor}
-            >
-              <option value="">Select model...</option>
-              {models.map(m => (
-                <option key={m.profile_id} value={m.profile_id}>
-                  {renderModelLabel(m)}
-                </option>
-              ))}
-            </select>
-          </div>
+          <Select
+            value={selectedProfileId || ''}
+            onChange={handleModelChange}
+            options={[
+              { value: '', label: 'Select model...' },
+              ...models.map(m => ({ value: m.profile_id, label: renderModelLabel(m) })),
+            ]}
+            disabled={disabled || !selectedVendor}
+            ariaLabel="BMC model"
+          />
         </div>
       </div>
 

--- a/frontend/src/systems/components/BulkEditPanel.tsx
+++ b/frontend/src/systems/components/BulkEditPanel.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import type { FanReading, SensorReading } from '../../types/api';
-import type { FanProfile } from '../../services/fanProfilesApi';
+import type { FanReading } from '../../types/api';
 import { useContextualPanel } from '../hooks/useContextualPanel';
-import { sortSensorGroupIds, deriveSensorGroupId } from '../../utils/sensorUtils';
-import { formatTemperature } from '../../utils/formatters';
 import { toast } from '../../utils/toast';
+import { Select } from '../../components/ui/Select';
+import type { SelectGroup, SelectOption } from '../../components/ui/Select';
+import { NO_PROFILE } from './profileSelectOptions';
+import { renderSensorTrigger, renderSensorOption } from './sensorSelectOptions';
 import {
   X,
   CheckSquare,
@@ -16,14 +17,19 @@ import '../styles/bulk-edit-panel.css';
 
 interface BulkEditPanelProps {
   fans: FanReading[];
-  sensors: SensorReading[];
-  profiles: FanProfile[];
   onApply: (fanIds: string[], sensorId?: string, profileId?: number) => Promise<void>;
-  getSensorDisplayName: (id: string, name: string, label: string) => string;
   getFanDisplayName: (id: string, name: string, label: string) => string;
-  getChipDisplayName: (chipId: string) => string;
-  groupSensorsByChip: (sensors: SensorReading[]) => Record<string, SensorReading[]>;
-  highestTemperature: number | null;
+  // Option lists + renderers built by SystemCard - same content as the
+  // per-fan Control Sensor / Fan Profile dropdowns, "" row = "Don't change"
+  sensorOptions: SelectGroup<string>[];
+  profileOptions: SelectGroup<number>[];
+  profileRenderers: {
+    renderTrigger: (selected: SelectOption<number> | null) => React.ReactNode;
+    renderOption: (
+      opt: SelectOption<number>,
+      state: { active: boolean; selected: boolean }
+    ) => React.ReactNode;
+  };
   isOpen: boolean;
   anchorRect: DOMRect | null;
   onClose: () => void;
@@ -43,14 +49,11 @@ const formatZoneName = (zoneId: string): string => {
  */
 export const BulkEditPanel: React.FC<BulkEditPanelProps> = ({
   fans,
-  sensors,
-  profiles,
   onApply,
-  getSensorDisplayName,
   getFanDisplayName,
-  getChipDisplayName,
-  groupSensorsByChip,
-  highestTemperature,
+  sensorOptions,
+  profileOptions,
+  profileRenderers,
   isOpen,
   anchorRect,
   onClose
@@ -176,60 +179,17 @@ export const BulkEditPanel: React.FC<BulkEditPanelProps> = ({
   const renderSensorDropdown = () => (
     <div className="control-group" title="The sensor used to control the speed of selected fans">
       <label htmlFor="bulk-sensor">Set Control Sensor:</label>
-      <select
+      <Select
         id="bulk-sensor"
-        className="bulk-edit-select"
         value={bulkSensorId}
-        onChange={(e) => setBulkSensorId(e.target.value)}
-      >
-        <option value="">Don't change</option>
-        <option value="__highest__">
-          Highest ({formatTemperature(highestTemperature, '0.0°C')})
-        </option>
-        <option disabled>────────────────────</option>
-
-        {(() => {
-          const sensorGroups = groupSensorsByChip(sensors);
-          const sortedGroupIds = sortSensorGroupIds(Object.keys(sensorGroups));
-          const groupsWithMultipleSensors = sortedGroupIds.filter(
-            groupId => sensorGroups[groupId].length > 1
-          );
-
-          if (groupsWithMultipleSensors.length === 0) return null;
-
-          return (
-            <>
-              <option disabled>(Groups)</option>
-              {groupsWithMultipleSensors.map(groupId => {
-                const groupSensors = sensorGroups[groupId];
-                const highestTemp = Math.max(...groupSensors.map(s => s.temperature));
-                return (
-                  <option
-                    key={`group-${groupId}`}
-                    value={`__group__${groupId}`}
-                    title="Selecting a group uses the Highest Temperature of that group"
-                  >
-                    {getChipDisplayName(groupId)} ({formatTemperature(highestTemp)})
-                  </option>
-                );
-              })}
-              <option disabled>────────────────────</option>
-            </>
-          );
-        })()}
-
-        <option disabled>(Sensors)</option>
-        {[...sensors].sort((a, b) => {
-          const groupA = deriveSensorGroupId(a);
-          const groupB = deriveSensorGroupId(b);
-          if (groupA !== groupB) return groupA.localeCompare(groupB);
-          return a.id.localeCompare(b.id);
-        }).map((sensor) => (
-          <option key={sensor.id} value={sensor.id}>
-            {getSensorDisplayName(sensor.id, sensor.name, sensor.label)} ({formatTemperature(sensor.temperature)})
-          </option>
-        ))}
-      </select>
+        onChange={setBulkSensorId}
+        options={sensorOptions}
+        renderTrigger={renderSensorTrigger}
+        renderOption={renderSensorOption}
+        searchable
+        menuMaxHeight={320}
+        ariaLabel="Set Control Sensor"
+      />
     </div>
   );
 
@@ -237,19 +197,16 @@ export const BulkEditPanel: React.FC<BulkEditPanelProps> = ({
   const renderProfileDropdown = () => (
     <div className="control-group" title="The behavior curve or manual speed to apply to selected fans">
       <label htmlFor="bulk-profile">Set Fan Profile:</label>
-      <select
+      <Select
         id="bulk-profile"
-        className="bulk-edit-select"
-        value={bulkProfileId || ''}
-        onChange={(e) => setBulkProfileId(e.target.value ? parseInt(e.target.value) : undefined)}
-      >
-        <option value="">Don't change</option>
-        {profiles.map((profile) => (
-          <option key={profile.id} value={profile.id}>
-            {profile.profile_name} ({profile.created_by === 'system' ? 'default' : 'custom'})
-          </option>
-        ))}
-      </select>
+        value={bulkProfileId ?? NO_PROFILE}
+        onChange={(v) => setBulkProfileId(v === NO_PROFILE ? undefined : v)}
+        options={profileOptions}
+        renderTrigger={profileRenderers.renderTrigger}
+        renderOption={profileRenderers.renderOption}
+        searchable
+        ariaLabel="Set Fan Profile"
+      />
     </div>
   );
 

--- a/frontend/src/systems/components/SensorBuilderModal.tsx
+++ b/frontend/src/systems/components/SensorBuilderModal.tsx
@@ -15,6 +15,7 @@ import { getSensorDisplayName } from '../../utils/displayNames';
 import { formatTemperature } from '../../utils/formatters';
 import { createVirtualSensor, updateVirtualSensor, deleteVirtualSensor, getVirtualSensorUsage } from '../../services/virtualSensorsApi';
 import { toast } from '../../utils/toast';
+import { Select } from '../../components/ui/Select';
 import '../styles/bulk-edit-panel.css';
 import '../styles/virtual-sensor-modals.css';
 
@@ -192,17 +193,12 @@ const SensorBuilderModal: React.FC<SensorBuilderModalProps> = ({
               </div>
               <div className="form-group">
                 <label htmlFor="vs-op">Operation</label>
-                <select
+                <Select<SensorAggregateOp>
                   id="vs-op"
                   value={operation}
-                  onChange={(e) => setOperation(e.target.value as SensorAggregateOp)}
-                >
-                  {operationOptions.map((o) => (
-                    <option key={o.value} value={o.value}>
-                      {o.label}
-                    </option>
-                  ))}
-                </select>
+                  onChange={setOperation}
+                  options={operationOptions.map((o) => ({ value: o.value, label: o.label }))}
+                />
                 {selectedOption?.description && <p className="vs-op-desc">{selectedOption.description}</p>}
               </div>
               <div className="vs-summary-divider" />

--- a/frontend/src/systems/components/SystemCard.tsx
+++ b/frontend/src/systems/components/SystemCard.tsx
@@ -27,6 +27,10 @@ import {
 } from "../../services/fanProfilesApi";
 import { getFanProfileTypes } from "../../services/fanProfileTypesApi";
 import type { FanProfileType } from "../../services/fanProfileTypesApi";
+import { Select } from "../../components/ui/Select";
+import type { SelectOption } from "../../components/ui/Select";
+import { buildProfileOptions, makeProfileRenderers, NO_PROFILE } from "./profileSelectOptions";
+import { buildSensorOptions, renderSensorTrigger, renderSensorOption } from "./sensorSelectOptions";
 import {
   setFanSensor,
   getFanConfigurations,
@@ -34,7 +38,7 @@ import {
 import { getChipDisplayName, getSensorLabel } from "../../config/sensorLabels";
 import { sortSensorGroups, deriveSensorGroupId, groupSensorsByChip, compareSensorGroups } from "../../utils/sensorUtils";
 import { sortByOrder } from "../../utils/ordering";
-import { getSensorDisplayName, getFanDisplayName } from "../../utils/displayNames";
+import { getFanDisplayName } from "../../utils/displayNames";
 import { getTemperatureClass, getFanRPMClass } from "../../utils/statusColors";
 import { formatTemperature, formatLastSeen, USER_TIMEZONE } from "../../utils/formatters";
 import { useDashboardSettings } from "../../contexts/DashboardSettingsContext";
@@ -71,6 +75,20 @@ import BmcProfilePicker from "./BmcProfilePicker";
 import { useSensorHistory } from "../hooks/useSensorHistory";
 import { assignProfileToAgent } from "../../services/api";
 import { getOption, getValues, getLabel, getCleanLabel, getDefault, interpolateTooltip } from "../../utils/uiOptions";
+
+// Settings-select options from the ui-options.json SST (static per session)
+const toSelectOptions = <T extends string | number>(key: Parameters<typeof getValues>[0]) =>
+  (getValues(key) as { value: T; label: string }[]).map(
+    (o): SelectOption<T> => ({ value: o.value, label: o.label })
+  );
+const SETTING_OPTIONS = {
+  logLevel: toSelectOptions<string>('logLevel'),
+  emergencyTemp: toSelectOptions<number>('emergencyTemp'),
+  failsafeSpeed: toSelectOptions<number>('failsafeSpeed'),
+  updateInterval: toSelectOptions<number>('updateInterval'),
+  fanStep: toSelectOptions<number>('fanStep'),
+  hysteresis: toSelectOptions<number>('hysteresis'),
+};
 
 interface SystemCardProps {
   system: SystemData;
@@ -339,6 +357,22 @@ const SystemCard: React.FC<SystemCardProps> = ({
     user.sort(byName);
     return { systemProfiles: system, userProfiles: user };
   }, [fanProfiles]);
+
+  // Design1 <Select> parts for the Fan Profile dropdowns (zone + per-fan).
+  const profileSelectGroups = useMemo(
+    () => buildProfileOptions(systemProfiles, userProfiles),
+    [systemProfiles, userProfiles]
+  );
+  const profileRenderers = useMemo(() => makeProfileRenderers(typeColorMap), [typeColorMap]);
+  // Bulk-edit variants: same lists, "" row reads "Don't change"
+  const bulkProfileGroups = useMemo(
+    () => buildProfileOptions(systemProfiles, userProfiles, "Don't change"),
+    [systemProfiles, userProfiles]
+  );
+  const bulkProfileRenderers = useMemo(
+    () => makeProfileRenderers(typeColorMap, "Don't change"),
+    [typeColorMap]
+  );
 
   // Load fan profiles, assignments, and configurations on mount and when hardware structure changes
   useEffect(() => {
@@ -1051,6 +1085,24 @@ const SystemCard: React.FC<SystemCardProps> = ({
     return isGroupHidden(chipName);
   };
 
+  // Control Sensor dropdown (Design1 <Select>) - one option list shared by
+  // the zone + per-fan dropdowns. Recomputed per render, like the Design0
+  // inline <option> lists were, so temperatures stay live while open.
+  const dropdownSensors =
+    system.current_temperatures?.filter(
+      (sensor: SensorReading) => !isSensorOrGroupHidden(sensor)
+    ) || [];
+  const dropdownSensorGroups = groupSensorsByChip(dropdownSensors);
+  const sensorOptionInputs = {
+    highestTemperature,
+    virtualRows,
+    sensorGroups: dropdownSensorGroups,
+    sortedGroupIds: orderGroupIds(Object.keys(dropdownSensorGroups)),
+    sortedSensors: [...dropdownSensors].sort(compareSensorsForDropdown),
+  };
+  const sensorSelectGroups = buildSensorOptions(sensorOptionInputs);
+  const bulkSensorGroups = buildSensorOptions({ ...sensorOptionInputs, emptyLabel: "Don't change" });
+
   // Helper to check if agent is read-only (over license limit OR IPMI without profile)
   const isIpmiNoProfile = (system.agent_type === 'ipmi_host' || system.agent_type === 'ipmi_network') && !system.profile_id && system.status === 'online';
   const isReadOnly = system.read_only === true || isIpmiNoProfile;
@@ -1298,19 +1350,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <Activity size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('logLevel')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('logLevel', logLevel)}</div>
-                  <select
-                    className="select-engine"
-                    value={logLevel}
-                    onChange={(e) => handleLogLevelChange(e.target.value)}
-                    disabled={loading === "log-level" || isReadOnly}
-                  >
-                    {(getValues('logLevel') as { value: string; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={logLevel}
+                  onChange={handleLogLevelChange}
+                  options={SETTING_OPTIONS.logLevel}
+                  renderTrigger={() => getCleanLabel('logLevel', logLevel)}
+                  disabled={loading === "log-level" || isReadOnly}
+                  ariaLabel={getLabel('logLevel')}
+                />
               </div>
 
               {/* Row 2: Emergency Temp, Failsafe Speed */}
@@ -1319,19 +1366,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <Thermometer size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('emergencyTemp')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('emergencyTemp', emergencyTemp)}</div>
-                  <select
-                    className="select-engine"
-                    value={emergencyTemp}
-                    onChange={(e) => handleEmergencyTempChange(parseFloat(e.target.value))}
-                    disabled={loading === "emergency-temp" || isReadOnly}
-                  >
-                    {(getValues('emergencyTemp') as { value: number; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={emergencyTemp}
+                  onChange={handleEmergencyTempChange}
+                  options={SETTING_OPTIONS.emergencyTemp}
+                  renderTrigger={() => getCleanLabel('emergencyTemp', emergencyTemp)}
+                  disabled={loading === "emergency-temp" || isReadOnly}
+                  ariaLabel={getLabel('emergencyTemp')}
+                />
               </div>
 
               <div className="command-item" title={interpolateTooltip(getOption('failsafeSpeed').tooltip, tooltipContext)}>
@@ -1339,19 +1381,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <Wind size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('failsafeSpeed')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('failsafeSpeed', failsafeSpeed)}</div>
-                  <select
-                    className="select-engine"
-                    value={failsafeSpeed}
-                    onChange={(e) => handleFailsafeSpeedChange(parseFloat(e.target.value))}
-                    disabled={loading === "failsafe-speed" || isReadOnly}
-                  >
-                    {(getValues('failsafeSpeed') as { value: number; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={failsafeSpeed}
+                  onChange={handleFailsafeSpeedChange}
+                  options={SETTING_OPTIONS.failsafeSpeed}
+                  renderTrigger={() => getCleanLabel('failsafeSpeed', failsafeSpeed)}
+                  disabled={loading === "failsafe-speed" || isReadOnly}
+                  ariaLabel={getLabel('failsafeSpeed')}
+                />
               </div>
 
               {/* Row 3: Agent Rate, Fan Step, Hysteresis */}
@@ -1360,19 +1397,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <Activity size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('updateInterval')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('updateInterval', agentInterval)}</div>
-                  <select
-                    className="select-engine"
-                    value={agentInterval}
-                    onChange={(e) => handleAgentIntervalChange(parseFloat(e.target.value))}
-                    disabled={loading === "agent-interval" || isReadOnly}
-                  >
-                    {(getValues('updateInterval') as { value: number; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={agentInterval}
+                  onChange={handleAgentIntervalChange}
+                  options={SETTING_OPTIONS.updateInterval}
+                  renderTrigger={() => getCleanLabel('updateInterval', agentInterval)}
+                  disabled={loading === "agent-interval" || isReadOnly}
+                  ariaLabel={getLabel('updateInterval')}
+                />
               </div>
 
               <div className="command-item" title={interpolateTooltip(getOption('fanStep').tooltip, tooltipContext)}>
@@ -1380,19 +1412,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <ChevronRight size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('fanStep')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('fanStep', fanStep)}</div>
-                  <select
-                    className="select-engine"
-                    value={fanStep}
-                    onChange={(e) => handleFanStepChange(parseFloat(e.target.value))}
-                    disabled={loading === "fan-step" || isReadOnly}
-                  >
-                    {(getValues('fanStep') as { value: number; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={fanStep}
+                  onChange={handleFanStepChange}
+                  options={SETTING_OPTIONS.fanStep}
+                  renderTrigger={() => getCleanLabel('fanStep', fanStep)}
+                  disabled={loading === "fan-step" || isReadOnly}
+                  ariaLabel={getLabel('fanStep')}
+                />
               </div>
 
               <div className="command-item" title={interpolateTooltip(getOption('hysteresis').tooltip, tooltipContext)}>
@@ -1400,19 +1427,14 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <Thermometer size={12} className="label-icon" />
                   <span className="stat-label">{getLabel('hysteresis')}</span>
                 </div>
-                <div className="stealth-select-wrapper">
-                  <div className="select-display">{getCleanLabel('hysteresis', hysteresis)}</div>
-                  <select
-                    className="select-engine"
-                    value={hysteresis}
-                    onChange={(e) => handleHysteresisChange(parseFloat(e.target.value))}
-                    disabled={loading === "hysteresis" || isReadOnly}
-                  >
-                    {(getValues('hysteresis') as { value: number; label: string }[]).map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  value={hysteresis}
+                  onChange={handleHysteresisChange}
+                  options={SETTING_OPTIONS.hysteresis}
+                  renderTrigger={() => getCleanLabel('hysteresis', hysteresis)}
+                  disabled={loading === "hysteresis" || isReadOnly}
+                  ariaLabel={getLabel('hysteresis')}
+                />
               </div>
             </div>
           </div>
@@ -1825,231 +1847,67 @@ const SystemCard: React.FC<SystemCardProps> = ({
                         {/* Sensor Selection Dropdown */}
                         <div className="fan-control-row">
                           <label className="control-label">Control Sensor:</label>
-                          <div className="stealth-select-wrapper sensor-select">
-                            <div className="select-display sensor-select-display">
-                              {(() => {
-                                const val = selectedSensors[representativeFan.id] || "";
-                                if (!val) return <span className="sensor-select-name">Select Sensor...</span>;
-                                if (val === "__highest__") return (
-                                  <>
-                                    <span className="sensor-select-name">Highest</span>
-                                    <span className="sensor-select-temp">({formatTemperature(highestTemperature, '0.0°C')})</span>
-                                  </>
-                                );
-                                if (val.startsWith("__virtual__")) {
-                                  const vrow = virtualRows.find(r => r.reading.id === val);
-                                  return (
-                                    <>
-                                      <span className="sensor-select-name">{vrow ? vrow.def.name : val}</span>
-                                      {vrow && !Number.isNaN(vrow.reading.temperature) && (
-                                        <span className="sensor-select-temp">({formatTemperature(vrow.reading.temperature)})</span>
-                                      )}
-                                    </>
-                                  );
-                                }
-                                if (val.startsWith("__group__")) {
-                                  const groupId = val.replace("__group__", "");
-                                  const visibleSensorsForGroups = system.current_temperatures?.filter(
-                                    (s: SensorReading) => !isSensorOrGroupHidden(s)
-                                  ) || [];
-                                  const groups = groupSensorsByChip(visibleSensorsForGroups);
-                                  const groupSensors = groups[groupId] || [];
-                                  const temp = groupSensors.length > 0
-                                    ? Math.max(...groupSensors.map(s => s.temperature))
-                                    : null;
-                                  return (
-                                    <>
-                                      <span className="sensor-select-name">{getChipDisplayName(groupId, groupSensors)}</span>
-                                      {temp !== null && <span className="sensor-select-temp">({formatTemperature(temp)})</span>}
-                                    </>
-                                  );
-                                }
-                                const sensor = system.current_temperatures?.find((s: SensorReading) => s.id === val);
-                                if (sensor) return (
-                                  <>
-                                    <span className="sensor-select-name">{getSensorDisplayName(sensor.id, sensor.name, sensor.label)}</span>
-                                    <span className="sensor-select-temp">({formatTemperature(sensor.temperature)})</span>
-                                  </>
-                                );
-                                return <span className="sensor-select-name">{val}</span>;
-                              })()}
-                            </div>
-                            <select
-                              className="select-engine"
-                              value={selectedSensors[representativeFan.id] || ""}
-                              onChange={async (e) => {
-                                await handleZoneSensorChange(zoneFans, e.target.value);
-                              }}
-                              disabled={system.status !== "online" || isReadOnly}
-                            >
-                              <option value="">Select Sensor...</option>
-                              <option value="__highest__" title="Use the Highest Temperature on the system">
-                                Highest ({formatTemperature(highestTemperature, '0.0°C')})
-                              </option>
-                              {virtualRows.length > 0 && (
-                                <optgroup label="Virtual">
-                                  {virtualRows.map(({ def, reading }) => (
-                                    <option key={reading.id} value={reading.id} title="Virtual sensor">
-                                      {def.name}{!Number.isNaN(reading.temperature) ? ` (${formatTemperature(reading.temperature)})` : ''}
-                                    </option>
-                                  ))}
-                                </optgroup>
-                              )}
-                              {(() => {
-                                const visibleSensors = system.current_temperatures?.filter(
-                                  (sensor: SensorReading) => !isSensorOrGroupHidden(sensor)
-                                ) || [];
-                                const sensorGroups = groupSensorsByChip(visibleSensors);
-                                const sortedGroupIds = orderGroupIds(Object.keys(sensorGroups));
-                                const groupsWithMultipleSensors = sortedGroupIds.filter(
-                                  (groupId) => sensorGroups[groupId].length > 1
-                                );
-                                if (groupsWithMultipleSensors.length === 0) return null;
-                                return (
-                                  <optgroup label="Groups">
-                                    {groupsWithMultipleSensors.map((groupId) => {
-                                      const groupSensors = sensorGroups[groupId];
-                                      const highestTemp = Math.max(...groupSensors.map((s) => s.temperature));
-                                      return (
-                                        <option key={`group-${groupId}`} value={`__group__${groupId}`}
-                                          title="Selecting a group uses the Highest Temperature of that group"
-                                        >
-                                          {getChipDisplayName(groupId, groupSensors)} ({formatTemperature(highestTemp)})
-                                        </option>
-                                      );
-                                    })}
-                                  </optgroup>
-                                );
-                              })()}
-                              <optgroup label="Sensors">
-                                {system.current_temperatures
-                                  ?.filter((sensor: SensorReading) => !isSensorOrGroupHidden(sensor))
-                                  .sort(compareSensorsForDropdown)
-                                  .map((sensor: SensorReading) => (
-                                    <option key={sensor.id} value={sensor.id}>
-                                      {getSensorDisplayName(sensor.id, sensor.name, sensor.label)}{" "}
-                                      ({formatTemperature(sensor.temperature)})
-                                    </option>
-                                  ))}
-                              </optgroup>
-                            </select>
-                          </div>
+                          {/* Control Sensor (Design1 <Select>) - grouped
+                            * Virtual / Groups / Sensors options with search;
+                            * name + temp on the trigger and on every open
+                            * row. Options built once per render in
+                            * sensorSelectGroups (shared with per-fan). */}
+                          <Select
+                            value={selectedSensors[representativeFan.id] || ""}
+                            onChange={(newSensorId) => {
+                              void handleZoneSensorChange(zoneFans, newSensorId);
+                            }}
+                            options={sensorSelectGroups}
+                            renderTrigger={renderSensorTrigger}
+                            renderOption={renderSensorOption}
+                            searchable
+                            menuMaxHeight={320}
+                            disabled={system.status !== "online" || isReadOnly}
+                            ariaLabel="Control Sensor"
+                            className="sensor-select"
+                          />
                         </div>
 
-                        {/* Profile Selection Dropdown
+                        {/* Profile Selection Dropdown (Design1 <Select>)
                          *
-                         * Closed `.select-display` shows a real status-dot
-                         * (.profile-color-dot) tinted by the selected
-                         * profile's profile_type color, plus the name and a
-                         * (System|User) badge-style suffix.
-                         *
-                         * The native popup is sorted into Manual -> System
-                         * (A-Z) -> User (A-Z) via <optgroup>; each <option>
-                         * is text-coloured by profile_type so the user sees
-                         * the same hue used by the profile-type badges in
-                         * the Fan Profile Manager. The trailing bullet (U+25CF,
-                         * BLACK CIRCLE) reinforces the colour cue inside the
-                         * option text since native <option> cannot host a
-                         * separate styled element.
+                         * Closed trigger and open rows share the same cues:
+                         * .profile-color-dot tinted by profile_type + name +
+                         * (type) suffix. The open list is our own DOM
+                         * (pk-select-*), so the dot cue works there too -
+                         * the old native popup could not host a styled
+                         * element. Order: Manual -> System (A-Z) -> User
+                         * (A-Z), via headerless + labeled option groups.
                          */}
                         <div className="fan-control-row">
                           <label className="control-label">Fan Profile:</label>
-                          <div className="stealth-select-wrapper fan-profile-select">
-                            {/* Closed-state visible chip. Real styled
-                             * `.profile-color-dot` span + name + (type)
-                             * suffix. The dot uses profile_type colour,
-                             * the text inherits the regular text colour.
-                             */}
-                            <div className="select-display">
-                              {(() => {
-                                const selected = fanProfiles.find(p => p.id === selectedProfiles[representativeFan.id]);
-                                if (!selected) return 'No Profile';
-                                const dotColor = typeColorMap[selected.profile_type] || null;
-                                return (
-                                  <>
-                                    {dotColor && (
-                                      <span
-                                        className="profile-color-dot"
-                                        style={{ background: dotColor }}
-                                      />
-                                    )}
-                                    <span className="profile-name-label">{selected.profile_name}</span>
-                                    <span className="profile-type-label">({selected.profile_type})</span>
-                                  </>
-                                );
-                              })()}
-                            </div>
-                            {/* Native popup uses the sensor-select grouping
-                             * pattern: disabled separator + disabled label
-                             * row act as section headers. The whole option
-                             * text is profile_type-coloured (native <option>
-                             * cannot scope colour to just the U+25CF
-                             * trailing bullet, so the entire row inherits
-                             * the colour) - the closed state above is
-                             * where the "only dot coloured" appearance
-                             * lives, in a real DOM element.
-                             */}
-                            <select
-                              className="select-engine"
-                              value={selectedProfiles[representativeFan.id] || ""}
-                              onChange={(e) => {
-                                const profileId = e.target.value;
-                                if (profileId) {
-                                  handleZoneProfileAssignment(zoneFans, parseInt(profileId));
-                                } else {
-                                  // Clear profile for all fans in zone
-                                  const updates: Record<string, number> = {};
+                          <Select
+                            value={selectedProfiles[representativeFan.id] ?? NO_PROFILE}
+                            onChange={(profileId) => {
+                              if (profileId !== NO_PROFILE) {
+                                handleZoneProfileAssignment(zoneFans, profileId);
+                              } else {
+                                // Clear profile for all fans in zone
+                                setSelectedProfiles(prev => {
+                                  const updated = { ...prev };
                                   for (const f of zoneFans) {
-                                    delete updates[f.id];
+                                    delete updated[f.id];
                                   }
-                                  setSelectedProfiles(prev => {
-                                    const updated = { ...prev };
-                                    for (const f of zoneFans) {
-                                      delete updated[f.id];
-                                    }
-                                    return updated;
-                                  });
-                                }
-                              }}
-                              disabled={
-                                loading === zoneLoadingKey ||
-                                system.status !== "online" ||
-                                isReadOnly
+                                  return updated;
+                                });
                               }
-                            >
-                              <option value="">No Profile (Manual)</option>
-                              {systemProfiles.length > 0 && (
-                                <>
-                                  <option disabled>────────────────────</option>
-                                  <option disabled>(System)</option>
-                                  {systemProfiles.map((profile: FanProfile) => (
-                                    <option
-                                      key={profile.id}
-                                      value={profile.id}
-                                      title={profile.description || profile.profile_name}
-                                    >
-                                      {profile.profile_name} ({profile.profile_type})
-                                    </option>
-                                  ))}
-                                </>
-                              )}
-                              {userProfiles.length > 0 && (
-                                <>
-                                  <option disabled>────────────────────</option>
-                                  <option disabled>(User)</option>
-                                  {userProfiles.map((profile: FanProfile) => (
-                                    <option
-                                      key={profile.id}
-                                      value={profile.id}
-                                      title={profile.description || profile.profile_name}
-                                    >
-                                      {profile.profile_name} ({profile.profile_type})
-                                    </option>
-                                  ))}
-                                </>
-                              )}
-                            </select>
-                          </div>
+                            }}
+                            options={profileSelectGroups}
+                            renderTrigger={profileRenderers.renderTrigger}
+                            renderOption={profileRenderers.renderOption}
+                            searchable
+                            disabled={
+                              loading === zoneLoadingKey ||
+                              system.status !== "online" ||
+                              isReadOnly
+                            }
+                            ariaLabel="Fan Profile"
+                            className="fan-profile-select"
+                          />
                           {loading === zoneLoadingKey && (
                             <Loader2 className="animate-spin" size={14} />
                           )}
@@ -2187,60 +2045,12 @@ const SystemCard: React.FC<SystemCardProps> = ({
                     {/* Sensor Selection Dropdown */}
                     <div className="fan-control-row">
                       <label className="control-label">Control Sensor:</label>
-                      <div className="stealth-select-wrapper sensor-select">
-                        <div className="select-display sensor-select-display">
-                          {(() => {
-                            const val = selectedSensors[fan.id] || "";
-                            if (!val) return <span className="sensor-select-name">Select Sensor...</span>;
-                            if (val === "__highest__") return (
-                              <>
-                                <span className="sensor-select-name">Highest</span>
-                                <span className="sensor-select-temp">({formatTemperature(highestTemperature, '0.0°C')})</span>
-                              </>
-                            );
-                            if (val.startsWith("__virtual__")) {
-                              const vrow = virtualRows.find(r => r.reading.id === val);
-                              return (
-                                <>
-                                  <span className="sensor-select-name">{vrow ? vrow.def.name : val}</span>
-                                  {vrow && !Number.isNaN(vrow.reading.temperature) && (
-                                    <span className="sensor-select-temp">({formatTemperature(vrow.reading.temperature)})</span>
-                                  )}
-                                </>
-                              );
-                            }
-                            if (val.startsWith("__group__")) {
-                              const groupId = val.replace("__group__", "");
-                              const visibleSensorsForGroups = system.current_temperatures?.filter(
-                                (s: SensorReading) => !isSensorOrGroupHidden(s)
-                              ) || [];
-                              const groups = groupSensorsByChip(visibleSensorsForGroups);
-                              const groupSensors = groups[groupId] || [];
-                              const temp = groupSensors.length > 0
-                                ? Math.max(...groupSensors.map(s => s.temperature))
-                                : null;
-                              return (
-                                <>
-                                  <span className="sensor-select-name">{getChipDisplayName(groupId, groupSensors)}</span>
-                                  {temp !== null && <span className="sensor-select-temp">({formatTemperature(temp)})</span>}
-                                </>
-                              );
-                            }
-                            const sensor = system.current_temperatures?.find((s: SensorReading) => s.id === val);
-                            if (sensor) return (
-                              <>
-                                <span className="sensor-select-name">{getSensorDisplayName(sensor.id, sensor.name, sensor.label)}</span>
-                                <span className="sensor-select-temp">({formatTemperature(sensor.temperature)})</span>
-                              </>
-                            );
-                            return <span className="sensor-select-name">{val}</span>;
-                          })()}
-                        </div>
-                      <select
-                        className="select-engine"
+                      {/* Control Sensor (Design1 <Select>) - mirror of the
+                        * zone-level dropdown above; same shared options,
+                        * search, and renderers. */}
+                      <Select
                         value={selectedSensors[fan.id] || ""}
-                        onChange={async (e) => {
-                          const newSensorId = e.target.value;
+                        onChange={async (newSensorId) => {
                           setSelectedSensors((prev) => ({
                             ...prev,
                             [fan.id]: newSensorId,
@@ -2273,186 +2083,51 @@ const SystemCard: React.FC<SystemCardProps> = ({
                             }
                           }
                         }}
+                        options={sensorSelectGroups}
+                        renderTrigger={renderSensorTrigger}
+                        renderOption={renderSensorOption}
+                        searchable
+                        menuMaxHeight={320}
                         disabled={system.status !== "online" || isReadOnly}
-                      >
-                        <option value="">Select Sensor...</option>
-
-                        {/* Highest Temperature Option */}
-                        <option
-                          value="__highest__"
-                          title="Use the Highest Temperature on the system"
-                        >
-                          Highest ({formatTemperature(highestTemperature, '0.0°C')})
-                        </option>
-
-                        {/* Virtual Sensors */}
-                        {virtualRows.length > 0 && (
-                          <optgroup label="Virtual">
-                            {virtualRows.map(({ def, reading }) => (
-                              <option key={reading.id} value={reading.id} title="Virtual sensor">
-                                {def.name}{!Number.isNaN(reading.temperature) ? ` (${formatTemperature(reading.temperature)})` : ''}
-                              </option>
-                            ))}
-                          </optgroup>
-                        )}
-
-                        {/* Sensor Groups Header and Options */}
-                        {(() => {
-                          const visibleSensors =
-                            system.current_temperatures?.filter(
-                              (sensor: SensorReading) =>
-                                !isSensorOrGroupHidden(sensor)
-                            ) || [];
-
-                          const sensorGroups =
-                            groupSensorsByChip(visibleSensors);
-                          const sortedGroupIds = orderGroupIds(Object.keys(sensorGroups));
-
-                          const groupsWithMultipleSensors =
-                            sortedGroupIds.filter(
-                              (groupId) => sensorGroups[groupId].length > 1
-                            );
-
-                          if (groupsWithMultipleSensors.length === 0)
-                            return null;
-
-                          return (
-                            <optgroup label="Groups">
-                              {groupsWithMultipleSensors.map((groupId) => {
-                                const groupSensors = sensorGroups[groupId];
-                                const highestTemp = Math.max(
-                                  ...groupSensors.map((s) => s.temperature)
-                                );
-                                return (
-                                  <option
-                                    key={`group-${groupId}`}
-                                    value={`__group__${groupId}`}
-                                    title="Selecting a group uses the Highest Temperature of that group"
-                                  >
-                                    {getChipDisplayName(groupId, groupSensors)}{" "}
-                                    ({formatTemperature(highestTemp)})
-                                  </option>
-                                );
-                              })}
-                            </optgroup>
-                          );
-                        })()}
-
-                        {/* Individual Sensors (sorted by group, then by ID) */}
-                        <optgroup label="Sensors">
-                          {system.current_temperatures
-                            ?.filter(
-                              (sensor: SensorReading) =>
-                                !isSensorOrGroupHidden(sensor)
-                            )
-                            .sort(compareSensorsForDropdown)
-                            .map((sensor: SensorReading) => (
-                              <option key={sensor.id} value={sensor.id}>
-                                {getSensorDisplayName(
-                                  sensor.id,
-                                  sensor.name,
-                                  sensor.label
-                                )}{" "}
-                                ({formatTemperature(sensor.temperature)})
-                              </option>
-                            ))}
-                        </optgroup>
-                      </select>
-                      </div>
+                        ariaLabel="Control Sensor"
+                        className="sensor-select"
+                      />
                     </div>
 
-                    {/* Profile Selection Dropdown
-                     *
-                     * Mirror of the zone-level dropdown above - see the
-                     * comment block there for the design rationale. Same
-                     * sort, same colour cues, same label format.
-                     */}
+                    {/* Profile Selection Dropdown (Design1 <Select>) -
+                     * mirror of the zone-level dropdown above; see that
+                     * comment block for the design rationale. */}
                     <div className="fan-control-row">
                       <label className="control-label">Fan Profile:</label>
-                      <div className="stealth-select-wrapper fan-profile-select">
-                        {/* Mirror of the zone-level dropdown above; same
-                         * sensor-pattern grouping and same closed-state
-                         * rendering. See that block for design notes. */}
-                        <div className="select-display">
-                          {(() => {
-                            const selected = fanProfiles.find(p => p.id === selectedProfiles[fan.id]);
-                            if (!selected) return 'No Profile';
-                            const dotColor = typeColorMap[selected.profile_type] || null;
-                            return (
-                              <>
-                                {dotColor && (
-                                  <span
-                                    className="profile-color-dot"
-                                    style={{ background: dotColor }}
-                                  />
-                                )}
-                                <span className="profile-name-label">{selected.profile_name}</span>
-                                <span className="profile-type-label">({selected.profile_type})</span>
-                              </>
-                            );
-                          })()}
-                        </div>
-                        <select
-                          className="select-engine"
-                          value={selectedProfiles[fan.id] || ""}
-                          onChange={(e) => {
-                            const profileId = e.target.value;
-                            if (profileId) {
-                              setSelectedProfiles((prev) => ({
-                                ...prev,
-                                [fan.id]: parseInt(profileId),
-                              }));
-                              handleFanProfileAssignment(
-                                fan,
-                                parseInt(profileId)
-                              );
-                            } else {
-                              setSelectedProfiles((prev) => {
-                                const updated = { ...prev };
-                                delete updated[fan.id];
-                                return updated;
-                              });
-                            }
-                          }}
-                          disabled={
-                            loading === `fan-profile-${fan.id}` ||
-                            system.status !== "online" ||
-                            isReadOnly
+                      <Select
+                        value={selectedProfiles[fan.id] ?? NO_PROFILE}
+                        onChange={(profileId) => {
+                          if (profileId !== NO_PROFILE) {
+                            setSelectedProfiles((prev) => ({
+                              ...prev,
+                              [fan.id]: profileId,
+                            }));
+                            handleFanProfileAssignment(fan, profileId);
+                          } else {
+                            setSelectedProfiles((prev) => {
+                              const updated = { ...prev };
+                              delete updated[fan.id];
+                              return updated;
+                            });
                           }
-                        >
-                          <option value="">No Profile (Manual)</option>
-                          {systemProfiles.length > 0 && (
-                            <>
-                              <option disabled>────────────────────</option>
-                              <option disabled>(System)</option>
-                              {systemProfiles.map((profile: FanProfile) => (
-                                <option
-                                  key={profile.id}
-                                  value={profile.id}
-                                  title={profile.description || profile.profile_name}
-                                >
-                                  {profile.profile_name} ({profile.profile_type})
-                                </option>
-                              ))}
-                            </>
-                          )}
-                          {userProfiles.length > 0 && (
-                            <>
-                              <option disabled>────────────────────</option>
-                              <option disabled>(User)</option>
-                              {userProfiles.map((profile: FanProfile) => (
-                                <option
-                                  key={profile.id}
-                                  value={profile.id}
-                                  title={profile.description || profile.profile_name}
-                                >
-                                  {profile.profile_name} ({profile.profile_type})
-                                </option>
-                              ))}
-                            </>
-                          )}
-                        </select>
-                      </div>
+                        }}
+                        options={profileSelectGroups}
+                        renderTrigger={profileRenderers.renderTrigger}
+                        renderOption={profileRenderers.renderOption}
+                        searchable
+                        disabled={
+                          loading === `fan-profile-${fan.id}` ||
+                          system.status !== "online" ||
+                          isReadOnly
+                        }
+                        ariaLabel="Fan Profile"
+                        className="fan-profile-select"
+                      />
                       {loading === `fan-profile-${fan.id}` && (
                         <Loader2 className="animate-spin" size={14} />
                       )}
@@ -2531,14 +2206,11 @@ const SystemCard: React.FC<SystemCardProps> = ({
       {/* Bulk Edit Panel */}
       <BulkEditPanel
         fans={system.current_fan_speeds || []}
-        sensors={system.current_temperatures || []}
-        profiles={fanProfiles}
         onApply={handleBulkApply}
-        getSensorDisplayName={getSensorDisplayName}
         getFanDisplayName={getFanDisplayName}
-        getChipDisplayName={getChipDisplayName}
-        groupSensorsByChip={groupSensorsByChip}
-        highestTemperature={highestTemperature}
+        sensorOptions={bulkSensorGroups}
+        profileOptions={bulkProfileGroups}
+        profileRenderers={bulkProfileRenderers}
         isOpen={isBulkEditOpen}
         anchorRect={anchorRect}
         onClose={() => setIsBulkEditOpen(false)}

--- a/frontend/src/systems/components/profileSelectOptions.tsx
+++ b/frontend/src/systems/components/profileSelectOptions.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+import type { FanProfile } from '../../services/fanProfilesApi';
+import type { SelectGroup, SelectOption } from '../../components/ui/Select';
+
+/**
+ * Options builder + renderers for the Fan Profile <Select> dropdowns in
+ * SystemCard (zone + per-fan).
+ */
+
+/** Sentinel for "No Profile (Manual)" - DB profile ids are SERIAL (>= 1). */
+export const NO_PROFILE = 0;
+
+/** Manual -> System (A-Z) -> User (A-Z); callers pass pre-sorted lists. */
+export function buildProfileOptions(
+  systemProfiles: FanProfile[],
+  userProfiles: FanProfile[],
+  emptyLabel = 'No Profile (Manual)' // bulk edit passes "Don't change"
+): SelectGroup<number>[] {
+  const toOption = (profile: FanProfile): SelectOption<number> => ({
+    value: profile.id,
+    label: `${profile.profile_name} (${profile.profile_type})`,
+    title: profile.description || profile.profile_name,
+    data: profile,
+  });
+  const groups: SelectGroup<number>[] = [
+    // Headerless group: renders as a plain top-level row.
+    { label: '', options: [{ value: NO_PROFILE, label: emptyLabel }] },
+  ];
+  if (systemProfiles.length > 0) {
+    groups.push({ label: 'System', options: systemProfiles.map(toOption) });
+  }
+  if (userProfiles.length > 0) {
+    groups.push({ label: 'User', options: userProfiles.map(toOption) });
+  }
+  return groups;
+}
+
+/**
+ * Renderers for trigger + rows: name + (type) + profile_type colour dot.
+ */
+export function makeProfileRenderers(
+  typeColorMap: Record<string, string | null>,
+  emptyTriggerLabel = 'No Profile' // bulk edit passes "Don't change"
+) {
+  const profileContent = (profile: FanProfile): ReactNode => {
+    const dotColor = typeColorMap[profile.profile_type] || null;
+    // "GPU Optimal (optimal) <dot>" - dot last; spacing from the flex gap
+    return (
+      <>
+        <span className="profile-name-label">{profile.profile_name}</span>
+        <span className="profile-type-label">({profile.profile_type})</span>
+        {dotColor && <span className="profile-color-dot" style={{ background: dotColor }} />}
+      </>
+    );
+  };
+  return {
+    renderTrigger: (selected: SelectOption<number> | null): ReactNode => {
+      const profile = selected?.data as FanProfile | undefined;
+      return profile ? profileContent(profile) : emptyTriggerLabel;
+    },
+    renderOption: (opt: SelectOption<number>): ReactNode => {
+      const profile = opt.data as FanProfile | undefined;
+      return profile ? (
+        profileContent(profile)
+      ) : (
+        <span className="pk-select-option-label">{opt.label}</span>
+      );
+    },
+  };
+}

--- a/frontend/src/systems/components/sensorSelectOptions.tsx
+++ b/frontend/src/systems/components/sensorSelectOptions.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react';
+import type { SensorReading } from '../../types/api';
+import type { VirtualSensorRow } from '../hooks/useVirtualSensors';
+import type { SelectGroup, SelectOption } from '../../components/ui/Select';
+import { formatTemperature } from '../../utils/formatters';
+import { getChipDisplayName } from '../../config/sensorLabels';
+import { getSensorDisplayName } from '../../utils/displayNames';
+
+/**
+ * Options builder + renderers for the Control Sensor <Select> dropdowns in
+ * SystemCard (zone + per-fan). Values: "" | __highest__ | __virtual__* |
+ * __group__<chip> | sensor id (unchanged from Design0).
+ */
+
+interface SensorOptionData {
+  name: string;
+  tempText: string | null;
+}
+
+export function buildSensorOptions(params: {
+  highestTemperature: number | null;
+  virtualRows: VirtualSensorRow[];
+  /** Visible (not hidden) sensors grouped by chip. */
+  sensorGroups: Record<string, SensorReading[]>;
+  /** Group ids in dashboard order (orderGroupIds). */
+  sortedGroupIds: string[];
+  /** Visible sensors in dropdown order (compareSensorsForDropdown). */
+  sortedSensors: SensorReading[];
+  /** Label for the "" row; bulk edit passes "Don't change". */
+  emptyLabel?: string;
+}): SelectGroup<string>[] {
+  const {
+    highestTemperature,
+    virtualRows,
+    sensorGroups,
+    sortedGroupIds,
+    sortedSensors,
+    emptyLabel = 'Select Sensor...',
+  } = params;
+
+  const opt = (
+    value: string,
+    name: string,
+    tempText: string | null,
+    title?: string
+  ): SelectOption<string> => ({
+    value,
+    label: tempText ? `${name} (${tempText})` : name, // search + type-ahead target
+    title,
+    data: { name, tempText } satisfies SensorOptionData,
+  });
+
+  const groups: SelectGroup<string>[] = [
+    {
+      // Headerless group: top-level rows above the labeled groups.
+      label: '',
+      options: [
+        opt('', emptyLabel, null),
+        opt(
+          '__highest__',
+          'Highest',
+          formatTemperature(highestTemperature, '0.0°C'),
+          'Use the Highest Temperature on the system'
+        ),
+      ],
+    },
+  ];
+
+  if (virtualRows.length > 0) {
+    groups.push({
+      label: 'Virtual',
+      options: virtualRows.map(({ def, reading }) =>
+        opt(
+          reading.id,
+          def.name,
+          Number.isNaN(reading.temperature) ? null : formatTemperature(reading.temperature),
+          'Virtual sensor'
+        )
+      ),
+    });
+  }
+
+  const multiSensorGroupIds = sortedGroupIds.filter((id) => sensorGroups[id].length > 1);
+  if (multiSensorGroupIds.length > 0) {
+    groups.push({
+      label: 'Groups',
+      options: multiSensorGroupIds.map((groupId) => {
+        const groupSensors = sensorGroups[groupId];
+        const highestTemp = Math.max(...groupSensors.map((s) => s.temperature));
+        return opt(
+          `__group__${groupId}`,
+          getChipDisplayName(groupId, groupSensors),
+          formatTemperature(highestTemp),
+          'Selecting a group uses the Highest Temperature of that group'
+        );
+      }),
+    });
+  }
+
+  if (sortedSensors.length > 0) {
+    groups.push({
+      label: 'Sensors',
+      options: sortedSensors.map((sensor) =>
+        opt(
+          sensor.id,
+          getSensorDisplayName(sensor.id, sensor.name, sensor.label),
+          formatTemperature(sensor.temperature)
+        )
+      ),
+    });
+  }
+
+  return groups;
+}
+
+/**
+ * Renderers: name + temp. Reuses .sensor-select-name/-temp (keep in Phase 5;
+ * only .sensor-select-display dies).
+ */
+export function renderSensorTrigger(selected: SelectOption<string> | null): ReactNode {
+  const data = selected?.data as SensorOptionData | undefined;
+  if (!data) return <span className="sensor-select-name">Select Sensor...</span>;
+  return (
+    <>
+      <span className="sensor-select-name">{data.name}</span>
+      {data.tempText && <span className="sensor-select-temp">({data.tempText})</span>}
+    </>
+  );
+}
+
+export function renderSensorOption(opt: SelectOption<string>): ReactNode {
+  const data = opt.data as SensorOptionData | undefined;
+  if (!data) return <span className="pk-select-option-label">{opt.label}</span>;
+  return (
+    <>
+      <span className="sensor-select-name">{data.name}</span>
+      {data.tempText && <span className="sensor-select-temp">({data.tempText})</span>}
+    </>
+  );
+}

--- a/frontend/src/systems/components/sensorSelectOptions.tsx
+++ b/frontend/src/systems/components/sensorSelectOptions.tsx
@@ -114,8 +114,7 @@ export function buildSensorOptions(params: {
 }
 
 /**
- * Renderers: name + temp. Reuses .sensor-select-name/-temp (keep in Phase 5;
- * only .sensor-select-display dies).
+ * Renderers: name + temp, styled by .sensor-select-name/-temp (sensors-fans.css).
  */
 export function renderSensorTrigger(selected: SelectOption<string> | null): ReactNode {
   const data = selected?.data as SensorOptionData | undefined;

--- a/frontend/src/systems/styles/bulk-edit-panel.css
+++ b/frontend/src/systems/styles/bulk-edit-panel.css
@@ -208,36 +208,22 @@
   color: var(--text-primary);
 }
 
-.bulk-edit-select {
-  width: 100%;
-  padding: 10px 12px;
-  border-radius: 6px;
-  border: 1px solid var(--border-color);
-  font-size: 14px;
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: border-color 0.2s;
-}
-
-.bulk-edit-select:hover {
-  border-color: var(--color-accent-dynamic);
-}
-
-.bulk-edit-select:focus {
-  outline: none;
-  border-color: var(--color-info);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.1);
-}
-
-/* Design1 trigger in a control group - old .bulk-edit-select footprint.
- * Not Phase 5 delete scope. */
+/* Design1 trigger in a control group - old .bulk-edit-select footprint. */
 .control-group .pk-select-trigger {
   width: 100%;
   padding: 10px 12px;
   padding-right: 24px; /* chevron room */
   font-size: 14px;
   background-color: var(--bg-primary);
+}
+
+/* Design1 trigger in a form group (Sensor Builder) - old .form-group select footprint */
+.bulk-edit-panel .form-group .pk-select-trigger {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  padding-right: 24px;
+  font-size: var(--font-size-base);
+  background: var(--bg-tertiary);
 }
 
 /* Select All Button */

--- a/frontend/src/systems/styles/bulk-edit-panel.css
+++ b/frontend/src/systems/styles/bulk-edit-panel.css
@@ -230,6 +230,16 @@
   box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.1);
 }
 
+/* Design1 trigger in a control group - old .bulk-edit-select footprint.
+ * Not Phase 5 delete scope. */
+.control-group .pk-select-trigger {
+  width: 100%;
+  padding: 10px 12px;
+  padding-right: 24px; /* chevron room */
+  font-size: 14px;
+  background-color: var(--bg-primary);
+}
+
 /* Select All Button */
 .select-all-btn {
   padding: 6px 12px;

--- a/frontend/src/systems/styles/cards.css
+++ b/frontend/src/systems/styles/cards.css
@@ -559,6 +559,21 @@
   background: var(--text-tertiary);
 }
 
+/* Dot-to-name gap parity with the old .select-display (Design1 trigger).
+ * Not Phase 5 delete scope; footprint lives in sensors-fans.css. */
+.pk-select-trigger.fan-profile-select .pk-select-value {
+  gap: var(--spacing-sm);
+}
+
+/* Design1 trigger in the settings grid - Design0's fixed 100x25 footprint.
+ * Not Phase 5 delete scope. */
+.command-item .pk-select-trigger {
+  width: 100px;
+  height: 25px;
+  font-size: var(--font-size-sm2);
+  font-weight: var(--font-weight-medium);
+}
+
 /* 3.7 Footer Stats */
 .system-stats {
   display: flex;

--- a/frontend/src/systems/styles/cards.css
+++ b/frontend/src/systems/styles/cards.css
@@ -489,65 +489,8 @@
   color: var(--color-accent-dynamic);
 } */
 
-.stealth-select-wrapper {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 4px 8px;
-  transition: all 0.2s ease;
-  width: 100px;
-  height: 25px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-}
-
-.stealth-select-wrapper:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: var(--border-light);
-}
-
-.select-engine {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.select-display {
-  font-size: var(--font-size-sm2);
-  font-weight: var(--font-weight-medium);
-  color: var(--text-primary);
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  text-align: left;
-  pointer-events: none;
-  /* text-transform: uppercase; */
-}
-
-/* Fan-profile dropdown collapsed state - small gap between the colour
- * dot and the profile name. Scoped to .fan-profile-select so we don't
- * accidentally add spacing to other .select-display usages (log level,
- * update interval, etc.) where there is only a single text child. */
-.fan-profile-select .select-display {
-  gap: var(--spacing-sm);
-}
-
-/* Inline colour swatch used in the fan-profile dropdown's collapsed state
- * (.select-display). Shape and size mirror `.status-badge .status-dot`,
- * but the colour comes from an inline `background` style set by the
- * renderer (the profile_type hex resolved through typeColorMap). Kept as
- * its own class so we don't have to nest under `.status-badge` just to
- * pick up styles. */
+/* Inline colour swatch in the fan-profile dropdown (trigger + menu rows).
+ * Size mirrors .status-badge .status-dot; colour set inline per-render. */
 .profile-color-dot {
   display: inline-block;
   width: 8px;
@@ -559,14 +502,12 @@
   background: var(--text-tertiary);
 }
 
-/* Dot-to-name gap parity with the old .select-display (Design1 trigger).
- * Not Phase 5 delete scope; footprint lives in sensors-fans.css. */
+/* Dot-to-name gap in the fan-profile trigger; footprint lives in sensors-fans.css */
 .pk-select-trigger.fan-profile-select .pk-select-value {
   gap: var(--spacing-sm);
 }
 
-/* Design1 trigger in the settings grid - Design0's fixed 100x25 footprint.
- * Not Phase 5 delete scope. */
+/* Design1 trigger in the settings grid - Design0's fixed 100x25 footprint */
 .command-item .pk-select-trigger {
   width: 100px;
   height: 25px;

--- a/frontend/src/systems/styles/dashboard.css
+++ b/frontend/src/systems/styles/dashboard.css
@@ -240,43 +240,6 @@
   opacity: 0.8;
 }
 
-/* Refresh Rate Selector */
-.refresh-rate-selector {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-  align-items: flex-start;
-}
-
-.refresh-rate-label {
-  font-size: var(--font-size-sm);
-  color: var(--text-primary);
-  font-weight: var(--font-weight-medium);
-  white-space: nowrap;
-}
-
-.refresh-rate-dropdown {
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  min-width: 180px;
-}
-
-.refresh-rate-dropdown:hover {
-  border-color: var(--color-info);
-  background: var(--bg-hover);
-}
-
-.refresh-rate-dropdown:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 /* Controller Interval Selector */
 .controller-interval-selector {
   display: flex;
@@ -290,28 +253,6 @@
   color: var(--text-primary);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
-}
-
-.controller-interval-dropdown {
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  min-width: 180px;
-}
-
-.controller-interval-dropdown:hover {
-  border-color: var(--color-info);
-  background: var(--bg-hover);
-}
-
-.controller-interval-dropdown:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 /* Loading States */

--- a/frontend/src/systems/styles/sensors-fans.css
+++ b/frontend/src/systems/styles/sensors-fans.css
@@ -567,6 +567,17 @@
   box-sizing: border-box;
 }
 
+/* Design1 trigger in a fan control row - same footprint as the Design0
+ * wrapper above (fill row, fixed 25px). Not Phase 5 delete scope. */
+.fan-control-row .pk-select-trigger {
+  flex: 1;
+  min-width: 0;
+  height: 25px;
+  font-size: var(--font-size-sm2);
+  font-weight: var(--font-weight-medium);
+  box-sizing: border-box;
+}
+
 .sensor-select-display {
   display: flex !important;
   gap: var(--spacing-xs);
@@ -583,6 +594,17 @@
 .sensor-select-temp {
   flex-shrink: 0;
   white-space: nowrap;
+}
+
+/* Control Sensor open rows: temp right-aligns as a column; the check yields
+ * its auto margin to it. Not Phase 5 delete scope. */
+.pk-select-option .sensor-select-temp {
+  margin-left: auto;
+  color: var(--text-secondary);
+}
+
+.pk-select-option:has(.sensor-select-temp) .pk-select-check {
+  margin-left: 0;
 }
 
 .fan-dropdown:hover:not(:disabled) {

--- a/frontend/src/systems/styles/sensors-fans.css
+++ b/frontend/src/systems/styles/sensors-fans.css
@@ -552,23 +552,8 @@
   flex-shrink: 0;
 }
 
-.fan-dropdown,
-.fan-control-row .stealth-select-wrapper {
-  flex: 1;
-  min-width: 0;
-  padding: 4px var(--spacing-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  font-size: var(--font-size-sm2);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-sizing: border-box;
-}
-
-/* Design1 trigger in a fan control row - same footprint as the Design0
- * wrapper above (fill row, fixed 25px). Not Phase 5 delete scope. */
+/* Design1 trigger in a fan control row - Design0 wrapper footprint
+ * (fill row, fixed 25px). */
 .fan-control-row .pk-select-trigger {
   flex: 1;
   min-width: 0;
@@ -576,12 +561,6 @@
   font-size: var(--font-size-sm2);
   font-weight: var(--font-weight-medium);
   box-sizing: border-box;
-}
-
-.sensor-select-display {
-  display: flex !important;
-  gap: var(--spacing-xs);
-  min-width: 0;
 }
 
 .sensor-select-name {
@@ -597,7 +576,7 @@
 }
 
 /* Control Sensor open rows: temp right-aligns as a column; the check yields
- * its auto margin to it. Not Phase 5 delete scope. */
+ * its auto margin to it. */
 .pk-select-option .sensor-select-temp {
   margin-left: auto;
   color: var(--text-secondary);
@@ -605,22 +584,6 @@
 
 .pk-select-option:has(.sensor-select-temp) .pk-select-check {
   margin-left: 0;
-}
-
-.fan-dropdown:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-info) 8%, var(--bg-secondary));
-  border-color: var(--color-info);
-}
-
-.fan-dropdown:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
-}
-
-.fan-dropdown:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .speed-control {

--- a/frontend/src/systems/styles/virtual-sensor-modals.css
+++ b/frontend/src/systems/styles/virtual-sensor-modals.css
@@ -1,10 +1,9 @@
 /* Virtual Sensor modals (Sensor Builder / Manage Sensors).
  *
- * The modal frame, buttons (.btn/.btn-primary/.btn-secondary), header/footer and
- * the .bulk-edit-select dropdown are REUSED from bulk-edit-panel.css. The Name
- * field reuses .form-group from styles/components/forms.css. Only the pieces
- * unique to these modals live here, using shared theme tokens (dark/light both
- * work) and the same hover/accent vocabulary as the sensor cards. */
+ * The modal frame, buttons (.btn/.btn-primary/.btn-secondary), header/footer
+ * and the Select trigger footprint are REUSED from bulk-edit-panel.css. The
+ * Name field reuses .form-group from styles/components/forms.css. Only the
+ * pieces unique to these modals live here. */
 
 /* Stable width so the panel does not resize while browsing / changing the
  * operation (bulk-edit-panel uses fit-content, which jumps with content). */


### PR DESCRIPTION
## Dropdown menus rework

  Replaces every native `<select>` in the app with a single in-house `Select` component that renders its own menu DOM. Native dropdowns hand the open list to the OS: row height and spacing ignore our CSS, long
  sensor lists became unusably tall, and rich rows (color dots, live temperatures) were impossible - which is why parts of the app were layering invisible selects over hand-built display divs. That workaround
  only ever fixed the closed state.

  **The new component**
  - One component covers both plain dropdowns and the "clean closed / detailed open" pattern via optional render hooks
  - Grouped options, built-in search filter, full keyboard navigation with type-ahead, proper combobox/listbox semantics
  - Matches native behavior where it matters: Esc is consumed by the open menu, page scroll locks while open, the menu opens below or above based on available space, focus returns to the trigger
  - Mobile is first-class: same features in a bottom sheet, which rides above the on-screen keyboard while searching
  - Existing design tokens only, light and dark themes, no new dependencies

  **Migrated everywhere**: dashboard interval, fan profile and control sensor pickers (zone and per-fan), the six per-system settings, bulk edit masters (now built from the same option builders as the per-fan
  controls, so virtual sensors finally appear there), BMC and deployment pickers, profile editor, import/export dialogs, font settings, and the virtual sensor builder. The old stealth-select CSS and all its
  satellite styles are deleted.

  **Also in this PR**
  - Font pickers preview each typeface inside the open menu, and the settings row shows a two-line specimen
  - New font size setting (80-130%) that scales all interface text, persisted server-side
  - Fixed a crash when right-clicking to remove a fan curve point
  - Profile editor emoji glyphs replaced with lucide icons
  - Graph scale and data retention preset rows no longer overflow on phones