### PR TITLE
feature: license-seat-binding-cancel

### DIFF
--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -509,3 +509,28 @@ DO $$ BEGIN
     RAISE NOTICE 'Migration: Added sort_order column to sensor_group_visibility';
   END IF;
 END $$;
+
+-- Migration: Add instance_id to license_config (task_07 seat binding - stable per-install identity).
+-- Generated once by LicenseManager on first use; survives container rebuilds (lives in the DB volume).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'license_config' AND column_name = 'instance_id'
+  ) THEN
+    ALTER TABLE license_config ADD COLUMN instance_id TEXT;
+    RAISE NOTICE 'Migration: Added instance_id column to license_config';
+  END IF;
+END $$;
+
+-- Migration: Add seat_state to license_config (task_07 seat binding).
+-- NULL = never bound (bind attempted on next activation/boot), 'bound' = seat held here,
+-- 'lost' = seat bound to another system (tier soft-demoted to Free until re-bound).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'license_config' AND column_name = 'seat_state'
+  ) THEN
+    ALTER TABLE license_config ADD COLUMN seat_state TEXT;
+    RAISE NOTICE 'Migration: Added seat_state column to license_config';
+  END IF;
+END $$;

--- a/backend/src/license/LicenseManager.ts
+++ b/backend/src/license/LicenseManager.ts
@@ -14,6 +14,7 @@ import { LICENSE_API_URL } from './license-config';
 import Database from '../database/database';
 import { log } from '../utils/logger';
 import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
 
 export class LicenseManager extends EventEmitter {
   private validator: LicenseValidator;
@@ -33,6 +34,9 @@ export class LicenseManager extends EventEmitter {
   private discountCyclesRemaining: number | null = null;  // Remaining discounted renewals
   private periodInterval: string | null = null;  // From JWT period_interval claim - billing cadence display ("Day"|"Week"|"Month"|"Year")
   private periodCount: number | null = null;     // From JWT period_count claim - e.g. 1, 7
+  private instanceId: string | null = null;  // Stable per-install identity for seat binding (persisted in license_config)
+  private seatState: 'bound' | 'lost' | null = null;  // null = never bound / bind-exempt; 'lost' = seat held elsewhere (soft demote)
+  private cancelScheduledAt: Date | null = null;  // When cancel-at-period-end was requested (from /status)
   private lastSyncAt: Date | null = null;  // Last successful sync with license server
   private readonly CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
   // Autonomous background sync loop (self-rescheduling; see startAutoSync)
@@ -72,8 +76,17 @@ export class LicenseManager extends EventEmitter {
   async initialize(): Promise<void> {
     try {
       const result = await this.getPool().query(
-        'SELECT license_key, last_sync_at FROM license_config WHERE id = 1'
+        'SELECT license_key, last_sync_at, instance_id, seat_state FROM license_config WHERE id = 1'
       );
+
+      if (result.rows.length > 0) {
+        // Load install identity + seat state before validation so the
+        // seat-lost demotion applies from the first cacheResult (task_07)
+        if (result.rows[0].instance_id) {
+          this.instanceId = result.rows[0].instance_id;
+        }
+        this.seatState = result.rows[0].seat_state || null;
+      }
 
       if (result.rows.length > 0 && result.rows[0].license_key) {
         // Load persisted lastSyncAt before sync so checkAutoSync can honor cooldown
@@ -83,6 +96,13 @@ export class LicenseManager extends EventEmitter {
 
         await this.validateAndCache(result.rows[0].license_key);
         log.info(`Initialized with tier: ${this.cachedTier.name}`, 'LicenseManager');
+
+        // One-time seat bind (task_07): covers grandfathered installs and
+        // lifetime licenses (which never sync). Best-effort - a network
+        // failure leaves seatState NULL and we retry next boot.
+        if (this.licenseId && this.seatState === null) {
+          await this.ensureSeatBound(result.rows[0].license_key);
+        }
 
         // Auto-sync on startup if we have a paid token on file (active OR
         // recently expired) to detect Dodo-side renewals during downtime.
@@ -100,14 +120,53 @@ export class LicenseManager extends EventEmitter {
   }
 
   /**
-   * Set a new license key and validate it
+   * Set a new license key and validate it.
+   *
+   * task_07 additions:
+   * - Recovery: a signature-valid but hard-expired token still proves
+   *   ownership of the lid; the ledger may hold a fresher JWT this install
+   *   never saw (renewals while offline, fresh install with an old key).
+   * - Seat binding: every paid activation binds (or confirms) the seat via
+   *   the worker before persisting. Worker unreachable fails loud -
+   *   activation is the one online-required step. 404 = CLI-minted token
+   *   (not in the ledger) -> bind-exempt.
    */
-  async setLicenseKey(key: string): Promise<{ success: boolean; tier: string; error?: string }> {
+  async setLicenseKey(key: string, opts: { forceSeat?: boolean; recovered?: boolean } = {}): Promise<{
+    success: boolean;
+    tier: string;
+    error?: string;
+    seatConflict?: boolean;
+    boundAt?: string | null;
+    canForce?: boolean;
+  }> {
     const result = await this.validator.validate(key);
-    
+
     if (!result.valid) {
+      if (!opts.recovered && result.error === 'License expired' && result.licenseId) {
+        const replacement = await this.fetchReplacementForToken(key);
+        if (replacement) {
+          log.info('Recovered current token via /status (expired key presented)', 'LicenseManager');
+          return this.setLicenseKey(replacement, { ...opts, recovered: true });
+        }
+      }
       return { success: false, tier: 'free', error: result.error };
     }
+
+    const bind = await this.bindSeat(key, opts.forceSeat === true);
+    if (!bind.ok) {
+      if (bind.seatConflict) {
+        return {
+          success: false,
+          tier: 'free',
+          error: bind.error || 'License is already in use on another system',
+          seatConflict: true,
+          boundAt: bind.boundAt ?? null,
+          canForce: bind.canForce === true,
+        };
+      }
+      return { success: false, tier: 'free', error: bind.error || 'License server unreachable' };
+    }
+    await this.setSeatState(bind.bindExempt ? null : 'bound');
 
     try {
       // Save to database - reset last_sync_at so the fresh license starts
@@ -141,8 +200,18 @@ export class LicenseManager extends EventEmitter {
    */
   async removeLicense(): Promise<{ success: boolean; error?: string }> {
     try {
-      // Delete from database
-      await this.getPool().query('DELETE FROM license_config WHERE id = 1');
+      // Release the seat first (best-effort, task_07): lets the customer
+      // re-activate elsewhere without burning a force-move. Worker
+      // unreachable is fine - the force-move path covers an orphaned binding.
+      const storedToken = await this.getStoredLicenseKey();
+      if (storedToken && this.seatState === 'bound') {
+        await this.releaseSeat(storedToken);
+      }
+
+      // Clear the license but keep instance_id (stable install identity)
+      await this.getPool().query(
+        'UPDATE license_config SET license_key = NULL, last_sync_at = NULL, seat_state = NULL, updated_at = NOW() WHERE id = 1'
+      );
 
       // Reset to free tier
       this.cachedTier = TIERS.free;
@@ -160,6 +229,8 @@ export class LicenseManager extends EventEmitter {
       this.discountCyclesRemaining = null;
       this.periodInterval = null;
       this.periodCount = null;
+      this.seatState = null;
+      this.cancelScheduledAt = null;
       this.lastSyncAt = null;
       this.cacheExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
@@ -271,6 +342,8 @@ export class LicenseManager extends EventEmitter {
     discountCyclesRemaining: number | null;
     periodInterval: string | null;
     periodCount: number | null;
+    seatState: 'bound' | 'lost' | null;
+    cancelScheduledAt: string | null;
     lastSyncAt: string | null;
   }> {
     // Check if auto-sync is needed before returning info
@@ -304,6 +377,8 @@ export class LicenseManager extends EventEmitter {
       discountCyclesRemaining: this.discountCyclesRemaining,
       periodInterval: this.periodInterval,
       periodCount: this.periodCount,
+      seatState: this.seatState,
+      cancelScheduledAt: this.cancelScheduledAt ? this.cancelScheduledAt.toISOString() : null,
       lastSyncAt: this.lastSyncAt ? this.lastSyncAt.toISOString() : null,
     };
   }
@@ -333,16 +408,19 @@ export class LicenseManager extends EventEmitter {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
 
-      // Send token for ownership proof; licenseId kept for logging/correlation
+      // Send token for ownership proof; licenseId kept for logging/correlation.
+      // instanceId lets the worker return a seat verdict and claim the seat
+      // for grandfathered (unbound) rows - task_07.
       const storedToken = await this.getStoredLicenseKey();
       if (!storedToken) {
         return { success: true, changed: false };
       }
+      const instanceId = await this.getInstanceId();
 
       const response = await fetch(`${LICENSE_API_URL}/status`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: storedToken, licenseId: this.licenseId }),
+        body: JSON.stringify({ token: storedToken, licenseId: this.licenseId, instanceId }),
         signal: controller.signal
       });
 
@@ -369,10 +447,33 @@ export class LicenseManager extends EventEmitter {
         discountCyclesRemaining?: number;
         customerId?: string;
         replacementToken?: string;
+        seat?: 'bound_here' | 'bound_elsewhere' | 'unbound';
+        cancelScheduledAt?: string | null;
       };
 
       if (!status.found) {
         return { success: true, changed: false };
+      }
+
+      // Seat verdict (task_07): soft demote when the seat is held elsewhere;
+      // restore when it comes back (e.g. released on the other system). The
+      // worker also withholds replacementToken from non-seat callers, so a
+      // shared copy hard-expires within one billing cycle.
+      if (status.seat === 'bound_elsewhere') {
+        if (this.seatState !== 'lost') {
+          log.warn('License seat is bound to another system - demoting to Free (soft)', 'LicenseManager');
+          await this.setSeatState('lost');
+          this.cachedTier = TIERS.free;
+          this.cacheExpiry = new Date(Date.now() + this.CACHE_DURATION_MS);
+          this.emit('licenseUpdated');
+        }
+      } else if (status.seat === 'bound_here' && this.seatState !== 'bound') {
+        const wasLost = this.seatState === 'lost';
+        await this.setSeatState('bound');
+        if (wasLost) {
+          await this.validateAndCache(storedToken);  // restore demoted tier
+          this.emit('licenseUpdated');
+        }
       }
 
       // Same-lid token refresh: D1 holds a fresher JWT for our existing license
@@ -416,6 +517,9 @@ export class LicenseManager extends EventEmitter {
       // Update other fields
       this.nextBillingDate = status.nextBillingDate && status.nextBillingDate !== 'NA'
         ? new Date(status.nextBillingDate)
+        : null;
+      this.cancelScheduledAt = status.cancelScheduledAt
+        ? new Date(status.cancelScheduledAt)
         : null;
       this.discountCode = status.discountCode || null;
       this.discountCyclesRemaining = status.discountCyclesRemaining ?? null;
@@ -552,6 +656,253 @@ export class LicenseManager extends EventEmitter {
         changed: false,
         error: error instanceof Error ? error.message : 'Network error',
       };
+    }
+  }
+
+  /**
+   * Schedule cancellation via Worker /cancel (vendor-independent, task_07).
+   * Cancel-at-period-end: the tier stays active until the paid-through date;
+   * the provider webhook flips the ledger status at the effective date.
+   */
+  async cancelSubscription(): Promise<{
+    success: boolean;
+    accessUntil?: string | null;
+    notCancellable?: boolean;
+    error?: string;
+  }> {
+    if (!this.licenseId || !this.licenseBilling || this.licenseBilling === 'lifetime') {
+      return { success: false, notCancellable: true, error: 'No active subscription to cancel' };
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const storedToken = await this.getStoredLicenseKey();
+      if (!storedToken) {
+        return { success: false, notCancellable: true, error: 'No stored license token' };
+      }
+
+      const response = await fetch(`${LICENSE_API_URL}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: storedToken }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      const bodyText = await response.text();
+      let parsed: { success?: boolean; accessUntil?: string | null; error?: string } | null = null;
+      try { parsed = JSON.parse(bodyText); } catch { /* non-JSON body */ }
+
+      if (!response.ok || !parsed?.success) {
+        log.error(`Cancel failed (${response.status}): ${bodyText}`, 'LicenseManager');
+        return {
+          success: false,
+          notCancellable: response.status === 400,
+          error: parsed?.error || 'License server error',
+        };
+      }
+
+      // Local marker until the next /status sync confirms the authoritative value
+      this.cancelScheduledAt = new Date();
+      this.emit('licenseUpdated');
+      log.info('Cancellation scheduled at period end', 'LicenseManager');
+
+      return { success: true, accessUntil: parsed.accessUntil ?? null };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        log.error('Cancel timeout', 'LicenseManager');
+        return { success: false, error: 'Timeout' };
+      }
+      log.error('Cancel error', 'LicenseManager', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Network error',
+      };
+    }
+  }
+
+  /**
+   * Stable per-install identity for seat binding (task_07). Generated once,
+   * persisted in license_config so it survives container rebuilds. A DB wipe
+   * produces a new identity - that is the force-move case, by design.
+   */
+  private async getInstanceId(): Promise<string> {
+    if (this.instanceId) return this.instanceId;
+
+    const result = await this.getPool().query(
+      'SELECT instance_id FROM license_config WHERE id = 1'
+    );
+    let id: string | null = result.rows[0]?.instance_id || null;
+
+    if (!id) {
+      id = randomUUID();
+      await this.getPool().query(`
+        INSERT INTO license_config (id, instance_id, updated_at)
+        VALUES (1, $1, NOW())
+        ON CONFLICT (id) DO UPDATE SET instance_id = COALESCE(license_config.instance_id, $1)
+      `, [id]);
+      // Re-read in case a concurrent writer won the race
+      const check = await this.getPool().query(
+        'SELECT instance_id FROM license_config WHERE id = 1'
+      );
+      id = check.rows[0]?.instance_id || id;
+    }
+
+    this.instanceId = id;
+    return id!;
+  }
+
+  /** Persist seat state (task_07). Non-fatal on DB error, like persistLastSyncAt. */
+  private async setSeatState(state: 'bound' | 'lost' | null): Promise<void> {
+    this.seatState = state;
+    try {
+      await this.getPool().query(`
+        INSERT INTO license_config (id, seat_state, updated_at)
+        VALUES (1, $1, NOW())
+        ON CONFLICT (id) DO UPDATE SET seat_state = $1
+      `, [state]);
+    } catch (error) {
+      log.error('Failed to persist seat_state', 'LicenseManager', error);
+    }
+  }
+
+  /**
+   * One-time seat bind for a token already on file (task_07). Best-effort:
+   * network failure leaves seatState NULL (retried next boot; subscriptions
+   * also get claimed server-side on /status sync). A positive seat conflict
+   * demotes softly.
+   */
+  private async ensureSeatBound(key: string): Promise<void> {
+    try {
+      const bind = await this.bindSeat(key, false);
+      if (bind.ok) {
+        await this.setSeatState(bind.bindExempt ? null : 'bound');
+      } else if (bind.seatConflict) {
+        log.warn('License seat is bound to another system - demoting to Free (soft)', 'LicenseManager');
+        await this.setSeatState('lost');
+        this.cachedTier = TIERS.free;
+      }
+    } catch (error) {
+      log.error('Seat bind attempt failed', 'LicenseManager', error);
+    }
+  }
+
+  /**
+   * Bind this install's seat via Worker /activate (task_07).
+   * 404 not_found = token not in the ledger (CLI-minted) -> bind-exempt.
+   */
+  private async bindSeat(token: string, force: boolean): Promise<{
+    ok: boolean;
+    bindExempt?: boolean;
+    moved?: boolean;
+    seatConflict?: boolean;
+    boundAt?: string | null;
+    canForce?: boolean;
+    error?: string;
+  }> {
+    try {
+      const instanceId = await this.getInstanceId();
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(`${LICENSE_API_URL}/activate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, instanceId, force: force || undefined }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      const body = await response.json().catch(() => null) as {
+        success?: boolean;
+        bound?: boolean;
+        moved?: boolean;
+        error?: string;
+        message?: string;
+        boundAt?: string | null;
+        canForce?: boolean;
+      } | null;
+
+      if (response.ok && body?.success) {
+        if (body.moved) log.info('Seat force-moved to this system', 'LicenseManager');
+        return { ok: true, moved: body.moved === true };
+      }
+      if (response.status === 404) {
+        log.info('License not in ledger (CLI-minted?) - bind-exempt', 'LicenseManager');
+        return { ok: true, bindExempt: true };
+      }
+      if (response.status === 409) {
+        return {
+          ok: false,
+          seatConflict: true,
+          boundAt: body?.boundAt ?? null,
+          canForce: body?.canForce === true,
+          error: body?.message || 'License is already in use on another system',
+        };
+      }
+      // 429 move_limit / 403 move_cap / 5xx - surface the worker's message
+      return { ok: false, error: body?.message || body?.error || 'License server error' };
+    } catch (error) {
+      log.error('Seat bind request failed', 'LicenseManager', error);
+      return { ok: false, error: 'License server unreachable. Check your connection and try again.' };
+    }
+  }
+
+  /** Release this install's seat via Worker /release (best-effort, task_07). */
+  private async releaseSeat(token: string): Promise<void> {
+    try {
+      const instanceId = await this.getInstanceId();
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(`${LICENSE_API_URL}/release`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, instanceId }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        log.info('Seat released', 'LicenseManager');
+      } else {
+        log.warn(`Seat release returned ${response.status} (force-move path covers this)`, 'LicenseManager');
+      }
+    } catch (error) {
+      log.error('Seat release failed (non-fatal)', 'LicenseManager', error);
+    }
+  }
+
+  /**
+   * Recovery lookup (task_07): ask /status whether the chain behind a
+   * signature-valid but expired token is alive and holds a fresher JWT.
+   */
+  private async fetchReplacementForToken(candidate: string): Promise<string | null> {
+    try {
+      const instanceId = await this.getInstanceId();
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(`${LICENSE_API_URL}/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: candidate, instanceId }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) return null;
+      const status = await response.json() as { found?: boolean; replacementToken?: string };
+      return (status.found && status.replacementToken) ? status.replacementToken : null;
+    } catch (error) {
+      log.error('Recovery /status lookup failed', 'LicenseManager', error);
+      return null;
     }
   }
 
@@ -717,6 +1068,11 @@ export class LicenseManager extends EventEmitter {
   private async cacheResult(key: string, result: ValidationResult): Promise<void> {
     const tier = result.valid ? result.tier : 'free';
     this.cachedTier = getTier(tier);
+    // Seat lost (task_07): license bound to another system - soft demote.
+    // Token stays on file so a later re-bind or force-move can restore.
+    if (this.seatState === 'lost') {
+      this.cachedTier = TIERS.free;
+    }
     this.cacheExpiry = new Date(Date.now() + this.CACHE_DURATION_MS);
     this.licenseExpiresAt = result.expiresAt;  // Store license expiry date
     this.licenseActivatedAt = result.activatedAt;  // Store license issued date

--- a/backend/src/license/routes.ts
+++ b/backend/src/license/routes.ts
@@ -6,6 +6,8 @@
  * - GET /api/license/pricing - Get all tier pricing info
  * - POST /api/license - Set/update license key
  * - POST /api/license/sync - Force sync with license server (for renewals)
+ * - POST /api/license/renew - Force-refresh token via worker /renew
+ * - POST /api/license/cancel - Schedule cancel-at-period-end (proxies to Worker)
  * - GET /api/license/promo - List advertised discounts (proxies to Worker)
  * - POST /api/license/checkout - Create Dodo checkout session (proxies to Worker)
  * - DELETE /api/license - Remove license (revert to free tier)
@@ -85,26 +87,40 @@ router.get('/pricing', async (req: Request, res: Response) => {
 /**
  * POST /api/license
  * Set or update license key
- * Body: { licenseKey: string }
+ * Body: { licenseKey: string, forceSeat?: boolean }
+ * forceSeat moves the seat here when the license is bound to another system
+ * (worker-enforced limits: 2 per 7 days, cumulative cap). A 409 response
+ * carries seatConflict + canForce so the UI can offer the move.
  */
 router.post('/', async (req: Request, res: Response) => {
   try {
-    const { licenseKey } = req.body;
-    
+    const { licenseKey, forceSeat } = req.body;
+
     if (!licenseKey || typeof licenseKey !== 'string') {
-      return res.status(400).json({ 
-        success: false, 
-        error: 'License key is required' 
+      return res.status(400).json({
+        success: false,
+        error: 'License key is required'
       });
     }
 
-    const result = await licenseManager.setLicenseKey(licenseKey.trim());
-    
+    const result = await licenseManager.setLicenseKey(licenseKey.trim(), {
+      forceSeat: forceSeat === true,
+    });
+
     if (result.success) {
       res.json({
         success: true,
         tier: result.tier,
         message: `License activated: ${result.tier}`,
+      });
+    } else if (result.seatConflict) {
+      res.status(409).json({
+        success: false,
+        tier: 'free',
+        error: result.error,
+        seatConflict: true,
+        boundAt: result.boundAt ?? null,
+        canForce: result.canForce === true,
       });
     } else {
       res.status(400).json({
@@ -176,6 +192,31 @@ router.post('/renew', async (req: Request, res: Response) => {
     res.status(500).json({
       success: false,
       error: 'Renew failed',
+    });
+  }
+});
+
+/**
+ * POST /api/license/cancel
+ * Self-serve cancellation. Proxies to worker /cancel which schedules a
+ * cancel-at-period-end with the payment provider. Access continues until the
+ * paid-through date; the provider webhook finalizes the ledger status.
+ */
+router.post('/cancel', async (req: Request, res: Response) => {
+  try {
+    const result = await licenseManager.cancelSubscription();
+
+    if (result.success) {
+      res.json(result);
+    } else {
+      // 400 for "nothing to cancel" (lifetime/free), 502 for upstream failure
+      res.status(result.notCancellable ? 400 : 502).json(result);
+    }
+  } catch (error) {
+    log.error('Cancel error', 'License API', error);
+    res.status(500).json({
+      success: false,
+      error: 'Cancel failed',
     });
   }
 });

--- a/backend/src/license/tiers.ts
+++ b/backend/src/license/tiers.ts
@@ -5,8 +5,8 @@
  * 
  * Pricing Model:
  * - Free: $0 (no payment required)
- * - Pro: $5/month, $49/year, $149 lifetime
- * - Enterprise: $25/month, $249/year, $499 lifetime
+ * - Pro: $5/month, $49/year, $199 lifetime
+ * - Enterprise: $25/month, $249/year, $649 lifetime
  * 
  * NOTE: Dodo Payments checkout URLs are defined in:
  *       frontend/src/settings/components/Settings.tsx → CHECKOUT_URLS constant

--- a/frontend/src/license/LicenseContext.tsx
+++ b/frontend/src/license/LicenseContext.tsx
@@ -29,6 +29,8 @@ export interface LicenseInfo {
   discountCyclesRemaining: number | null;
   periodInterval: string | null;  // From JWT period_interval claim - "Day"|"Week"|"Month"|"Year"; null falls back to billing enum for badge display
   periodCount: number | null;     // From JWT period_count claim - e.g. 1, 7
+  seatState: 'bound' | 'lost' | null;  // Seat binding: 'lost' = license active on another system (soft-demoted); null = unbound/bind-exempt
+  cancelScheduledAt: string | null;    // When cancel-at-period-end was requested; drives the "Cancellation scheduled" state
   lastSyncAt: string | null;
 }
 
@@ -85,6 +87,8 @@ export const LicenseProvider: React.FC<LicenseProviderProps> = ({ children }) =>
         discountCyclesRemaining: null,
         periodInterval: null,
         periodCount: null,
+        seatState: null,
+        cancelScheduledAt: null,
         lastSyncAt: null,
       });
     } finally {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -271,8 +271,14 @@ export const getLicense = async () => {
   return response.data;
 };
 
-export const setLicense = async (licenseKey: string) => {
-  const response = await api.post("/api/license", { licenseKey });
+export const setLicense = async (licenseKey: string, forceSeat = false) => {
+  // 409 = seat conflict (license bound to another system); pass the body
+  // through so the UI can offer a force-move instead of throwing.
+  const response = await api.post(
+    "/api/license",
+    { licenseKey, forceSeat },
+    { validateStatus: (s) => (s >= 200 && s < 300) || s === 400 || s === 409 }
+  );
   return response.data;
 };
 

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -36,7 +36,10 @@ import {
   Trash2,
   RefreshCw,
   ChevronUp,
-  ChevronDown
+  ChevronDown,
+  Monitor,
+  Ban,
+  TriangleAlert
 } from 'lucide-react';
 import '../styles/settings.css';
 
@@ -875,6 +878,10 @@ const Settings: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [isRenewing, setIsRenewing] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+  // Seat conflict (activation 409): holds the pending key + worker's verdict
+  // so the modal can retry with forceSeat. null = modal closed.
+  const [seatConflict, setSeatConflict] = useState<{ key: string; boundAt: string | null; canForce: boolean } | null>(null);
 
   // Billing period toggles for pricing cards
   const [proBilling, setProBilling] = useState<'monthly' | 'yearly'>('monthly');
@@ -1233,26 +1240,75 @@ const Settings: React.FC = () => {
     }
   };
 
-  const handleLicenseSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!licenseKey.trim()) return;
-
+  /**
+   * Activate a key. On 409 seat_taken the worker says the license is bound to
+   * another system - open the conflict dialog instead of failing; the dialog
+   * retries with forceSeat (worker-enforced: 2 moves/7 days, owner emailed).
+   */
+  const activateKey = async (key: string, forceSeat = false) => {
     setIsSubmitting(true);
     setLicenseStatus(null);
 
     try {
-      const result = await setLicense(licenseKey.trim());
+      const result = await setLicense(key, forceSeat);
       if (result.success) {
         setLicenseStatus({ success: true, message: `License activated: ${result.tier}` });
         setLicenseKey('');
+        setSeatConflict(null);
         await refreshLicense();
+      } else if (result.seatConflict) {
+        setSeatConflict({ key, boundAt: result.boundAt ?? null, canForce: result.canForce === true });
       } else {
         setLicenseStatus({ success: false, message: result.error || 'Invalid license key' });
       }
-    } catch (error) {
+    } catch {
       setLicenseStatus({ success: false, message: 'Failed to validate license' });
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleLicenseSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!licenseKey.trim()) return;
+    await activateKey(licenseKey.trim());
+  };
+
+  /** Force-move retry from the conflict dialog (or seat-lost banner via stored token). */
+  const handleForceMove = async () => {
+    if (!seatConflict) return;
+    await activateKey(seatConflict.key, true);
+  };
+
+  /**
+   * Schedule cancel-at-period-end via backend /cancel proxy. Access continues
+   * until the paid-through date; UI flips to "Cancellation scheduled".
+   */
+  const handleCancelSubscription = async () => {
+    const until = license?.expiresAt ? formatFriendlyDate(license.expiresAt, USER_TIMEZONE) : 'the end of the current billing period';
+    if (!confirm(`Cancel your subscription?\n\nYour ${license?.tier} features stay active until ${until}. No further charges after that.`)) {
+      return;
+    }
+
+    setIsCancelling(true);
+    try {
+      const response = await fetch('/api/license/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const result = await response.json();
+
+      if (result.success) {
+        const accessUntil = result.accessUntil ? formatFriendlyDate(result.accessUntil, USER_TIMEZONE) : until;
+        setLicenseStatus({ success: true, message: `Cancellation scheduled. Access continues until ${accessUntil}.` });
+        await refreshLicense();
+      } else {
+        setLicenseStatus({ success: false, message: result.error || 'Cancellation failed. Please try again or contact support.' });
+      }
+    } catch {
+      setLicenseStatus({ success: false, message: 'Could not reach license server. Check your internet connection.' });
+    } finally {
+      setIsCancelling(false);
     }
   };
 
@@ -1266,7 +1322,7 @@ const Settings: React.FC = () => {
       await deleteLicense();
       await refreshLicense();
       setLicenseStatus({ success: true, message: 'License removed. Reverted to Free tier.' });
-    } catch (error) {
+    } catch {
       setLicenseStatus({ success: false, message: 'Failed to remove license' });
     } finally {
       setIsSubmitting(false);
@@ -2507,6 +2563,33 @@ const Settings: React.FC = () => {
                       </span>
                     </div>
                   )}
+                  {/* Cancellation scheduled - access continues to the paid-through date */}
+                  {license.cancelScheduledAt && license.tier !== 'Free' && (
+                    <div className="cancel-banner">
+                      <TriangleAlert size={14} className="cancel-banner-icon" />
+                      <span>
+                        <strong>Cancellation scheduled</strong> · access continues until {license.expiresAt ? formatFriendlyDate(license.expiresAt, USER_TIMEZONE) : 'the end of the billing period'} · no further charges
+                      </span>
+                    </div>
+                  )}
+                  {/* Seat lost - license was activated on another system (soft demote) */}
+                  {license.seatState === 'lost' && (
+                    <div className="seat-lost-banner">
+                      <TriangleAlert size={14} className="seat-lost-icon" />
+                      <span>
+                        Your license was activated on <strong>another system</strong>. This system reverted to Free.
+                      </span>
+                      {license.token && (
+                        <button
+                          type="button"
+                          className="license-action-btn"
+                          onClick={() => setSeatConflict({ key: license.token!, boundAt: null, canForce: true })}
+                        >
+                          <span>Move license here</span>
+                        </button>
+                      )}
+                    </div>
+                  )}
                   <div className="license-limits">
                     <div className="limit-item">
                       <span className="limit-label">Agents</span>
@@ -2555,10 +2638,10 @@ const Settings: React.FC = () => {
                           <span className="limit-label">Remaining</span>
                           <div className="limit-value-group">
                             <span className="limit-value">{remaining.text}</span>
-                            {/* Show "Renews {date}" for subscriptions, or nothing for lifetime */}
+                            {/* "Renews {date}" for subscriptions; flips to "Ends" once a cancellation is scheduled */}
                             {license.billing !== 'lifetime' && license.nextBillingDate && (
                               <span className="limit-subtext-date">
-                                Renews {formatFriendlyDate(license.nextBillingDate, USER_TIMEZONE)}
+                                {license.cancelScheduledAt ? 'Ends' : 'Renews'} {formatFriendlyDate(license.nextBillingDate, USER_TIMEZONE)}
                               </span>
                             )}
                           </div>
@@ -2566,6 +2649,76 @@ const Settings: React.FC = () => {
                       );
                     })()}
                   </div>
+                  {/* Manage strip - server-scoped status + actions, styled in the
+                      limit-tiles language (bg surface + left accent) so it reads
+                      as part of the card, not floating buttons. */}
+                  {license.licenseId && (
+                    <div className="manage-strip">
+                      <span className="license-manage-status">
+                        {license.seatState === 'bound' && (
+                          <span className="seat-chip">
+                            <Monitor size={13} />
+                            This system holds the license
+                          </span>
+                        )}
+                        {license.lastSyncAt && (
+                          <span title={formatDateTooltip(license.lastSyncAt)}>
+                            Last synced {formatRelativeTime(license.lastSyncAt)}
+                          </span>
+                        )}
+                      </span>
+                      <span className="license-manage-actions">
+                        <span className="btn-group">
+                          <button
+                            type="button"
+                            className="license-action-btn"
+                            onClick={handleSyncLicense}
+                            disabled={isSyncing}
+                            title="Check the license server for renewals or updates"
+                          >
+                            <RefreshCw
+                              size={16}
+                              style={{ animation: isSyncing ? 'spin 1s linear infinite' : 'none' }}
+                            />
+                            <span>Sync</span>
+                          </button>
+                          <button
+                            type="button"
+                            className="license-action-btn"
+                            onClick={handleRenewLicense}
+                            disabled={!canRenew || isRenewing}
+                            title={canRenew
+                              ? 'Force-refresh your license token from the server. 15 min cooldown, 3/day.'
+                              : 'Available when Sync cannot recover your license (e.g., token expired or webhook lost). Try Sync first.'}
+                          >
+                            <KeyRound
+                              size={16}
+                              style={{ animation: isRenewing ? 'spin 1s linear infinite' : 'none' }}
+                            />
+                            <span>Renew</span>
+                          </button>
+                        </span>
+                        {license.tier !== 'Free' && license.billing !== 'lifetime' && (
+                          license.cancelScheduledAt ? (
+                            <button type="button" className="license-action-btn" disabled title="Cancellation is scheduled; access continues until the paid-through date">
+                              <span>Cancellation scheduled</span>
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="license-action-btn license-action-btn--danger"
+                              onClick={handleCancelSubscription}
+                              disabled={isCancelling}
+                              title="Cancel your subscription at the end of the current billing period"
+                            >
+                              <Ban size={16} />
+                              <span>{isCancelling ? 'Cancelling...' : 'Cancel Subscription'}</span>
+                            </button>
+                          )
+                        )}
+                      </span>
+                    </div>
+                  )}
                 </div>
 
                 <form onSubmit={handleLicenseSubmit} className="license-form">
@@ -2593,43 +2746,11 @@ const Settings: React.FC = () => {
                         className="license-action-btn license-action-btn--danger"
                         onClick={handleRemoveLicense}
                         disabled={isSubmitting}
-                        title="Remove license and revert to free tier"
+                        title="Remove license from this system and free its seat"
                       >
                         <Trash2 size={16} />
                         <span>Remove</span>
                       </button>
-                    )}
-                    {license.licenseId && (
-                      <>
-                        <button
-                          type="button"
-                          className="license-action-btn"
-                          onClick={handleSyncLicense}
-                          disabled={isSyncing}
-                          title="Check the license server for renewals or updates"
-                        >
-                          <RefreshCw
-                            size={16}
-                            style={{ animation: isSyncing ? 'spin 1s linear infinite' : 'none' }}
-                          />
-                          <span>Sync</span>
-                        </button>
-                        <button
-                          type="button"
-                          className="license-action-btn"
-                          onClick={handleRenewLicense}
-                          disabled={!canRenew || isRenewing}
-                          title={canRenew
-                            ? 'Force-refresh your license token from the server. 15 min cooldown, 3/day.'
-                            : 'Available when Sync cannot recover your license (e.g., token expired or webhook lost). Try Sync first.'}
-                        >
-                          <KeyRound
-                            size={16}
-                            style={{ animation: isRenewing ? 'spin 1s linear infinite' : 'none' }}
-                          />
-                          <span>Renew</span>
-                        </button>
-                      </>
                     )}
                   </div>
                   {licenseStatus && (
@@ -2638,6 +2759,53 @@ const Settings: React.FC = () => {
                     </p>
                   )}
                 </form>
+
+                {/* Seat-conflict dialog: activation hit 409 (license bound to another
+                    system). Move is consequential, not destructive - the other
+                    system reverts to Free with data intact. */}
+                {seatConflict && (
+                  <div
+                    className="seat-modal-backdrop"
+                    onClick={(e) => { if (e.target === e.currentTarget) setSeatConflict(null); }}
+                  >
+                    <div className="seat-modal" role="dialog" aria-modal="true" aria-labelledby="seat-modal-title">
+                      <div className="seat-modal-head">
+                        <TriangleAlert size={20} />
+                        <h4 id="seat-modal-title">License in use on another system</h4>
+                      </div>
+                      <p>
+                        This license is active on another system{seatConflict.boundAt ? ` (since ${formatFriendlyDate(seatConflict.boundAt, USER_TIMEZONE)})` : ''}.
+                        A license can only be active on one system at a time.
+                      </p>
+                      <p>
+                        Moving it here deactivates it there - that system reverts to Free,
+                        its settings and data stay intact.
+                      </p>
+                      <p className="seat-modal-fine">
+                        Limit: 2 moves per 7 days. The license owner is notified by email on every move.
+                      </p>
+                      <div className="seat-modal-actions">
+                        <button type="button" className="license-action-btn" onClick={() => setSeatConflict(null)}>
+                          Keep it there
+                        </button>
+                        {seatConflict.canForce ? (
+                          <button
+                            type="button"
+                            className="seat-modal-move"
+                            onClick={handleForceMove}
+                            disabled={isSubmitting}
+                          >
+                            {isSubmitting ? 'Moving...' : 'Move license here'}
+                          </button>
+                        ) : (
+                          <span className="seat-modal-fine">
+                            Move limit reached - try again later or contact support@pankha.app
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
 
                 {license.tier !== 'Free' && (license.customerName || license.customerEmail) && (
                   <div className="license-details">

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -676,6 +676,224 @@
   color: var(--color-error);
 }
 
+/* Manage strip — server-scoped status + actions inside .license-info. Speaks
+   the limit-tiles language (bg-secondary + 3px left accent) so it reads as a
+   sibling of the tile grid, not floating buttons. Wraps to status-then-actions
+   rows on narrow viewports. */
+.manage-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-info);
+}
+
+.manage-strip .license-action-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm2);
+  background: var(--bg-tertiary);
+}
+
+.license-manage-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm2);
+  flex-wrap: wrap;
+}
+
+.license-manage-actions {
+  display: inline-flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+/* Segmented button group — joined buttons read as one designed control. */
+.btn-group {
+  display: inline-flex;
+}
+
+.btn-group .license-action-btn {
+  border-radius: 0;
+  margin-left: -1px;
+}
+
+.btn-group .license-action-btn:first-child {
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  margin-left: 0;
+}
+
+.btn-group .license-action-btn:last-child {
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.btn-group .license-action-btn:hover:not(:disabled) {
+  position: relative;
+  z-index: 1;
+}
+
+/* Seat chip — quiet when healthy; amber/red variants carry exception states. */
+.seat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.manage-strip .seat-chip {
+  background: var(--bg-tertiary);
+}
+
+.seat-chip svg {
+  flex-shrink: 0;
+}
+
+/* Cancellation-scheduled banner — amber sibling of .discount-banner. */
+.cancel-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--temp-caution-bg);
+  border: 1px solid var(--temp-caution-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.cancel-banner .cancel-banner-icon {
+  color: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.cancel-banner strong {
+  color: var(--color-warning);
+}
+
+/* Seat-lost banner — red sibling, carries the recovery action inline. */
+.seat-lost-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.seat-lost-banner .seat-lost-icon {
+  color: var(--color-error);
+  flex-shrink: 0;
+}
+
+.seat-lost-banner strong {
+  color: var(--color-error);
+}
+
+.seat-lost-banner .license-action-btn {
+  margin-left: auto;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm2);
+}
+
+/* Seat-conflict dialog — activation returned 409 seat_taken. */
+.seat-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xl);
+}
+
+.seat-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  max-width: 460px;
+  width: 100%;
+  padding: var(--spacing-xl);
+}
+
+.seat-modal-head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.seat-modal-head svg {
+  color: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.seat-modal-head h4 {
+  font-size: var(--font-size-md);
+  margin: 0;
+}
+
+.seat-modal p {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm2);
+  line-height: 1.55;
+  margin: 0 0 var(--spacing-md);
+}
+
+.seat-modal-fine {
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+.seat-modal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}
+
+/* Move is consequential (warning), not destructive (error): the other system
+   reverts to Free with data intact. */
+.seat-modal-move {
+  background: var(--color-warning);
+  color: black;
+  border: none;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-family: var(--font-primary);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+}
+
+.seat-modal-move:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.seat-modal-move:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* General Settings UI */
 .settings-groups {
   display: flex;


### PR DESCRIPTION
## Enhance License Management with Seat Binding and Cancellation Features

- Implemented seat binding logic to manage license activation across systems, including handling seat conflicts and soft demotion of licenses.
- Added functionality to schedule cancellation of subscriptions at the end of the billing period, allowing users to retain access until the paid-through date.
- Updated API routes to support new cancellation and renewal endpoints.
- Modified LicenseManager to persist seat state and instance identity for better license management.
- Enhanced frontend components to handle seat conflict scenarios and display cancellation status to users.
- Updated license tiers with revised pricing for Pro and Enterprise plans.

## One license per system, self-serve cancellation

  - A license now works on one system at a time. Activating it on a second
  system offers to move it instead, with the previous system reverting to the
  Free tier. Removing a license frees it for use elsewhere.

  - Subscriptions can now be cancelled directly from Settings > Subscription.
  Access continues until the end of the paid period, with no further charges
  after that.

  - Your license key is now permanent: renewals no longer send new keys, and
  everything updates automatically in the background. Pasting an older key
  into a fresh install activates the current license as long as the
  subscription is active.

  - The subscription page has been reorganized: license details and management
  actions (Sync, Renew, Cancel) live together in the overview card, and the
  key-entry row is simpler. Improved mobile layout.

  Existing installations are not affected and update automatically. Activating
  a new key requires an internet connection.