### PR TITLE
Feature: authentication and api security, security pass, all apis and connections now need to authenticate, nothing left unsecured

### DIFF
--- a/.env
+++ b/.env
@@ -1,35 +1,27 @@
-# Environment Variables for pankha Repository
+# Environment Variables for pankha
 
 ## --- REQUIRED CONFIGURATION (CHANGE THESE) --- ###
-# PostgreSQL Database Configuration:
-POSTGRES_USER="pankha_user"
-POSTGRES_PASSWORD="pankha_password"
+POSTGRES_USER="pankha_user"         # PostgreSQL Database User
+POSTGRES_PASSWORD="pankha_password" # PostgreSQL Database Password
+PANKHA_HUB_IP="<YOUR_PANKHA_IP>"    # Local LAN IP or hostname of this pankha server, 
+                                    # used in agents deployment e.g. 192.168.1.100
+TIMEZONE="UTC"                      # List of valid timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+                                    # Setting wrong timezone will result in wrong time being recorded in the dashboard and logs
 
-# Local IP needed for agent , Agents target this IP to connect to:
-PANKHA_HUB_IP="<YOUR_PANKHA_IP>"     # Local LAN IP or hostname of this pankha server, used in agents deployment e.g. 192.168.1.100
-
-# Staging Directory
-# Path to store downloaded agent binaries, checksums, reports, etc. (persistent)
-PANKHA_STAGING_DIR="/app/backend/data/staging"
-
-# TIMEZONE="Asia/Kolkata"
-
-# Set the timezone for the application (default: UTC), remove starting # to set
-# List of valid timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-# Setting wrong timezone will result in wrong time being displayed in the dashboard and logs
-
-
-## --- OPTIONAL CONFIGURATION (CHANGE BELOW ONLY IF YOU KNOW WHAT YOU ARE DOING) --- ###
-PANKHA_PORT="3143"      # HTTP/Web server port (browser connects here)
+## --- OPTIONAL CONFIGURATION (Recommended to keep defaults) --- ###
+PANKHA_PORT="3143"      # HTTP/Web server port (browser connects here, default is 3143)
 
 # Logging Configuration
-# LOG_LEVEL: Set logging verbosity (error, warn, info, debug, trace), default=warn
-LOG_LEVEL="info"
+LOG_LEVEL="info"    # logging verbosity (error, warn, info, debug, trace), default=info
 
 # PostgreSQL Database Configuration (continued)
 POSTGRES_DB="db_pankha"
 POSTGRES_HOST="pankha-postgres"
 POSTGRES_PORT="5432"    # PostgreSQL port (database clients connect here) (keep default, recomended)
+
+# Staging Directory
+# Internal path to store downloaded agent binaries, checksums, reports, etc. (persistent)
+PANKHA_STAGING_DIR="/app/backend/data/staging"
 
 # PostgreSQL Performance Tuning (Optional) (leave as is unless you know what you're doing)
 # Controls transaction log size and cleanup behavior to prevent disk space bloat
@@ -40,17 +32,3 @@ POSTGRES_MIN_WAL_SIZE="80MB"
 POSTGRES_CHECKPOINT_TIMEOUT="5min"
 # WAL size to keep for recovery purposes (default: 64MB)
 POSTGRES_WAL_KEEP_SIZE="64MB"
-
-## --- Deprecated or unused: DO NOT USE OR CHANGE THESE --- ###
-# Authentication Secrets - CHANGE THESE (use anything random and long)
-# JWT_SECRET="your-super-secret-jwt-key-change-this"
-# SESSION_SECRET="your-super-secret-session-key-change-this"
-
-# Database Connection String (for manual queries, NOT used by backend)
-# The backend constructs its own DATABASE_URL from the vars above with URL-encoding
-# To query the database with psql, use:  
-# docker exec -it <container_name> psql -U <POSTGRES_USER> -d <POSTGRES_DB>
-# directly connect to pankha-postgres:
-# Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
-# DATABASE_URL="postgresql://pankha_user:pankha_password@pankha-postgres:5432/db_pankha"
-# DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   typecheck:
-    name: Typecheck (Frontend + Backend)
+    name: Server (Frontend + Backend) Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,15 +33,15 @@ jobs:
         working-directory: frontend
 
   cargo-check:
-    name: Cargo Check (${{ matrix.agent }})
+    name: Agent (${{ matrix.agent }}) Cargo Check
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - agent: OS Agent
+          - agent: Linux OS
             path: agents/clients/linux/rust
-          - agent: IPMI Agent
+          - agent: Linux IPMI
             path: agents/clients/linux/virtual-agents/host-ipmi-rust
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         run: cargo check --release --locked
 
   windows-agent-check:
-    name: Windows Agent Compile Check
+    name: Agent (Windows) Compile Check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,8 +84,18 @@ jobs:
         run: .\build.ps1 -Configuration Release -Version "0.0.0-ci"
 
   docker-build:
-    name: Docker Build
-    runs-on: ubuntu-latest
+    name: Docker (${{ matrix.arch }}) Build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -96,7 +106,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ci-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ci-${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,31 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: cargo check --release --locked
 
+  windows-agent-check:
+    name: Windows Agent Compile Check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('agents/clients/windows/varient-c/**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      # Compile-only: runs the ui-options codegen + builds agent and tray
+      # csproj like the release does, but skips publish and the WiX installer.
+      # Explicit -Version: the shallow checkout has no tags, so build.ps1's
+      # git-describe fallback would produce an invalid AssemblyVersion
+      - name: Compile agent + tray
+        working-directory: agents/clients/windows/varient-c
+        run: .\build.ps1 -Configuration Release -Version "0.0.0-ci"
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/agents/clients/linux/rust/src/config/persistence.rs
+++ b/agents/clients/linux/rust/src/config/persistence.rs
@@ -86,6 +86,12 @@ pub async fn load_config(path: Option<&str>) -> Result<AgentConfig> {
 pub async fn save_config(config: &AgentConfig, path: &str) -> Result<()> {
     let content = serde_json::to_string_pretty(config)?;
     tokio::fs::write(path, content).await?;
+    // config.json carries the Hub auth token - keep it owner-only
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+    }
     info!("Configuration saved to: {}", path);
     Ok(())
 }

--- a/agents/clients/linux/rust/src/config/setup.rs
+++ b/agents/clients/linux/rust/src/config/setup.rs
@@ -195,6 +195,9 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
             max_log_size_mb: 10,
             log_retention_days: 7,
         },
+        // Wizard setups start without credentials; enrollment needs a deploy
+        // token from the Hub's Deployment page (see enrollment_token)
+        auth: AuthSettings::default(),
     };
 
     save_config(&config, config_file.to_str().unwrap()).await?;

--- a/agents/clients/linux/rust/src/config/types.rs
+++ b/agents/clients/linux/rust/src/config/types.rs
@@ -9,6 +9,21 @@ pub struct AgentConfig {
     pub backend: BackendSettings,
     pub hardware: HardwareSettings,
     pub logging: LoggingSettings,
+    // Hub credentials. Declared last so it serializes as the final section
+    // of config.json. #[serde(default)] keeps pre-auth config files parsing.
+    #[serde(default)]
+    pub auth: AuthSettings,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthSettings {
+    // One-time bootstrap credential written by the install script; removed
+    // when the Hub issues the permanent auth_token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrollment_token: Option<String>,
+    // Hub-minted permanent credential, presented on every registration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -95,6 +110,7 @@ impl Default for AgentConfig {
                 max_log_size_mb: 10,
                 log_retention_days: 7,
             },
+            auth: AuthSettings::default(),
         }
     }
 }

--- a/agents/clients/linux/rust/src/websocket/client.rs
+++ b/agents/clients/linux/rust/src/websocket/client.rs
@@ -439,6 +439,20 @@ impl WebSocketClient {
                 "registered" => {
                     info!("Agent successfully registered with backend");
 
+                    // Enrollment exchange: persist the Hub-minted auth token
+                    // (delivered in the registered response) and drop the
+                    // one-time enrollment token
+                    let issued_token = message
+                        .get("data")
+                        .and_then(|d| d.get("auth_token"))
+                        .or_else(|| message.get("auth_token"))
+                        .and_then(|v| v.as_str());
+                    if let Some(token) = issued_token {
+                        if let Err(e) = self.set_auth_token(token).await {
+                            error!("Failed to persist Hub auth token: {}", e);
+                        }
+                    }
+
                     // Cleanup after successful update (if applicable)
                     if let Ok(current_exe) = std::env::current_exe() {
                         if let Some(exe_dir) = current_exe.parent() {
@@ -510,6 +524,19 @@ impl WebSocketClient {
                             }
                         }
                     }
+                }
+                "registrationError" => {
+                    // Hub refused this agent. Say exactly why (expired deploy
+                    // token vs rejected credential) - the Hub closes the
+                    // connection next, and the standard reconnect backoff
+                    // (capped at 15s) takes over; no special retry handling.
+                    let reason = message
+                        .get("data")
+                        .and_then(|d| d.get("error"))
+                        .or_else(|| message.get("error"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("no reason given");
+                    error!("Hub rejected registration: {}", reason);
                 }
                 _ => {
                     debug!("Received message type: {}", msg_type);

--- a/agents/clients/linux/rust/src/websocket/client.rs
+++ b/agents/clients/linux/rust/src/websocket/client.rs
@@ -525,6 +525,21 @@ impl WebSocketClient {
                         }
                     }
                 }
+                "registrationPending" => {
+                    // Hub is holding this agent for admin approval (D13).
+                    // Keep the connection; the Hub promotes us with a
+                    // "registered" message once approved. Telemetry we send
+                    // meanwhile is ignored Hub-side.
+                    let reason = message
+                        .get("data")
+                        .and_then(|d| d.get("reason"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("awaiting approval");
+                    info!(
+                        "Hub is holding this agent for approval ({}). Approve it on the Pankha dashboard.",
+                        reason
+                    );
+                }
                 "registrationError" => {
                     // Hub refused this agent. Say exactly why (expired deploy
                     // token vs rejected credential) - the Hub closes the

--- a/agents/clients/linux/rust/src/websocket/commands.rs
+++ b/agents/clients/linux/rust/src/websocket/commands.rs
@@ -177,6 +177,19 @@ impl super::client::WebSocketClient {
                     (false, Some("Missing or invalid excludedSensors".to_string()), serde_json::json!({}))
                 }
             }
+            "setAuthToken" => {
+                // Persist happens inside set_auth_token BEFORE the ack below -
+                // the Hub only commits the token hash once we respond success,
+                // so acking an unpersisted token would lock this agent out.
+                if let Some(token) = payload.get("authToken").and_then(|v| v.as_str()) {
+                    match self.set_auth_token(token).await {
+                        Ok(_) => (true, None, serde_json::json!({"message": "Auth token stored"})),
+                        Err(e) => (false, Some(e.to_string()), serde_json::json!({})),
+                    }
+                } else {
+                    (false, Some("Missing or invalid authToken".to_string()), serde_json::json!({}))
+                }
+            }
             "selfUpdate" => {
                 // Extract version from payload for comparison
                 let target_version = payload.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
@@ -446,6 +459,32 @@ impl super::client::WebSocketClient {
         let status = if enabled { "enabled" } else { "disabled" };
         let old_status = if old_enabled { "enabled" } else { "disabled" };
         info!("Fan Control changed: {} → {}", old_status, status);
+        Ok(())
+    }
+
+    pub(crate) async fn set_auth_token(&self, token: &str) -> Result<()> {
+        if token.trim().is_empty() {
+            return Err(anyhow::anyhow!("Auth token cannot be empty"));
+        }
+
+        // Update config quickly with minimal lock time
+        {
+            let mut config = self.config.write().await;
+            config.auth.auth_token = Some(token.to_string());
+            // One-time bootstrap credential - no longer needed
+            config.auth.enrollment_token = None;
+        } // Lock released here
+
+        // Perform I/O outside of lock
+        let config_path = std::env::current_exe()?
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine executable directory"))?
+            .join("config.json");
+
+        save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
+
+        // Never log the token itself
+        info!("Hub auth token stored (saved to config)");
         Ok(())
     }
 

--- a/agents/clients/linux/rust/src/websocket/messaging.rs
+++ b/agents/clients/linux/rust/src/websocket/messaging.rs
@@ -44,7 +44,7 @@ impl super::client::WebSocketClient {
         let fans = self.hardware_monitor.discover_fans().await?;
 
         let config = self.config.read().await;
-        let registration = serde_json::json!({
+        let mut registration = serde_json::json!({
             "type": "register",
             "data": {
                 "agentId": config.agent.id,
@@ -66,6 +66,14 @@ impl super::client::WebSocketClient {
                 }
             }
         });
+
+        // Present the permanent token if we have one; otherwise the one-time
+        // enrollment token from the install script (exchanged on first register)
+        if let Some(token) = &config.auth.auth_token {
+            registration["data"]["auth_token"] = serde_json::json!(token);
+        } else if let Some(token) = &config.auth.enrollment_token {
+            registration["data"]["enrollment_token"] = serde_json::json!(token);
+        }
 
         write.send(Message::text(registration.to_string())).await?;
         info!("✅ Agent registered: {}", config.agent.id);

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/persistence.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/persistence.rs
@@ -86,6 +86,12 @@ pub async fn load_config(path: Option<&str>) -> Result<AgentConfig> {
 pub async fn save_config(config: &AgentConfig, path: &str) -> Result<()> {
     let content = serde_json::to_string_pretty(config)?;
     tokio::fs::write(path, content).await?;
+    // config.json carries the Hub auth token - keep it owner-only
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+    }
     info!("Configuration saved to: {}", path);
     Ok(())
 }

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/setup.rs
@@ -193,6 +193,9 @@ pub async fn run_setup_wizard(config_path: Option<&str>) -> Result<()> {
             max_log_size_mb: 10,
             log_retention_days: 7,
         },
+        // Wizard setups start without credentials; enrollment needs a deploy
+        // token from the Hub's Deployment page (see enrollment_token)
+        auth: AuthSettings::default(),
     };
 
     save_config(&config, config_file.to_str().unwrap()).await?;

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/types.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/config/types.rs
@@ -9,6 +9,21 @@ pub struct AgentConfig {
     pub backend: BackendSettings,
     pub hardware: HardwareSettings,
     pub logging: LoggingSettings,
+    // Hub credentials. Declared last so it serializes as the final section
+    // of config.json. #[serde(default)] keeps pre-auth config files parsing.
+    #[serde(default)]
+    pub auth: AuthSettings,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthSettings {
+    // One-time bootstrap credential written by the install script; removed
+    // when the Hub issues the permanent auth_token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrollment_token: Option<String>,
+    // Hub-minted permanent credential, presented on every registration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,6 +124,7 @@ impl Default for AgentConfig {
                 max_log_size_mb: 10,
                 log_retention_days: 7,
             },
+            auth: AuthSettings::default(),
         }
     }
 }

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
@@ -289,6 +289,7 @@ async fn main() -> Result<()> {
         match websocket::profile_fetch::fetch_and_cache_profile(
             &profile_url,
             &install_dir,
+            config.auth.auth_token.as_deref(),
         ).await {
             Ok(path) => info!("BMC profile ready at {:?}", path),
             Err(e) => warn!("Profile fetch failed: {}. Agent will use --profile flag or existing profile.json", e),

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
@@ -403,6 +403,20 @@ impl WebSocketClient {
                 "registered" => {
                     info!("Agent successfully registered with backend");
 
+                    // Enrollment exchange: persist the Hub-minted auth token
+                    // (delivered in the registered response) and drop the
+                    // one-time enrollment token
+                    let issued_token = message
+                        .get("data")
+                        .and_then(|d| d.get("auth_token"))
+                        .or_else(|| message.get("auth_token"))
+                        .and_then(|v| v.as_str());
+                    if let Some(token) = issued_token {
+                        if let Err(e) = self.set_auth_token(token).await {
+                            error!("Failed to persist Hub auth token: {}", e);
+                        }
+                    }
+
                     // Cleanup after successful update (if applicable)
                     if let Ok(current_exe) = std::env::current_exe() {
                         if let Some(exe_dir) = current_exe.parent() {
@@ -474,6 +488,34 @@ impl WebSocketClient {
                             }
                         }
                     }
+                }
+                "registrationPending" => {
+                    // Hub is holding this agent for admin approval (D13).
+                    // Keep the connection; the Hub promotes us with a
+                    // "registered" message once approved. Telemetry we send
+                    // meanwhile is ignored Hub-side.
+                    let reason = message
+                        .get("data")
+                        .and_then(|d| d.get("reason"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("awaiting approval");
+                    info!(
+                        "Hub is holding this agent for approval ({}). Approve it on the Pankha dashboard.",
+                        reason
+                    );
+                }
+                "registrationError" => {
+                    // Hub refused this agent. Say exactly why (expired deploy
+                    // token vs rejected credential) - the Hub closes the
+                    // connection next, and the standard reconnect backoff
+                    // (capped at 15s) takes over; no special retry handling.
+                    let reason = message
+                        .get("data")
+                        .and_then(|d| d.get("error"))
+                        .or_else(|| message.get("error"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("no reason given");
+                    error!("Hub rejected registration: {}", reason);
                 }
                 _ => {
                     debug!("Received message type: {}", msg_type);

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/commands.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/commands.rs
@@ -165,6 +165,19 @@ impl super::client::WebSocketClient {
                     (false, Some("Missing or invalid excludedSensors".to_string()), serde_json::json!({}))
                 }
             }
+            "setAuthToken" => {
+                // Persist happens inside set_auth_token BEFORE the ack below -
+                // the Hub only commits the token hash once we respond success,
+                // so acking an unpersisted token would lock this agent out.
+                if let Some(token) = payload.get("authToken").and_then(|v| v.as_str()) {
+                    match self.set_auth_token(token).await {
+                        Ok(_) => (true, None, serde_json::json!({"message": "Auth token stored"})),
+                        Err(e) => (false, Some(e.to_string()), serde_json::json!({})),
+                    }
+                } else {
+                    (false, Some("Missing or invalid authToken".to_string()), serde_json::json!({}))
+                }
+            }
             "selfUpdate" => {
                 // Extract version from payload for comparison
                 let target_version = payload.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
@@ -183,6 +196,7 @@ impl super::client::WebSocketClient {
                 // Fetch fresh profile from backend API, save to disk, then hot-reload
                 let config = self.config.read().await;
                 let profile_url = config.profile_url();
+                let auth_token = config.auth.auth_token.clone();
                 drop(config);
 
                 let install_dir = std::env::current_exe()
@@ -190,7 +204,7 @@ impl super::client::WebSocketClient {
                     .and_then(|p| p.parent().map(|d| d.to_path_buf()))
                     .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-                match super::profile_fetch::fetch_and_cache_profile(&profile_url, &install_dir).await {
+                match super::profile_fetch::fetch_and_cache_profile(&profile_url, &install_dir, auth_token.as_deref()).await {
                     Ok(path) => {
                         info!("Profile fetched from API to {:?}, hot-reloading...", path);
                         match self.hardware_monitor.reload_profile().await {
@@ -503,6 +517,32 @@ impl super::client::WebSocketClient {
         let status = if enabled { "enabled" } else { "disabled" };
         let old_status = if old_enabled { "enabled" } else { "disabled" };
         info!("Fan Control changed: {} → {}", old_status, status);
+        Ok(())
+    }
+
+    pub(crate) async fn set_auth_token(&self, token: &str) -> Result<()> {
+        if token.trim().is_empty() {
+            return Err(anyhow::anyhow!("Auth token cannot be empty"));
+        }
+
+        // Update config quickly with minimal lock time
+        {
+            let mut config = self.config.write().await;
+            config.auth.auth_token = Some(token.to_string());
+            // One-time bootstrap credential - no longer needed
+            config.auth.enrollment_token = None;
+        } // Lock released here
+
+        // Perform I/O outside of lock
+        let config_path = std::env::current_exe()?
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine executable directory"))?
+            .join("config.json");
+
+        save_config(&*self.config.read().await, config_path.to_str().unwrap()).await?;
+
+        // Never log the token itself
+        info!("Hub auth token stored (saved to config)");
         Ok(())
     }
 

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/messaging.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/messaging.rs
@@ -76,7 +76,7 @@ impl super::client::WebSocketClient {
         };
 
         let config = self.config.read().await;
-        let registration = serde_json::json!({
+        let mut registration = serde_json::json!({
             "type": "register",
             "data": {
                 "agentId": config.agent.id,
@@ -99,6 +99,14 @@ impl super::client::WebSocketClient {
                 }
             }
         });
+
+        // Present the permanent token if we have one; otherwise the one-time
+        // enrollment token from the install script (exchanged on first register)
+        if let Some(token) = &config.auth.auth_token {
+            registration["data"]["auth_token"] = serde_json::json!(token);
+        } else if let Some(token) = &config.auth.enrollment_token {
+            registration["data"]["enrollment_token"] = serde_json::json!(token);
+        }
 
         write.send(Message::text(registration.to_string())).await?;
         info!("✅ Agent registered: {}", config.agent.id);

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/profile_fetch.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/profile_fetch.rs
@@ -14,12 +14,15 @@ use tracing::{info, warn, debug};
 pub async fn fetch_and_cache_profile(
     profile_url: &str,
     install_dir: &Path,
+    // Hub auth token: required once this agent is secured (the Hub rejects
+    // tokenless fetches for secured agents); None during first enrollment
+    auth_token: Option<&str>,
 ) -> Result<PathBuf> {
     let profile_path = install_dir.join("profile.json");
 
     // Attempt HTTP fetch
     info!("Fetching BMC profile from {}", profile_url);
-    match fetch_profile_http(profile_url).await {
+    match fetch_profile_http(profile_url, auth_token).await {
         Ok(json) => {
             std::fs::write(&profile_path, &json)
                 .with_context(|| format!("Failed to write profile to {:?}", profile_path))?;
@@ -41,9 +44,20 @@ pub async fn fetch_and_cache_profile(
 }
 
 /// Perform the HTTP GET request using curl (same pattern as self_update.rs).
-async fn fetch_profile_http(url: &str) -> Result<String> {
+async fn fetch_profile_http(url: &str, auth_token: Option<&str>) -> Result<String> {
+    let mut args: Vec<String> = vec![
+        "-sSL".to_string(),
+        "--max-time".to_string(),
+        "10".to_string(),
+    ];
+    if let Some(token) = auth_token {
+        args.push("-H".to_string());
+        args.push(format!("Authorization: Bearer {}", token));
+    }
+    args.push(url.to_string());
+
     let output = std::process::Command::new("curl")
-        .args(["-sSL", "--max-time", "10", url])
+        .args(&args)
         .output()
         .context("Failed to execute curl - ensure it is installed")?;
 

--- a/agents/clients/windows/varient-c/Core/CommandHandler.cs
+++ b/agents/clients/windows/varient-c/Core/CommandHandler.cs
@@ -68,6 +68,9 @@ public class CommandHandler
                 case "setEnableFanControl":
                     return await HandleSetEnableFanControlAsync(commandId, payload);
 
+                case "setAuthToken":
+                    return HandleSetAuthToken(commandId, payload);
+
                 case "setAgentName":
                     return await HandleSetAgentNameAsync(commandId, payload);
 
@@ -278,6 +281,28 @@ public class CommandHandler
         _logger.Information("Fan Control changed: {Old} → {New}", oldStatus, status);
 
         return Task.FromResult(CreateSuccessResponse(commandId, new { enabled }));
+    }
+
+    private CommandResponse HandleSetAuthToken(string commandId, Dictionary<string, object> payload)
+    {
+        // Persist happens BEFORE the response is returned - the Hub only
+        // commits the token hash once we respond success, so acking an
+        // unpersisted token would lock this agent out.
+        var token = GetPayloadValue<string>(payload, "authToken");
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return CreateErrorResponse(commandId, "Auth token cannot be empty");
+        }
+
+        _config.Auth.AuthToken = token;
+        // One-time bootstrap credential - no longer needed
+        _config.Auth.EnrollmentToken = null;
+        _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
+
+        // Never log the token itself
+        _logger.Information("Hub auth token stored (saved to config)");
+
+        return CreateSuccessResponse(commandId, new { message = "Auth token stored" });
     }
 
     private Task<CommandResponse> HandleSetAgentNameAsync(string commandId, Dictionary<string, object> payload)

--- a/agents/clients/windows/varient-c/Core/WebSocketClient.cs
+++ b/agents/clients/windows/varient-c/Core/WebSocketClient.cs
@@ -227,7 +227,13 @@ public class WebSocketClient : IDisposable
                         Sensors = sensors,
                         Fans = fans,
                         FanControl = _config.Hardware.EnableFanControl
-                    }
+                    },
+                    // Permanent token if enrolled; otherwise the one-time
+                    // enrollment token (exchanged on first register)
+                    AuthToken = _config.Auth.AuthToken,
+                    EnrollmentToken = _config.Auth.AuthToken == null
+                        ? _config.Auth.EnrollmentToken
+                        : null
                 }
             };
 
@@ -440,6 +446,43 @@ public class WebSocketClient : IDisposable
             {
                 case "registered":
                     _logger.Information("Registration confirmed by backend");
+
+                    // Enrollment exchange: persist the Hub-minted auth token
+                    // (delivered in the registered response) and drop the
+                    // one-time enrollment token
+                    var registeredJson = Newtonsoft.Json.Linq.JObject.Parse(json);
+                    var issuedToken = registeredJson["data"]?["auth_token"]?.Value<string>()
+                        ?? registeredJson["auth_token"]?.Value<string>();
+                    if (!string.IsNullOrEmpty(issuedToken))
+                    {
+                        _config.Auth.AuthToken = issuedToken;
+                        _config.Auth.EnrollmentToken = null;
+                        _config.SaveToFile(Pankha.WindowsAgent.Platform.PathResolver.ConfigPath);
+                        // Never log the token itself
+                        _logger.Information("Hub auth token stored (saved to config)");
+                    }
+                    break;
+
+                case "registrationPending":
+                    // Hub is holding this agent for admin approval (D13). Keep
+                    // the connection; the Hub promotes us with "registered"
+                    // once approved. Telemetry sent meanwhile is ignored.
+                    var pendingJson = Newtonsoft.Json.Linq.JObject.Parse(json);
+                    var pendingReason = pendingJson["data"]?["reason"]?.Value<string>()
+                        ?? "awaiting approval";
+                    _logger.Information(
+                        "Hub is holding this agent for approval ({Reason}). Approve it on the Pankha dashboard.",
+                        pendingReason);
+                    break;
+
+                case "registrationError":
+                    // Hub refused this agent. The Hub closes the connection
+                    // next; standard reconnect backoff takes over.
+                    var errorJson = Newtonsoft.Json.Linq.JObject.Parse(json);
+                    var errorReason = errorJson["data"]?["error"]?.Value<string>()
+                        ?? errorJson["error"]?.Value<string>()
+                        ?? "no reason given";
+                    _logger.Error("Hub rejected registration: {Reason}", errorReason);
                     break;
 
                 case "command":

--- a/agents/clients/windows/varient-c/Core/WebSocketClient.cs
+++ b/agents/clients/windows/varient-c/Core/WebSocketClient.cs
@@ -451,8 +451,8 @@ public class WebSocketClient : IDisposable
                     // (delivered in the registered response) and drop the
                     // one-time enrollment token
                     var registeredJson = Newtonsoft.Json.Linq.JObject.Parse(json);
-                    var issuedToken = registeredJson["data"]?["auth_token"]?.Value<string>()
-                        ?? registeredJson["auth_token"]?.Value<string>();
+                    var issuedToken = (string?)registeredJson["data"]?["auth_token"]
+                        ?? (string?)registeredJson["auth_token"];
                     if (!string.IsNullOrEmpty(issuedToken))
                     {
                         _config.Auth.AuthToken = issuedToken;
@@ -468,7 +468,7 @@ public class WebSocketClient : IDisposable
                     // the connection; the Hub promotes us with "registered"
                     // once approved. Telemetry sent meanwhile is ignored.
                     var pendingJson = Newtonsoft.Json.Linq.JObject.Parse(json);
-                    var pendingReason = pendingJson["data"]?["reason"]?.Value<string>()
+                    var pendingReason = (string?)pendingJson["data"]?["reason"]
                         ?? "awaiting approval";
                     _logger.Information(
                         "Hub is holding this agent for approval ({Reason}). Approve it on the Pankha dashboard.",
@@ -479,8 +479,8 @@ public class WebSocketClient : IDisposable
                     // Hub refused this agent. The Hub closes the connection
                     // next; standard reconnect backoff takes over.
                     var errorJson = Newtonsoft.Json.Linq.JObject.Parse(json);
-                    var errorReason = errorJson["data"]?["error"]?.Value<string>()
-                        ?? errorJson["error"]?.Value<string>()
+                    var errorReason = (string?)errorJson["data"]?["error"]
+                        ?? (string?)errorJson["error"]
                         ?? "no reason given";
                     _logger.Error("Hub rejected registration: {Reason}", errorReason);
                     break;

--- a/agents/clients/windows/varient-c/Models/Configuration/AgentConfig.cs
+++ b/agents/clients/windows/varient-c/Models/Configuration/AgentConfig.cs
@@ -23,6 +23,11 @@ public class AgentConfig
     [JsonProperty("logging")]
     public LoggingSettings Logging { get; set; } = new();
 
+    // Hub credentials. Declared last so it serializes as the final section
+    // of config.json; default keeps pre-auth config files parsing.
+    [JsonProperty("auth")]
+    public AuthSettings Auth { get; set; } = new();
+
     /// <summary>
     /// Load configuration from file
     /// </summary>
@@ -265,7 +270,8 @@ public class AgentConfig
                 LogFile = "logs/agent.log",
                 MaxLogSizeMb = 50,
                 LogRetentionDays = 7
-            }
+            },
+            Auth = new AuthSettings()
         };
     }
 }

--- a/agents/clients/windows/varient-c/Models/Configuration/AuthSettings.cs
+++ b/agents/clients/windows/varient-c/Models/Configuration/AuthSettings.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+
+namespace Pankha.WindowsAgent.Models.Configuration;
+
+/// <summary>
+/// Hub credentials. Kept as the last section of config.json (property
+/// declaration order in AgentConfig controls serialization order).
+/// </summary>
+public class AuthSettings
+{
+    /// <summary>
+    /// One-time bootstrap credential written by the install flow; removed
+    /// when the Hub issues the permanent auth_token.
+    /// </summary>
+    [JsonProperty("enrollment_token", NullValueHandling = NullValueHandling.Ignore)]
+    public string? EnrollmentToken { get; set; }
+
+    /// <summary>
+    /// Hub-minted permanent credential, presented on every registration.
+    /// </summary>
+    [JsonProperty("auth_token", NullValueHandling = NullValueHandling.Ignore)]
+    public string? AuthToken { get; set; }
+}

--- a/agents/clients/windows/varient-c/Models/Messages/RegisterMessage.cs
+++ b/agents/clients/windows/varient-c/Models/Messages/RegisterMessage.cs
@@ -65,6 +65,18 @@ public class RegisterData
 
     [JsonProperty("capabilities")]
     public Capabilities Capabilities { get; set; } = new();
+
+    /// <summary>
+    /// Hub-minted permanent credential (absent until enrolled)
+    /// </summary>
+    [JsonProperty("auth_token", NullValueHandling = NullValueHandling.Ignore)]
+    public string? AuthToken { get; set; }
+
+    /// <summary>
+    /// One-time deploy token, exchanged for auth_token on first register
+    /// </summary>
+    [JsonProperty("enrollment_token", NullValueHandling = NullValueHandling.Ignore)]
+    public string? EnrollmentToken { get; set; }
 }
 
 /// <summary>

--- a/agents/clients/windows/varient-c/build.ps1
+++ b/agents/clients/windows/varient-c/build.ps1
@@ -413,6 +413,10 @@ if (-not $Publish) {
     $TrayBuildParams = @("Pankha.Tray\Pankha.Tray.csproj", "-c", $Configuration)
     if ($AppIconPath) { $TrayBuildParams += "/p:AppIconPath=`"$AppIconPath`"" }
     dotnet build @TrayBuildParams
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Tray App Build failed" -ForegroundColor Red
+        exit 1
+    }
     Write-Host "✅ Tray App Build complete" -ForegroundColor Green
     Write-Host ""
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@types/compression": "^1.8.1",
+    "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.19",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^5.0.3",
@@ -30,9 +31,11 @@
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "jose": "^5.10.0",
     "pg": "^8.13.1",
     "uuid": "^14.0.0",
     "ws": "^8.21.0"

--- a/backend/src/auth/enrollment.ts
+++ b/backend/src/auth/enrollment.ts
@@ -1,0 +1,17 @@
+import Database from '../database/database';
+
+/**
+ * Check a deploy/enrollment token against deployment_templates. Multi-use by
+ * design (fleet paste): validity is expiry-only, used_count is statistics.
+ */
+export async function isValidDeployToken(token: unknown): Promise<boolean> {
+  if (typeof token !== 'string' || token.length === 0 || token.length > 64) {
+    return false;
+  }
+  const db = Database.getInstance();
+  const row = await db.get(
+    'SELECT 1 FROM deployment_templates WHERE token = $1 AND expires_at > NOW()',
+    [token]
+  );
+  return !!row;
+}

--- a/backend/src/auth/passwords.ts
+++ b/backend/src/auth/passwords.ts
@@ -1,0 +1,69 @@
+import crypto from 'crypto';
+
+// scrypt cost parameters (OWASP recommended). Embedded in each stored hash so
+// they can be raised later without invalidating existing rows.
+const SCRYPT_N = 131072; // 2^17
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const SALT_BYTES = 16;
+const KEY_BYTES = 32;
+// scrypt needs 128 * N * r bytes; default maxmem (32MB) is too low for N=2^17
+const SCRYPT_MAXMEM = 256 * 1024 * 1024;
+
+function scryptAsync(
+  password: string,
+  salt: Buffer,
+  N: number,
+  r: number,
+  p: number
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    crypto.scrypt(
+      password,
+      salt,
+      KEY_BYTES,
+      { N, r, p, maxmem: SCRYPT_MAXMEM },
+      (err, key) => (err ? reject(err) : resolve(key))
+    );
+  });
+}
+
+/**
+ * Hash a password. Stored format: scrypt$N$r$p$<salt b64>$<hash b64>
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.randomBytes(SALT_BYTES);
+  const key = await scryptAsync(password, salt, SCRYPT_N, SCRYPT_R, SCRYPT_P);
+  return [
+    'scrypt',
+    SCRYPT_N,
+    SCRYPT_R,
+    SCRYPT_P,
+    salt.toString('base64'),
+    key.toString('base64'),
+  ].join('$');
+}
+
+/**
+ * Verify a password against a stored hash. Timing-safe comparison.
+ */
+export async function verifyPassword(
+  password: string,
+  stored: string
+): Promise<boolean> {
+  const parts = stored.split('$');
+  if (parts.length !== 6 || parts[0] !== 'scrypt') return false;
+  const N = parseInt(parts[1], 10);
+  const r = parseInt(parts[2], 10);
+  const p = parseInt(parts[3], 10);
+  if (!Number.isFinite(N) || !Number.isFinite(r) || !Number.isFinite(p)) {
+    return false;
+  }
+  const salt = Buffer.from(parts[4], 'base64');
+  const expected = Buffer.from(parts[5], 'base64');
+  const actual = await scryptAsync(password, salt, N, r, p);
+  return (
+    actual.length === expected.length &&
+    crypto.timingSafeEqual(actual, expected)
+  );
+}

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -2,13 +2,16 @@ import crypto from 'crypto';
 import { SignJWT, jwtVerify } from 'jose';
 import Database from '../database/database';
 import { log } from '../utils/logger';
+import { parseDurationSeconds } from '../utils/duration';
 
 // Browser sessions: HS256 JWT in an httpOnly cookie. The token carries the
 // role NAME only - numeric levels exist solely in middleware/auth.ts.
 export const SESSION_COOKIE = 'pankha_session';
-export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days, sliding
-// Reissue the cookie once a session token is older than this (sliding expiry)
-export const SESSION_RENEW_AFTER_SECONDS = 24 * 60 * 60;
+// Session lifetime (sliding), e.g. "7 days", "12 hours". Via PANKHA_SESSION_DURATION; default 7 days.
+export const SESSION_TTL_SECONDS =
+  parseDurationSeconds(process.env.PANKHA_SESSION_DURATION) ?? 7 * 24 * 60 * 60;
+// Reissue the cookie once a session has used ~1/7 of its life (sliding expiry).
+export const SESSION_RENEW_AFTER_SECONDS = Math.floor(SESSION_TTL_SECONDS / 7);
 
 const SECRET_SETTING_KEY = 'session_secret';
 

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -8,8 +8,14 @@ import { parseDurationSeconds } from '../utils/duration';
 // role NAME only - numeric levels exist solely in middleware/auth.ts.
 export const SESSION_COOKIE = 'pankha_session';
 // Session lifetime (sliding), e.g. "7 days", "12 hours". Via PANKHA_SESSION_DURATION; default 7 days.
-export const SESSION_TTL_SECONDS =
-  parseDurationSeconds(process.env.PANKHA_SESSION_DURATION) ?? 7 * 24 * 60 * 60;
+export const SESSION_TTL_SECONDS = (() => {
+  const raw = (process.env.PANKHA_SESSION_DURATION ?? '').trim();
+  const parsed = parseDurationSeconds(raw);
+  if (raw && parsed === null) {
+    log.warn(`PANKHA_SESSION_DURATION unrecognized ("${raw}") - using the 7 day default.`, 'auth');
+  }
+  return parsed ?? 7 * 24 * 60 * 60;
+})();
 // Reissue the cookie once a session has used ~1/7 of its life (sliding expiry).
 export const SESSION_RENEW_AFTER_SECONDS = Math.floor(SESSION_TTL_SECONDS / 7);
 

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -1,0 +1,108 @@
+import crypto from 'crypto';
+import { SignJWT, jwtVerify } from 'jose';
+import Database from '../database/database';
+import { log } from '../utils/logger';
+
+// Browser sessions: HS256 JWT in an httpOnly cookie. The token carries the
+// role NAME only - numeric levels exist solely in middleware/auth.ts.
+export const SESSION_COOKIE = 'pankha_session';
+export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days, sliding
+// Reissue the cookie once a session token is older than this (sliding expiry)
+export const SESSION_RENEW_AFTER_SECONDS = 24 * 60 * 60;
+
+const SECRET_SETTING_KEY = 'session_secret';
+
+export interface SessionUser {
+  userId: number;
+  username: string;
+  role: string;
+}
+
+let secretKey: Uint8Array | null = null;
+
+/**
+ * Load the session signing secret from backend_settings, generating and
+ * persisting one on first boot (sessions survive container restarts).
+ */
+export async function initSessionSecret(): Promise<void> {
+  const db = Database.getInstance();
+  const row = await db.get(
+    'SELECT setting_value FROM backend_settings WHERE setting_key = $1',
+    [SECRET_SETTING_KEY]
+  );
+  if (row?.setting_value) {
+    secretKey = Buffer.from(row.setting_value, 'base64');
+    return;
+  }
+  const fresh = crypto.randomBytes(32);
+  await db.run(
+    `INSERT INTO backend_settings (setting_key, setting_value, description)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (setting_key) DO NOTHING`,
+    [SECRET_SETTING_KEY, fresh.toString('base64'), 'Session cookie signing secret']
+  );
+  // Re-read in case a concurrent boot won the insert race
+  const persisted = await db.get(
+    'SELECT setting_value FROM backend_settings WHERE setting_key = $1',
+    [SECRET_SETTING_KEY]
+  );
+  secretKey = Buffer.from(persisted.setting_value, 'base64');
+  log.info('Generated new session signing secret', 'auth');
+}
+
+export async function signSession(user: SessionUser): Promise<string> {
+  if (!secretKey) throw new Error('Session secret not initialized');
+  return new SignJWT({ username: user.username, role: user.role })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(String(user.userId))
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS)
+    .sign(secretKey);
+}
+
+export interface VerifiedSession {
+  user: SessionUser;
+  /** Seconds since the token was issued (drives sliding renewal) */
+  ageSeconds: number;
+}
+
+/**
+ * Minimal cookie-header parser for the WebSocket upgrade request (Express's
+ * cookie-parser only runs on HTTP routes).
+ */
+export function parseCookieHeader(header: string | undefined): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  if (!header) return cookies;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name) cookies[name] = decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return cookies;
+}
+
+export async function verifySession(
+  token: string
+): Promise<VerifiedSession | null> {
+  if (!secretKey) return null;
+  try {
+    const { payload } = await jwtVerify(token, secretKey, {
+      algorithms: ['HS256'],
+    });
+    if (!payload.sub || typeof payload.username !== 'string' || typeof payload.role !== 'string') {
+      return null;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    return {
+      user: {
+        userId: parseInt(payload.sub, 10),
+        username: payload.username,
+        role: payload.role,
+      },
+      ageSeconds: now - (payload.iat ?? now),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/auth/tokens.ts
+++ b/backend/src/auth/tokens.ts
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+
+// Agent tokens: 128-bit random, base64url, self-identifying prefix.
+// Format: pka_ + 22 chars, ~26 chars total. Only the SHA-256 hex hash is
+// stored Hub-side (systems.auth_token_hash); plaintext lives solely in the
+// agent's config.json.
+const TOKEN_PREFIX = 'pka_';
+const TOKEN_BYTES = 16;
+
+export const AGENT_TOKEN_PATTERN = /^pka_[A-Za-z0-9_-]{22}$/;
+
+export function mintAgentToken(): string {
+  return TOKEN_PREFIX + crypto.randomBytes(TOKEN_BYTES).toString('base64url');
+}
+
+export function hashAgentToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Timing-safe check of a presented token against a stored hash.
+ */
+export function verifyAgentToken(
+  presented: string,
+  storedHash: string | null | undefined
+): boolean {
+  if (!presented || !storedHash) return false;
+  const actual = Buffer.from(hashAgentToken(presented), 'hex');
+  const expected = Buffer.from(storedHash, 'hex');
+  return (
+    actual.length === expected.length &&
+    crypto.timingSafeEqual(actual, expected)
+  );
+}

--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -612,3 +612,30 @@ DO $$ BEGIN
     RAISE NOTICE 'Migration: Added calibration_version to fan_calibration_history';
   END IF;
 END $$;
+
+-- ============================================================================
+-- Hub authentication (task_02): user accounts + per-agent token hash
+-- ============================================================================
+
+-- Dashboard user accounts. Role names are validated in the backend; no CHECK
+-- constraint so new roles need no schema migration.
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role VARCHAR(50) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Migration: per-agent auth token hash (SHA-256 hex). NULL = agent not yet
+-- secured (pre-auth agent awaiting token issuance).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'systems' AND column_name = 'auth_token_hash'
+  ) THEN
+    ALTER TABLE systems ADD COLUMN auth_token_hash TEXT;
+    RAISE NOTICE 'Migration: Added auth_token_hash column to systems';
+  END IF;
+END $$;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import http from 'http';
 import cors from 'cors';
 import compression from 'compression';
+import cookieParser from 'cookie-parser';
 import Database from './database/database';
 import { AgentManager } from './services/AgentManager';
 import { AgentCommunication } from './services/AgentCommunication';
@@ -28,6 +29,8 @@ import fanConfigurationsRouter from './routes/fanConfigurations';
 import virtualSensorsRouter from './routes/virtualSensors';
 import deployRouter from './routes/deploy';
 import configRouter from './routes/config';
+import authRouter from './routes/auth';
+import { apiAuthGuard, initAuth } from './middleware/auth';
 import { licenseRouter, licenseManager } from './license';
 import { log, logger } from './utils/logger';
 import { createDemoLockResponse, isDemoMode } from './utils/mode';
@@ -114,6 +117,9 @@ async function initializeServices() {
     const db = Database.getInstance();
     await db.initialize();
 
+    // Auth: session secret, PANKHA_AUTH_RESET handling, user cache
+    await initAuth();
+
     // Initialize core services
     const agentManager = AgentManager.getInstance();
     const agentCommunication = AgentCommunication.getInstance();
@@ -195,8 +201,11 @@ async function initializeServices() {
 }
 
 // Middleware
-app.use(cors());
+// origin: true reflects the request origin so cookie-carrying requests work
+// from the Vite dev server (5173); same trust surface as the previous cors()
+app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
+app.use(cookieParser());
 app.use(
   compression({
     threshold: COMPRESSION_THRESHOLD_BYTES,
@@ -232,7 +241,12 @@ app.get('/health', (req, res) => {
   });
 });
 
+// Central auth guard: classifies every /api request (public, deploy-token,
+// agent-token, or session + minimum role) before any router runs
+app.use('/api', apiAuthGuard);
+
 // API routes
+app.use('/api/auth', authRouter);
 app.use('/api/systems', systemsRouter);
 app.use('/api/discovery', discoveryRouter);
 app.use('/api/fan-profiles', fanProfilesRouter);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ dotenv.config({ path: path.join(__dirname, '../../.env') }); // Load from projec
 
 import express from 'express';
 import http from 'http';
+import net from 'net';
 import cors from 'cors';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
@@ -42,10 +43,30 @@ const app = express();
 // 3. 3143 (default fallback / brand port)
 const PORT = process.env.PORT || process.env.PANKHA_PORT || 3143;
 
-// Reverse-proxy hop count so the login limiter sees the real client IP, not the proxy. 0 (default) = off.
-const TRUST_PROXY_HOPS = parseInt(process.env.PANKHA_TRUST_PROXY ?? '', 10);
-if (Number.isInteger(TRUST_PROXY_HOPS) && TRUST_PROXY_HOPS > 0) {
-  app.set('trust proxy', TRUST_PROXY_HOPS);
+// Trusted reverse proxies, comma-separated IPs/CIDRs. Only forwarded-for
+// headers arriving FROM these addresses are believed, so the login limiter
+// sees the real client IP. Unset = no proxy trusted.
+const isIpOrCidr = (entry: string): boolean => {
+  const [ip, prefix, extra] = entry.split('/');
+  if (extra !== undefined) return false;
+  const family = net.isIP(ip);
+  if (family === 0) return false;
+  if (prefix === undefined) return true;
+  if (!/^\d+$/.test(prefix)) return false;
+  const bits = parseInt(prefix, 10);
+  return bits >= 0 && bits <= (family === 4 ? 32 : 128);
+};
+const TRUST_PROXY_RAW = (process.env.PANKHA_TRUST_PROXY ?? '').trim();
+if (TRUST_PROXY_RAW) {
+  const proxies = TRUST_PROXY_RAW.split(',').map((s) => s.trim()).filter(Boolean);
+  if (proxies.length > 0 && proxies.every(isIpOrCidr)) {
+    app.set('trust proxy', proxies);
+  } else {
+    log.warn(
+      `PANKHA_TRUST_PROXY ignored - expected comma-separated IPs/CIDRs (e.g. "192.168.1.5, 10.0.0.0/8"), got "${TRUST_PROXY_RAW}". No proxy is trusted.`,
+      'startup'
+    );
+  }
 }
 
 // Periodic heap-usage check. Warns only when heapUsed exceeds the threshold

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -42,6 +42,12 @@ const app = express();
 // 3. 3143 (default fallback / brand port)
 const PORT = process.env.PORT || process.env.PANKHA_PORT || 3143;
 
+// Reverse-proxy hop count so the login limiter sees the real client IP, not the proxy. 0 (default) = off.
+const TRUST_PROXY_HOPS = parseInt(process.env.PANKHA_TRUST_PROXY ?? '', 10);
+if (Number.isInteger(TRUST_PROXY_HOPS) && TRUST_PROXY_HOPS > 0) {
+  app.set('trust proxy', TRUST_PROXY_HOPS);
+}
+
 // Periodic heap-usage check. Warns only when heapUsed exceeds the threshold
 // (default 1024MB, tunable via MEMORY_WARN_THRESHOLD_MB) - high enough to stay
 // silent in normal operation, so a warning signals an abnormal climb (leak).

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import Database from '../database/database';
 import { log } from '../utils/logger';
+import { isDemoMode } from '../utils/mode';
 import {
   SESSION_COOKIE,
   SESSION_TTL_SECONDS,
@@ -193,6 +194,11 @@ export async function apiAuthGuard(
   if (access === 'public' || access === 'deploy-token' || access === 'agent-token') {
     // deploy-token and agent-token routes validate their own credentials
     return next();
+  }
+
+  // Demo instances (PANKHA_MODE=demo) render a read-only viewer view.
+  if (!req.session && isDemoMode()) {
+    req.session = { userId: -1, username: 'demo', role: 'viewer' };
   }
 
   if (!req.session) {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -63,6 +63,8 @@ const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
   { pattern: /^POST \/deploy\/profiles\/custom$/, access: 'admin' },
   { pattern: /^POST \/systems\/\d+\/update$/, access: 'admin' },
   { pattern: /^DELETE \/systems\/\d+$/, access: 'admin' },
+  // Pending-approval queue (D13): admitting machines is admin territory
+  { pattern: /^(GET|POST|DELETE) \/systems\/pending(\/|$)/, access: 'admin' },
   { pattern: /^(POST|DELETE) \/license$/, access: 'admin' },
   { pattern: /^POST \/license\/(sync|renew|cancel|checkout)$/, access: 'admin' },
 ];

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -111,7 +111,18 @@ export function isAuthResetActive(): boolean {
 export async function initAuth(): Promise<void> {
   await initSessionSecret();
 
-  if (process.env.PANKHA_AUTH_RESET === 'true') {
+  // Destructive switch: strict values only. Garbage means unclear operator
+  // intent, so refuse to start rather than guess.
+  const authReset = (process.env.PANKHA_AUTH_RESET ?? '').trim();
+  if (authReset && authReset !== 'true' && authReset !== 'false') {
+    log.error(
+      `PANKHA_AUTH_RESET must be "true", "false", or unset - got "${authReset}". Refusing to start.`,
+      'auth'
+    );
+    process.exit(1);
+  }
+
+  if (authReset === 'true') {
     authResetActive = true;
     const db = Database.getInstance();
     const result = await db.run('DELETE FROM users');

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,236 @@
+import { Request, Response, NextFunction } from 'express';
+import Database from '../database/database';
+import { log } from '../utils/logger';
+import {
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+  SESSION_RENEW_AFTER_SECONDS,
+  SessionUser,
+  initSessionSecret,
+  signSession,
+  verifySession,
+} from '../auth/session';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      session?: SessionUser;
+    }
+  }
+}
+
+// The ONLY place role names map to levels. Persisted and transmitted values
+// are role NAMES; numeric levels never leave this file.
+const ROLE_LEVEL: Record<string, number> = {
+  viewer: 1,
+  operator: 2,
+  admin: 3,
+};
+
+export const VALID_ROLES = Object.keys(ROLE_LEVEL);
+
+type Role = 'viewer' | 'operator' | 'admin';
+type AccessClass = 'public' | 'deploy-token' | 'agent-token' | Role;
+
+// REST surface classification (task_02 section 5.5). Matched against
+// "<METHOD> <path>" where path is relative to the /api mount. First match
+// wins; defaults below the table: GET -> viewer, everything else -> operator.
+const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
+  // Auth bootstrap + boot-time frontend config (login page needs these)
+  { pattern: /^POST \/auth\/(login|logout|setup)$/, access: 'public' },
+  { pattern: /^GET \/auth\/me$/, access: 'public' },
+  { pattern: /^GET \/config\/deployment(\.js)?$/, access: 'public' },
+  // Own-password change: any authenticated rank
+  { pattern: /^PUT \/auth\/password$/, access: 'viewer' },
+  // User management: admin only
+  { pattern: /^(GET|POST|PUT|DELETE) \/auth\/users(\/|$)/, access: 'admin' },
+  // Install scripts fetch these headlessly with their own short-lived
+  // ?token= (validated in the route; hardened in M3)
+  { pattern: /^GET \/deploy\/(linux|ipmi)$/, access: 'deploy-token' },
+  { pattern: /^PUT \/deploy\/profiles\/assign\/[^/]+$/, access: 'deploy-token' },
+  // Binaries are public by design: they are the public GitHub release
+  // artifacts, and pre-auth binaries must be able to self-update into a
+  // build that can authenticate at all
+  { pattern: /^GET \/deploy\/binaries\//, access: 'public' },
+  // IPMI profile fetch: bearer required once the agent is secured
+  // (grandfather-aware check lives in the route)
+  { pattern: /^GET \/deploy\/profiles\/assigned\//, access: 'agent-token' },
+  // Provisioning, fleet updates, settings, license mutations: admin
+  { pattern: /^POST \/deploy\/templates$/, access: 'admin' },
+  { pattern: /^(GET|POST|DELETE) \/deploy\/hub\//, access: 'admin' },
+  { pattern: /^GET \/deploy\/profiles\/refresh$/, access: 'admin' },
+  { pattern: /^POST \/deploy\/profiles\/custom$/, access: 'admin' },
+  { pattern: /^POST \/systems\/\d+\/update$/, access: 'admin' },
+  { pattern: /^DELETE \/systems\/\d+$/, access: 'admin' },
+  { pattern: /^(POST|DELETE) \/license$/, access: 'admin' },
+  { pattern: /^POST \/license\/(sync|renew|cancel|checkout)$/, access: 'admin' },
+];
+
+function classify(method: string, path: string): AccessClass {
+  const key = `${method} ${path}`;
+  for (const rule of ACCESS_RULES) {
+    if (rule.pattern.test(key)) return rule.access;
+  }
+  return method === 'GET' ? 'viewer' : 'operator';
+}
+
+// Live user cache: userId -> role. The session JWT carries the role name,
+// but the level check always uses the live role, so role changes and user
+// deletions apply immediately without waiting for token expiry.
+let userRoles = new Map<number, string>();
+let authResetActive = false;
+
+export async function reloadUserCache(): Promise<void> {
+  const db = Database.getInstance();
+  const rows = await db.all('SELECT id, role FROM users');
+  userRoles = new Map(rows.map((r) => [r.id, r.role]));
+}
+
+export function usersExist(): boolean {
+  return userRoles.size > 0;
+}
+
+export function isAuthResetActive(): boolean {
+  return authResetActive;
+}
+
+/**
+ * Boot-time init: session secret, PANKHA_AUTH_RESET handling, user cache.
+ * Call after the database is initialized.
+ */
+export async function initAuth(): Promise<void> {
+  await initSessionSecret();
+
+  if (process.env.PANKHA_AUTH_RESET === 'true') {
+    authResetActive = true;
+    const db = Database.getInstance();
+    const result = await db.run('DELETE FROM users');
+    log.warn(
+      `PANKHA_AUTH_RESET is set: removed ${result.rowCount ?? 0} user account(s). ` +
+        'The setup screen is open to anyone who can reach this Hub. ' +
+        'Remove PANKHA_AUTH_RESET from .env after recovering access.',
+      'auth'
+    );
+  }
+
+  await reloadUserCache();
+  if (!usersExist()) {
+    log.info('No user accounts exist - setup screen active', 'auth');
+  }
+}
+
+export function setSessionCookie(res: Response, token: string): void {
+  res.cookie(SESSION_COOKIE, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_TTL_SECONDS * 1000,
+  });
+}
+
+export function clearSessionCookie(res: Response): void {
+  res.clearCookie(SESSION_COOKIE, { httpOnly: true, sameSite: 'lax', path: '/' });
+}
+
+/**
+ * Level check for routes that combine a session with another credential
+ * (e.g. deploy token OR operator session). Keeps the ladder in this file.
+ */
+export function hasLevel(session: SessionUser | undefined, minRole: Role): boolean {
+  return !!session && (ROLE_LEVEL[session.role] ?? 0) >= ROLE_LEVEL[minRole];
+}
+
+/**
+ * Level check for explicit per-route use. Prefer classification via the
+ * ACCESS_RULES table; this exists for handlers that need a second gate.
+ */
+export function requireLevel(minRole: Role) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.session) {
+      return res.status(401).json({ error: 'authentication required' });
+    }
+    if ((ROLE_LEVEL[req.session.role] ?? 0) < ROLE_LEVEL[minRole]) {
+      return res.status(403).json({ error: 'insufficient role' });
+    }
+    next();
+  };
+}
+
+/**
+ * Central API guard, mounted at /api before all routers. Attaches
+ * req.session from a valid cookie, slides the expiry, then enforces the
+ * access class from ACCESS_RULES.
+ */
+export async function apiAuthGuard(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void | Response> {
+  const raw = req.cookies?.[SESSION_COOKIE];
+  if (raw) {
+    const verified = await verifySession(raw);
+    if (verified) {
+      const liveRole = userRoles.get(verified.user.userId);
+      if (liveRole) {
+        req.session = { ...verified.user, role: liveRole };
+        if (verified.ageSeconds > SESSION_RENEW_AFTER_SECONDS) {
+          setSessionCookie(res, await signSession(req.session));
+        }
+      }
+    }
+  }
+
+  const access = classify(req.method, req.path);
+  if (access === 'public' || access === 'deploy-token' || access === 'agent-token') {
+    // deploy-token and agent-token routes validate their own credentials
+    return next();
+  }
+
+  if (!req.session) {
+    return res.status(401).json({
+      error: 'authentication required',
+      setup_required: !usersExist(),
+    });
+  }
+  if ((ROLE_LEVEL[req.session.role] ?? 0) < ROLE_LEVEL[access]) {
+    return res.status(403).json({ error: 'insufficient role' });
+  }
+  next();
+}
+
+// Login brute-force limiter: per-IP failure counter with lockout.
+const LOCKOUT_THRESHOLD = 5;
+const LOCKOUT_MS = 15 * 60 * 1000;
+const loginFailures = new Map<string, { fails: number; lockedUntil: number }>();
+
+export function loginRateCheck(ip: string): { allowed: boolean; retryAfterSeconds: number } {
+  const entry = loginFailures.get(ip);
+  if (!entry) return { allowed: true, retryAfterSeconds: 0 };
+  const now = Date.now();
+  if (entry.lockedUntil > now) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.ceil((entry.lockedUntil - now) / 1000),
+    };
+  }
+  if (entry.lockedUntil > 0 && entry.lockedUntil <= now) {
+    loginFailures.delete(ip); // lockout expired
+  }
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+export function loginRateFail(ip: string): void {
+  const entry = loginFailures.get(ip) ?? { fails: 0, lockedUntil: 0 };
+  entry.fails += 1;
+  if (entry.fails >= LOCKOUT_THRESHOLD) {
+    entry.lockedUntil = Date.now() + LOCKOUT_MS;
+    entry.fails = 0;
+    log.warn(`Login lockout for ${ip} (${LOCKOUT_THRESHOLD} failures)`, 'auth');
+  }
+  loginFailures.set(ip, entry);
+}
+
+export function loginRateReset(ip: string): void {
+  loginFailures.delete(ip);
+}

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -37,14 +37,17 @@ type AccessClass = 'public' | 'deploy-token' | 'agent-token' | Role;
 // "<METHOD> <path>" where path is relative to the /api mount. First match
 // wins; defaults below the table: GET -> viewer, everything else -> operator.
 const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
-  // Auth bootstrap + boot-time frontend config (login page needs these)
-  { pattern: /^POST \/auth\/(login|logout|setup)$/, access: 'public' },
+  // Auth bootstrap + boot-time frontend config (login page needs these).
+  // register is public here; the route itself enforces the admin's
+  // self-registration toggle (D15)
+  { pattern: /^POST \/auth\/(login|logout|setup|register)$/, access: 'public' },
   { pattern: /^GET \/auth\/me$/, access: 'public' },
   { pattern: /^GET \/config\/deployment(\.js)?$/, access: 'public' },
   // Own-password change: any authenticated rank
   { pattern: /^PUT \/auth\/password$/, access: 'viewer' },
-  // User management: admin only
+  // User management + registration settings: admin only
   { pattern: /^(GET|POST|PUT|DELETE) \/auth\/users(\/|$)/, access: 'admin' },
+  { pattern: /^(GET|PUT) \/auth\/registration$/, access: 'admin' },
   // Install scripts fetch these headlessly with their own short-lived
   // ?token= (validated in the route; hardened in M3)
   { pattern: /^GET \/deploy\/(linux|ipmi)$/, access: 'deploy-token' },

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -73,7 +73,10 @@ const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
 ];
 
 function classify(method: string, path: string): AccessClass {
-  const key = `${method} ${path}`;
+  // Strip trailing slashes: Express routes "/foo/" to the "/foo" handler, so
+  // a rule must not be dodged by a slash that drops the path to the default.
+  const normalized = path.length > 1 ? path.replace(/\/+$/, '') : path;
+  const key = `${method} ${normalized}`;
   for (const rule of ACCESS_RULES) {
     if (rule.pattern.test(key)) return rule.access;
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,324 @@
+import { Router, Request, Response } from 'express';
+import Database from '../database/database';
+import { log } from '../utils/logger';
+import { hashPassword, verifyPassword } from '../auth/passwords';
+import { signSession } from '../auth/session';
+import {
+  VALID_ROLES,
+  usersExist,
+  reloadUserCache,
+  isAuthResetActive,
+  setSessionCookie,
+  clearSessionCookie,
+  loginRateCheck,
+  loginRateFail,
+  loginRateReset,
+} from '../middleware/auth';
+
+const router = Router();
+
+const USERNAME_PATTERN = /^[a-zA-Z0-9_.-]{3,32}$/;
+const MIN_PASSWORD_LENGTH = 8;
+// Fixed delay on failed logins to slow guessing
+const FAIL_DELAY_MS = 500;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function validateCredentials(username: unknown, password: unknown): string | null {
+  if (typeof username !== 'string' || !USERNAME_PATTERN.test(username)) {
+    return 'Username must be 3-32 characters (letters, numbers, . _ -)';
+  }
+  if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
+    return `Password must be at least ${MIN_PASSWORD_LENGTH} characters`;
+  }
+  return null;
+}
+
+/**
+ * POST /api/auth/setup
+ * One-time creation of the initial admin account. Only works while no
+ * users exist (fresh install or after PANKHA_AUTH_RESET).
+ */
+router.post('/setup', async (req: Request, res: Response) => {
+  try {
+    if (usersExist()) {
+      return res.status(400).json({ error: 'Setup already completed' });
+    }
+    const { username, password } = req.body ?? {};
+    const invalid = validateCredentials(username, password);
+    if (invalid) {
+      return res.status(400).json({ error: invalid });
+    }
+
+    const passwordHash = await hashPassword(password);
+    // WHERE NOT EXISTS guards the race of two concurrent setup submissions
+    const db = Database.getInstance();
+    const row = await db.get(
+      `INSERT INTO users (username, password_hash, role)
+       SELECT $1, $2, 'admin'
+       WHERE NOT EXISTS (SELECT 1 FROM users)
+       RETURNING id`,
+      [username, passwordHash]
+    );
+    if (!row) {
+      return res.status(400).json({ error: 'Setup already completed' });
+    }
+    await reloadUserCache();
+
+    const user = { userId: row.id, username, role: 'admin' };
+    setSessionCookie(res, await signSession(user));
+    log.info(`Initial admin account created: ${username}`, 'auth');
+    res.json({ username, role: 'admin' });
+  } catch (error) {
+    log.error('Setup failed', 'auth', error);
+    res.status(500).json({ error: 'Setup failed' });
+  }
+});
+
+/**
+ * POST /api/auth/login
+ */
+router.post('/login', async (req: Request, res: Response) => {
+  try {
+    const ip = req.ip ?? 'unknown';
+    const gate = loginRateCheck(ip);
+    if (!gate.allowed) {
+      return res.status(429).json({
+        error: 'Too many failed attempts, try again later',
+        retry_after_seconds: gate.retryAfterSeconds,
+      });
+    }
+
+    const { username, password } = req.body ?? {};
+    if (typeof username !== 'string' || typeof password !== 'string') {
+      return res.status(400).json({ error: 'Username and password required' });
+    }
+
+    const db = Database.getInstance();
+    const user = await db.get(
+      'SELECT id, username, password_hash, role FROM users WHERE username = $1',
+      [username]
+    );
+    const valid = user ? await verifyPassword(password, user.password_hash) : false;
+    if (!valid) {
+      loginRateFail(ip);
+      await sleep(FAIL_DELAY_MS);
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+
+    loginRateReset(ip);
+    const session = { userId: user.id, username: user.username, role: user.role };
+    setSessionCookie(res, await signSession(session));
+    log.info(`User logged in: ${user.username}`, 'auth');
+    res.json({ username: user.username, role: user.role });
+  } catch (error) {
+    log.error('Login failed', 'auth', error);
+    res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+/**
+ * POST /api/auth/logout
+ */
+router.post('/logout', (req: Request, res: Response) => {
+  clearSessionCookie(res);
+  res.json({ message: 'Logged out' });
+});
+
+/**
+ * GET /api/auth/me
+ * Public: tells the frontend whether to show the app, login, or setup.
+ */
+router.get('/me', (req: Request, res: Response) => {
+  if (req.session) {
+    return res.json({
+      authenticated: true,
+      username: req.session.username,
+      role: req.session.role,
+      auth_reset_active: isAuthResetActive(),
+    });
+  }
+  res.json({
+    authenticated: false,
+    setup_required: !usersExist(),
+    auth_reset_active: isAuthResetActive(),
+  });
+});
+
+/**
+ * PUT /api/auth/password
+ * Change own password (any authenticated rank).
+ */
+router.put('/password', async (req: Request, res: Response) => {
+  try {
+    if (!req.session) {
+      return res.status(401).json({ error: 'authentication required' });
+    }
+    const { current_password, new_password } = req.body ?? {};
+    if (typeof new_password !== 'string' || new_password.length < MIN_PASSWORD_LENGTH) {
+      return res.status(400).json({
+        error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+      });
+    }
+
+    const db = Database.getInstance();
+    const user = await db.get(
+      'SELECT password_hash FROM users WHERE id = $1',
+      [req.session.userId]
+    );
+    if (!user || typeof current_password !== 'string' ||
+        !(await verifyPassword(current_password, user.password_hash))) {
+      await sleep(FAIL_DELAY_MS);
+      return res.status(401).json({ error: 'Current password is incorrect' });
+    }
+
+    const passwordHash = await hashPassword(new_password);
+    await db.run(
+      'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
+      [passwordHash, req.session.userId]
+    );
+    log.info(`Password changed: ${req.session.username}`, 'auth');
+    res.json({ message: 'Password updated' });
+  } catch (error) {
+    log.error('Password change failed', 'auth', error);
+    res.status(500).json({ error: 'Password change failed' });
+  }
+});
+
+/**
+ * GET /api/auth/users (admin)
+ */
+router.get('/users', async (_req: Request, res: Response) => {
+  try {
+    const db = Database.getInstance();
+    const users = await db.all(
+      'SELECT id, username, role, created_at, updated_at FROM users ORDER BY id'
+    );
+    res.json(users);
+  } catch (error) {
+    log.error('Failed to list users', 'auth', error);
+    res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * POST /api/auth/users (admin)
+ */
+router.post('/users', async (req: Request, res: Response) => {
+  try {
+    const { username, password, role } = req.body ?? {};
+    const invalid = validateCredentials(username, password);
+    if (invalid) {
+      return res.status(400).json({ error: invalid });
+    }
+    if (typeof role !== 'string' || !VALID_ROLES.includes(role)) {
+      return res.status(400).json({ error: `Role must be one of: ${VALID_ROLES.join(', ')}` });
+    }
+
+    const db = Database.getInstance();
+    const passwordHash = await hashPassword(password);
+    const row = await db.get(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (username) DO NOTHING
+       RETURNING id`,
+      [username, passwordHash, role]
+    );
+    if (!row) {
+      return res.status(409).json({ error: 'Username already exists' });
+    }
+    await reloadUserCache();
+    log.info(`User created: ${username} (${role})`, 'auth');
+    res.status(201).json({ id: row.id, username, role });
+  } catch (error) {
+    log.error('User creation failed', 'auth', error);
+    res.status(500).json({ error: 'User creation failed' });
+  }
+});
+
+/**
+ * PUT /api/auth/users/:id (admin)
+ * Update role and/or reset password.
+ */
+router.put('/users/:id', async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+    const { password, role } = req.body ?? {};
+
+    const db = Database.getInstance();
+    const target = await db.get('SELECT id, username, role FROM users WHERE id = $1', [id]);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (role !== undefined) {
+      if (typeof role !== 'string' || !VALID_ROLES.includes(role)) {
+        return res.status(400).json({ error: `Role must be one of: ${VALID_ROLES.join(', ')}` });
+      }
+      if (target.role === 'admin' && role !== 'admin') {
+        const admins = await db.get("SELECT COUNT(*)::int AS count FROM users WHERE role = 'admin'");
+        if (admins.count <= 1) {
+          return res.status(400).json({ error: 'Cannot demote the last admin' });
+        }
+      }
+      await db.run('UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2', [role, id]);
+    }
+
+    if (password !== undefined) {
+      if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
+        return res.status(400).json({
+          error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+        });
+      }
+      const passwordHash = await hashPassword(password);
+      await db.run(
+        'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
+        [passwordHash, id]
+      );
+    }
+
+    await reloadUserCache();
+    log.info(`User updated: ${target.username}`, 'auth');
+    res.json({ message: 'User updated' });
+  } catch (error) {
+    log.error('User update failed', 'auth', error);
+    res.status(500).json({ error: 'User update failed' });
+  }
+});
+
+/**
+ * DELETE /api/auth/users/:id (admin)
+ */
+router.delete('/users/:id', async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const db = Database.getInstance();
+    const target = await db.get('SELECT id, username, role FROM users WHERE id = $1', [id]);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    if (target.role === 'admin') {
+      const admins = await db.get("SELECT COUNT(*)::int AS count FROM users WHERE role = 'admin'");
+      if (admins.count <= 1) {
+        return res.status(400).json({ error: 'Cannot delete the last admin' });
+      }
+    }
+
+    await db.run('DELETE FROM users WHERE id = $1', [id]);
+    await reloadUserCache();
+    log.info(`User deleted: ${target.username}`, 'auth');
+    res.json({ message: 'User deleted' });
+  } catch (error) {
+    log.error('User deletion failed', 'auth', error);
+    res.status(500).json({ error: 'User deletion failed' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import Database from '../database/database';
 import { log } from '../utils/logger';
 import { hashPassword, verifyPassword } from '../auth/passwords';
 import { signSession } from '../auth/session';
+import { isDemoMode } from '../utils/mode';
 import {
   VALID_ROLES,
   usersExist,
@@ -255,6 +256,15 @@ router.get('/me', async (req: Request, res: Response) => {
       authenticated: true,
       username: req.session.username,
       role: req.session.role,
+      auth_reset_active: isAuthResetActive(),
+    });
+  }
+  // Demo instances (PANKHA_MODE=demo) render a read-only viewer view.
+  if (isDemoMode()) {
+    return res.json({
+      authenticated: true,
+      username: 'demo',
+      role: 'viewer',
       auth_reset_active: isAuthResetActive(),
     });
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -22,6 +22,35 @@ const MIN_PASSWORD_LENGTH = 8;
 // Fixed delay on failed logins to slow guessing
 const FAIL_DELAY_MS = 500;
 
+// Self-registration settings (D15), stored in backend_settings.
+// Off by default: open registration on a LAN would undo the auth feature.
+const REG_ENABLED_KEY = 'auth_self_registration';
+const REG_ROLE_KEY = 'auth_default_role';
+
+async function getRegistrationSettings(): Promise<{ enabled: boolean; default_role: string }> {
+  const db = Database.getInstance();
+  const rows = await db.all(
+    'SELECT setting_key, setting_value FROM backend_settings WHERE setting_key IN ($1, $2)',
+    [REG_ENABLED_KEY, REG_ROLE_KEY]
+  );
+  const map = new Map(rows.map((r) => [r.setting_key, r.setting_value]));
+  const role = map.get(REG_ROLE_KEY);
+  return {
+    enabled: map.get(REG_ENABLED_KEY) === 'true',
+    default_role: role && VALID_ROLES.includes(role) ? role : 'viewer',
+  };
+}
+
+async function saveSetting(key: string, value: string, description: string): Promise<void> {
+  const db = Database.getInstance();
+  await db.run(
+    `INSERT INTO backend_settings (setting_key, setting_value, description)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2, updated_at = NOW()`,
+    [key, value, description]
+  );
+}
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function validateCredentials(username: unknown, password: unknown): string | null {
@@ -72,6 +101,96 @@ router.post('/setup', async (req: Request, res: Response) => {
   } catch (error) {
     log.error('Setup failed', 'auth', error);
     res.status(500).json({ error: 'Setup failed' });
+  }
+});
+
+/**
+ * POST /api/auth/register
+ * Self-registration from the sign-in screen. Only works while the admin has
+ * enabled it; the account gets the admin-chosen default role.
+ */
+router.post('/register', async (req: Request, res: Response) => {
+  try {
+    const settings = await getRegistrationSettings();
+    if (!settings.enabled) {
+      return res.status(403).json({ error: 'Account creation is disabled on this Hub' });
+    }
+    if (!usersExist()) {
+      // Fresh hub: the first account must be the admin (setup flow)
+      return res.status(400).json({ error: 'Set up the admin account first' });
+    }
+
+    const { username, password } = req.body ?? {};
+    const invalid = validateCredentials(username, password);
+    if (invalid) {
+      return res.status(400).json({ error: invalid });
+    }
+
+    const db = Database.getInstance();
+    const passwordHash = await hashPassword(password);
+    const row = await db.get(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (username) DO NOTHING
+       RETURNING id`,
+      [username, passwordHash, settings.default_role]
+    );
+    if (!row) {
+      return res.status(409).json({ error: 'Username already exists' });
+    }
+    await reloadUserCache();
+
+    const user = { userId: row.id, username, role: settings.default_role };
+    setSessionCookie(res, await signSession(user));
+    log.info(`Self-registered user: ${username} (${settings.default_role})`, 'auth');
+    res.status(201).json({ username, role: settings.default_role });
+  } catch (error) {
+    log.error('Registration failed', 'auth', error);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+/**
+ * GET /api/auth/registration (admin)
+ * PUT /api/auth/registration (admin) - body { enabled?, default_role? }
+ */
+router.get('/registration', async (_req: Request, res: Response) => {
+  try {
+    res.json(await getRegistrationSettings());
+  } catch (error) {
+    log.error('Failed to read registration settings', 'auth', error);
+    res.status(500).json({ error: 'Failed to read registration settings' });
+  }
+});
+
+router.put('/registration', async (req: Request, res: Response) => {
+  try {
+    const { enabled, default_role } = req.body ?? {};
+    if (enabled !== undefined) {
+      if (typeof enabled !== 'boolean') {
+        return res.status(400).json({ error: 'enabled must be a boolean' });
+      }
+      await saveSetting(
+        REG_ENABLED_KEY,
+        enabled ? 'true' : 'false',
+        'Allow account creation from the sign-in screen'
+      );
+    }
+    if (default_role !== undefined) {
+      if (typeof default_role !== 'string' || !VALID_ROLES.includes(default_role)) {
+        return res.status(400).json({ error: `Role must be one of: ${VALID_ROLES.join(', ')}` });
+      }
+      await saveSetting(REG_ROLE_KEY, default_role, 'Role given to self-created accounts');
+    }
+    const settings = await getRegistrationSettings();
+    log.info(
+      `Registration settings updated: enabled=${settings.enabled}, default_role=${settings.default_role}`,
+      'auth'
+    );
+    res.json(settings);
+  } catch (error) {
+    log.error('Failed to update registration settings', 'auth', error);
+    res.status(500).json({ error: 'Failed to update registration settings' });
   }
 });
 
@@ -127,9 +246,10 @@ router.post('/logout', (req: Request, res: Response) => {
 
 /**
  * GET /api/auth/me
- * Public: tells the frontend whether to show the app, login, or setup.
+ * Public: tells the frontend whether to show the app, login, setup, and
+ * whether the login card offers self-registration.
  */
-router.get('/me', (req: Request, res: Response) => {
+router.get('/me', async (req: Request, res: Response) => {
   if (req.session) {
     return res.json({
       authenticated: true,
@@ -138,9 +258,11 @@ router.get('/me', (req: Request, res: Response) => {
       auth_reset_active: isAuthResetActive(),
     });
   }
+  const registration = await getRegistrationSettings().catch(() => ({ enabled: false }));
   res.json({
     authenticated: false,
     setup_required: !usersExist(),
+    registration_enabled: registration.enabled,
     auth_reset_active: isAuthResetActive(),
   });
 });

--- a/backend/src/routes/deploy-profiles.ts
+++ b/backend/src/routes/deploy-profiles.ts
@@ -20,6 +20,9 @@ import { ProfileService } from '../services/ProfileService';
 import { CommandDispatcher } from '../services/CommandDispatcher';
 import { AgentManager } from '../services/AgentManager';
 import { createDemoLockResponse, isDemoMode } from '../utils/mode';
+import { verifyAgentToken } from '../auth/tokens';
+import { isValidDeployToken } from '../auth/enrollment';
+import { hasLevel } from '../middleware/auth';
 
 const router = Router();
 const db = Database.getInstance();
@@ -74,9 +77,20 @@ router.get('/assigned/:agentId', async (req, res) => {
     const { agentId } = req.params;
 
     const system = await db.get(
-      'SELECT profile_id FROM systems WHERE agent_id = $1',
+      'SELECT profile_id, auth_token_hash FROM systems WHERE agent_id = $1',
       [agentId]
     );
+
+    // Secured agents must present their token. Unsecured rows stay open so
+    // fresh installs (profile fetched before first registration) and
+    // grandfathered agents keep working; a session (dashboard preview) also
+    // passes.
+    if (system?.auth_token_hash && !req.session) {
+      const bearer = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
+      if (!verifyAgentToken(bearer, system.auth_token_hash)) {
+        return res.status(401).json({ error: 'Agent token required' });
+      }
+    }
 
     if (!system || !system.profile_id) {
       return res.status(404).json({ error: 'No profile assigned to this agent' });
@@ -121,6 +135,14 @@ router.put('/assign/:agentId', async (req, res) => {
   try {
     if (isDemoMode()) {
       return res.json(createDemoLockResponse('Profile Change not allowed, it is locked in demo'));
+    }
+
+    // Install scripts present the deploy token; dashboard users an
+    // operator+ session (profiles are operator domain per the role matrix)
+    if (!hasLevel(req.session, 'operator') && !(await isValidDeployToken(req.query.token))) {
+      return res.status(401).json({
+        error: 'Valid deploy token or operator session required',
+      });
     }
 
     const { agentId } = req.params;

--- a/backend/src/routes/deploy.ts
+++ b/backend/src/routes/deploy.ts
@@ -124,7 +124,7 @@ router.get('/linux', async (req, res) => {
     const localBinaryBase = `${backendUrl}/api/deploy/binaries`;
 
     // Generate install script
-    const script = generateInstallScript(config, backendUrl, wsUrl, localBinaryBase);
+    const script = generateInstallScript(config, backendUrl, wsUrl, localBinaryBase, String(token));
 
     res.setHeader('Content-Type', 'text/x-shellscript');
     res.send(script);
@@ -296,7 +296,7 @@ router.get('/ipmi', async (req, res) => {
     const wsUrl = `${protocol === 'https' ? 'wss' : 'ws'}://${hubHost}/websocket`;
     const localBinaryBase = `${backendUrl}/api/deploy/binaries`;
 
-    const script = generateIpmiInstallScript(config, backendUrl, wsUrl, localBinaryBase);
+    const script = generateIpmiInstallScript(config, backendUrl, wsUrl, localBinaryBase, String(token));
 
     res.setHeader('Content-Type', 'text/x-shellscript');
     res.send(script);
@@ -306,7 +306,7 @@ router.get('/ipmi', async (req, res) => {
   }
 });
 
-function generateIpmiInstallScript(config: any, backendUrl: string, wsUrl: string, localBinaryBase: string): string {
+function generateIpmiInstallScript(config: any, backendUrl: string, wsUrl: string, localBinaryBase: string, deployToken: string): string {
   const {
     path_mode,
     log_level,
@@ -443,13 +443,18 @@ CONFIG_CONTENT='{
     "log_file": "'$LOG_FILE'",
     "max_log_size_mb": 10,
     "log_retention_days": 7
+  },
+  "auth": {
+    "enrollment_token": "${deployToken}"
   }
 }'
 
 if [ "$INSTALL_DIR" = "$(pwd)" ]; then
     echo "$CONFIG_CONTENT" > "$INSTALL_DIR/config.json"
+    chmod 600 "$INSTALL_DIR/config.json"
 else
     echo "$CONFIG_CONTENT" | run_as_root tee "$INSTALL_DIR/config.json" > /dev/null
+    run_as_root chmod 600 "$INSTALL_DIR/config.json"
 fi
 
 echo "      Agent ID: $AGENT_ID"
@@ -473,7 +478,7 @@ ASSIGN_OK=false
 for i in 1 2 3 4 5; do
     sleep 2
     ASSIGN_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \\
-      "$BACKEND_URL/api/deploy/profiles/assign/$AGENT_ID" \\
+      "$BACKEND_URL/api/deploy/profiles/assign/$AGENT_ID?token=${deployToken}" \\
       -H "Content-Type: application/json" \\
       -d '{"profile_id":"'$PROFILE_ID'"}')
     if [ "$ASSIGN_CODE" = "200" ]; then
@@ -511,7 +516,7 @@ fi
 `;
 }
 
-function generateInstallScript(config: any, backendUrl: string, wsUrl: string, localBinaryBase: string): string {
+function generateInstallScript(config: any, backendUrl: string, wsUrl: string, localBinaryBase: string, deployToken: string): string {
   const {
     path_mode,
     log_level,
@@ -636,13 +641,18 @@ CONFIG_CONTENT='{
     "log_file": "'$LOG_FILE'",
     "max_log_size_mb": 10,
     "log_retention_days": 7
+  },
+  "auth": {
+    "enrollment_token": "${deployToken}"
   }
 }'
 
 if [ "$INSTALL_DIR" = "$(pwd)" ]; then
     echo "$CONFIG_CONTENT" > "$INSTALL_DIR/config.json"
+    chmod 600 "$INSTALL_DIR/config.json"
 else
     echo "$CONFIG_CONTENT" | run_as_root tee "$INSTALL_DIR/config.json" > /dev/null
+    run_as_root chmod 600 "$INSTALL_DIR/config.json"
 fi
 
 echo "      Agent ID: $AGENT_ID"

--- a/backend/src/routes/systems.ts
+++ b/backend/src/routes/systems.ts
@@ -213,8 +213,12 @@ router.get("/", async (req: Request, res: Response) => {
       const isReadOnly = readOnlyStatus.get(system.agent_id) ?? false;
       const accessStatus = isReadOnly ? "over_limit" : "active";
 
+      // The token hash never leaves the hub; the UI only needs the boolean
+      const { auth_token_hash, ...publicSystem } = system;
+
       return {
-        ...system,
+        ...publicSystem,
+        unsecured: !auth_token_hash,
         capabilities: system.capabilities || null,
         config_data: system.config_data || null,
         access_status: accessStatus,
@@ -467,8 +471,12 @@ router.get("/:id", async (req: Request, res: Response) => {
     const agentStatus = agentManager.getAgentStatus(system.agent_id);
     const systemData = dataAggregator.getSystemData(system.agent_id);
 
+    // The token hash never leaves the hub; the UI only needs the boolean
+    const { auth_token_hash, ...publicSystem } = system;
+
     res.json({
-      ...system,
+      ...publicSystem,
+      unsecured: !auth_token_hash,
       capabilities: system.capabilities || null,
       config_data: system.config_data || null,
       sensors,

--- a/backend/src/routes/systems.ts
+++ b/backend/src/routes/systems.ts
@@ -398,6 +398,45 @@ router.put("/controller/interval", async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/systems/pending - Agents held for admin approval (D13)
+router.get("/pending", (_req: Request, res: Response) => {
+  res.json(WebSocketHub.getInstance().getPendingAgents());
+});
+
+// POST /api/systems/pending/:agentId/approve - Admit a pending agent
+router.post("/pending/:agentId/approve", async (req: Request, res: Response) => {
+  try {
+    if (isDemoMode()) {
+      return res.json(createDemoLockResponse("Agent approval is locked in demo"));
+    }
+    const result = await WebSocketHub.getInstance().approvePendingAgent(
+      req.params.agentId
+    );
+    if (!result.ok) {
+      return res.status(404).json({ error: result.error });
+    }
+    res.json({ message: "Agent approved", agent_id: req.params.agentId });
+  } catch (error) {
+    log.error("Error approving pending agent:", "systems", error);
+    res.status(500).json({ error: "Failed to approve agent" });
+  }
+});
+
+// DELETE /api/systems/pending/:agentId - Dismiss a pending agent (not a ban;
+// it reappears on its next reconnect unless uninstalled on the machine)
+router.delete("/pending/:agentId", (req: Request, res: Response) => {
+  if (isDemoMode()) {
+    return res.json(createDemoLockResponse("Agent dismissal is locked in demo"));
+  }
+  const result = WebSocketHub.getInstance().dismissPendingAgent(
+    req.params.agentId
+  );
+  if (!result.ok) {
+    return res.status(404).json({ error: result.error });
+  }
+  res.json({ message: "Agent dismissed", agent_id: req.params.agentId });
+});
+
 // GET /api/systems/:id - Get system details
 router.get("/:id", async (req: Request, res: Response) => {
   try {

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -952,6 +952,11 @@ export class WebSocketHub extends EventEmitter {
             [hashAgentToken(mintedToken), agentId]
           );
           log.info(`Agent ${agentId} enrolled - auth token issued`, "WebSocketHub");
+          // Clear the Unsecured badge live
+          this.agentManager.emit("agentConfigUpdated", {
+            agentId,
+            config: { unsecured: false },
+          });
         }
 
         // Send registration confirmation with configuration
@@ -979,6 +984,11 @@ export class WebSocketHub extends EventEmitter {
                   [hashAgentToken(grandfatherToken), agentId]
                 );
                 log.info(`Agent ${agentId} secured via setAuthToken`, "WebSocketHub");
+                // Clear the Unsecured badge live
+                this.agentManager.emit("agentConfigUpdated", {
+                  agentId,
+                  config: { unsecured: false },
+                });
               })
               .catch((err) => {
                 log.debug(
@@ -1323,8 +1333,12 @@ export class WebSocketHub extends EventEmitter {
     const agentId = system.agent_id;
     const agentStatus = this.agentManager.getAgentStatus(agentId);
 
+    // The token hash never leaves the hub; the UI only needs the boolean
+    const { auth_token_hash, ...publicSystem } = system;
+
     return {
-      ...system,
+      ...publicSystem,
+      unsecured: !auth_token_hash,
       status: agentStatus?.status || systemData?.status || system.status,
       real_time_status: agentStatus?.status || systemData?.status || "unknown",
       last_seen: systemData?.lastUpdate?.toISOString() || system.last_seen || null,

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -71,8 +71,7 @@ interface PendingAgent {
   requestedAt: string;
 }
 
-// Bound on concurrently held pending agents (memory + card-spam cap).
-// Raise it for a large first-time migration so the whole fleet pends at once.
+// Max agents held awaiting approval at once (memory + card-spam bound); raise for large migrations.
 const MAX_PENDING_AGENTS = (() => {
   const raw = parseInt(process.env.PANKHA_MAX_PENDING_AGENTS ?? '', 10);
   return Number.isInteger(raw) && raw > 0 ? raw : 20;
@@ -694,8 +693,7 @@ export class WebSocketHub extends EventEmitter {
   private async handleAgentRegistration(
     clientId: string,
     registrationData: any,
-    // true only from approvePendingAgent: an admin vouched for this agent, so
-    // the credential tree is skipped and a token is pushed via setAuthToken
+    // Set only by approvePendingAgent: admin vouched, so skip the credential tree and push a token.
     preApproved: boolean = false
   ): Promise<void> {
     try {
@@ -753,12 +751,7 @@ export class WebSocketHub extends EventEmitter {
             return;
           }
         } else {
-          // No stored token, known or unknown - the agent_id alone proves
-          // nothing. Valid enrollment token = automatic (script flow).
-          // Anything else is held as a pending-approval card (D13): fleet
-          // migration, --setup installs, stale (>24h) install scripts,
-          // deleted-but-still-running agents. A human admin decides; nothing
-          // flows until then.
+          // No stored token (known or unknown): a valid enrollment token auto-enrolls (script flow); anything else is held for admin approval (D13, single door).
           if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
             mintedToken = mintAgentToken();
           } else {
@@ -967,11 +960,7 @@ export class WebSocketHub extends EventEmitter {
           ...(mintedToken ? { auth_token: mintedToken } : {}),
         });
 
-        // Approval path: push a permanent token to the agent an admin just
-        // approved. The hash is committed only on the agent's ack, so old
-        // binaries that ignore setAuthToken stay connectable (shown Unsecured
-        // in the UI) until fleet self-update delivers a binary that completes
-        // this.
+        // Approved agent: push its permanent token. Hash commits only on the agent's ack, so pre-auth binaries stay connectable (shown Unsecured) until self-update.
         if (preApproved) {
           const approvalToken = mintAgentToken();
           setTimeout(() => {

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -691,7 +691,7 @@ export class WebSocketHub extends EventEmitter {
     clientId: string,
     registrationData: any,
     // true only from approvePendingAgent: an admin vouched for this agent, so
-    // the credential tree is skipped and the grandfather path issues a token
+    // the credential tree is skipped and a token is pushed via setAuthToken
     preApproved: boolean = false
   ): Promise<void> {
     try {
@@ -721,13 +721,11 @@ export class WebSocketHub extends EventEmitter {
         return;
       }
 
-      // Credential decision tree (task_02 section 4.4):
+      // Credential decision tree (task_02 section 4.4, single door):
       //   auth_token + stored hash        -> verify or close
       //   enrollment_token valid          -> exchange for a minted token
-      //   known agent, no stored hash     -> grandfather, issue via setAuthToken
-      //   unknown, nothing valid          -> hold as pending-approval card
+      //   anything else, known or unknown -> hold as pending-approval card
       let mintedToken: string | null = null; // returned in the registered response
-      let issueTokenViaCommand = preApproved; // grandfather path (setAuthToken push)
 
       if (!preApproved) {
         const db2 = Database.getInstance();
@@ -750,25 +748,21 @@ export class WebSocketHub extends EventEmitter {
             this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
             return;
           }
-        } else if (existing) {
-          // Known agent, not yet secured. A valid enrollment token (reinstall
-          // over an existing system) mints inline; otherwise grandfather.
-          if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
-            mintedToken = mintAgentToken();
-          } else {
-            issueTokenViaCommand = true;
-          }
         } else {
-          // Unknown agent. Valid enrollment token = automatic (script flow).
-          // Anything else is held as a pending-approval card (D13): --setup
-          // installs, stale (>24h) install scripts, deleted-but-still-running
-          // agents. A human admin decides; nothing flows until then.
+          // No stored token, known or unknown - the agent_id alone proves
+          // nothing. Valid enrollment token = automatic (script flow).
+          // Anything else is held as a pending-approval card (D13): fleet
+          // migration, --setup installs, stale (>24h) install scripts,
+          // deleted-but-still-running agents. A human admin decides; nothing
+          // flows until then.
           if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
             mintedToken = mintAgentToken();
           } else {
             const reason = presentedEnrollment
               ? "Install token expired - approve on the dashboard or run a fresh install script"
-              : "Registered without credentials - approve on the dashboard";
+              : existing
+                ? "Existing agent has no token yet - approve to migrate it"
+                : "Registered without credentials - approve on the dashboard";
             this.holdPendingAgent(clientId, registrationData, reason);
             return;
           }
@@ -969,19 +963,20 @@ export class WebSocketHub extends EventEmitter {
           ...(mintedToken ? { auth_token: mintedToken } : {}),
         });
 
-        // Grandfather path: push a token to a known-but-unsecured agent. The
-        // hash is committed only on the agent's ack, so old binaries that
-        // ignore setAuthToken stay connectable (shown Unsecured in the UI)
-        // until fleet self-update delivers a binary that completes this.
-        if (issueTokenViaCommand) {
-          const grandfatherToken = mintAgentToken();
+        // Approval path: push a permanent token to the agent an admin just
+        // approved. The hash is committed only on the agent's ack, so old
+        // binaries that ignore setAuthToken stay connectable (shown Unsecured
+        // in the UI) until fleet self-update delivers a binary that completes
+        // this.
+        if (preApproved) {
+          const approvalToken = mintAgentToken();
           setTimeout(() => {
             this.commandDispatcher
-              .sendCommand(agentId, "setAuthToken", { authToken: grandfatherToken })
+              .sendCommand(agentId, "setAuthToken", { authToken: approvalToken })
               .then(async () => {
                 await db.run(
                   "UPDATE systems SET auth_token_hash = $1 WHERE agent_id = $2",
-                  [hashAgentToken(grandfatherToken), agentId]
+                  [hashAgentToken(approvalToken), agentId]
                 );
                 log.info(`Agent ${agentId} secured via setAuthToken`, "WebSocketHub");
                 // Clear the Unsecured badge live
@@ -1123,8 +1118,8 @@ export class WebSocketHub extends EventEmitter {
 
   /**
    * Admin approved a pending agent: run the normal registration for the held
-   * connection (row, config sync, registered response) with the grandfather
-   * path pushing its permanent token.
+   * connection (row, config sync, registered response) with the approval
+   * path pushing its permanent token via setAuthToken.
    */
   public async approvePendingAgent(
     agentId: string

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -12,6 +12,9 @@ import Database from "../database/database";
 import type { AggregatedSystemData } from "../types/aggregatedData";
 import { licenseManager } from "../license";
 import { log } from "../utils/logger";
+import { SESSION_COOKIE, parseCookieHeader, verifySession } from "../auth/session";
+import { mintAgentToken, hashAgentToken, verifyAgentToken } from "../auth/tokens";
+import { isValidDeployToken } from "../auth/enrollment";
 import { 
   defaultUpdateInterval, 
   defaultFanStep, 
@@ -38,6 +41,11 @@ interface ClientConnection {
     connectedAt: Date;
     agentId?: string;
     isAgent?: boolean;
+    // Session-verified dashboard connection. Connections start unclassified;
+    // isFrontend is granted by a valid session cookie at upgrade, isAgent by
+    // an authenticated register message. Neither = no data flows.
+    isFrontend?: boolean;
+    username?: string;
   };
 }
 
@@ -94,7 +102,10 @@ export class WebSocketHub extends EventEmitter {
     });
 
     this.wss.on("connection", (ws: WebSocket, request: IncomingMessage) => {
-      this.handleNewConnection(ws, request);
+      this.handleNewConnection(ws, request).catch((error) => {
+        log.error("Failed to handle new WebSocket connection", "WebSocketHub", error);
+        ws.close();
+      });
     });
 
     this.startPingInterval();
@@ -274,11 +285,19 @@ export class WebSocketHub extends EventEmitter {
   /**
    * Handle new WebSocket connection
    */
-  private handleNewConnection(ws: WebSocket, request: IncomingMessage): void {
+  private async handleNewConnection(ws: WebSocket, request: IncomingMessage): Promise<void> {
     const clientId = this.generateClientId();
     const userAgent = request.headers["user-agent"] || "";
-    const isAgent =
-      userAgent.includes("Python") || userAgent.includes("websockets");
+
+    // Classification is credential-based: a valid session cookie on the
+    // upgrade request marks a frontend connection; agents earn isAgent via an
+    // authenticated register message. Unclassified connections receive
+    // nothing and may only register or ping.
+    const cookies = parseCookieHeader(request.headers.cookie);
+    const session = cookies[SESSION_COOKIE]
+      ? await verifySession(cookies[SESSION_COOKIE])
+      : null;
+    const isFrontend = !!session;
 
     // Get real IP address (handles nginx proxy and IPv6-mapped IPv4)
     const realIp = this.extractRealIp(request);
@@ -292,20 +311,22 @@ export class WebSocketHub extends EventEmitter {
         userAgent: userAgent,
         ip: realIp,
         connectedAt: new Date(),
-        isAgent: isAgent,
+        isAgent: false,
+        isFrontend,
+        username: session?.user.username,
       },
     };
 
     this.clients.set(clientId, client);
 
-    if (isAgent) {
+    if (!isFrontend) {
       log.info(
-        ` New AGENT WebSocket connected: ${clientId} (${client.metadata.ip})`,
+        ` New unclassified WebSocket connected (agent register or login pending): ${clientId} (${client.metadata.ip})`,
         "WebSocketHub"
       );
     } else {
       log.info(
-        ` New FRONTEND WebSocket connected: ${clientId} (${client.metadata.ip})`,
+        ` New FRONTEND WebSocket connected: ${clientId} (${client.metadata.ip}, user: ${session!.user.username})`,
         "WebSocketHub"
       );
 
@@ -443,6 +464,24 @@ export class WebSocketHub extends EventEmitter {
       if (!client) return;
 
       client.lastActivity = new Date();
+
+      // Dashboard data flows only to session-verified connections. 4401 lets
+      // the frontend distinguish "log in again" from a network drop.
+      const FRONTEND_MESSAGES = [
+        "subscribe",
+        "unsubscribe",
+        "requestFullSync",
+        "getSystemData",
+        "getOverview",
+      ];
+      if (FRONTEND_MESSAGES.includes(message.type) && !client.metadata.isFrontend) {
+        log.warn(
+          `Unauthenticated client ${clientId} sent ${message.type} - closing`,
+          "WebSocketHub"
+        );
+        client.websocket.close(4401, "authentication required");
+        return;
+      }
 
       switch (message.type) {
         case "subscribe":
@@ -635,9 +674,68 @@ export class WebSocketHub extends EventEmitter {
       }
 
       const agentId = registrationData.agentId;
+      const client = this.clients.get(clientId);
+
+      if (client?.metadata.isFrontend) {
+        this.sendToClient(clientId, "registrationError", {
+          error: "Frontend connections cannot register as agents",
+        });
+        return;
+      }
+
+      // Credential decision tree (task_02 section 4.1):
+      //   auth_token + stored hash        -> verify or close
+      //   enrollment_token, unknown agent -> exchange for a minted token
+      //   known agent, no stored hash     -> grandfather, issue via setAuthToken
+      //   nothing valid                   -> close
+      const db2 = Database.getInstance();
+      const existing = await db2.get(
+        "SELECT auth_token_hash FROM systems WHERE agent_id = $1",
+        [agentId]
+      );
+      const presentedToken = registrationData.auth_token;
+      const presentedEnrollment = registrationData.enrollment_token;
+
+      let mintedToken: string | null = null; // returned in the registered response
+      let issueTokenViaCommand = false; // grandfather path (setAuthToken push)
+
+      if (existing?.auth_token_hash) {
+        if (!verifyAgentToken(presentedToken, existing.auth_token_hash)) {
+          log.warn(
+            `Agent ${agentId} presented ${presentedToken ? "an invalid" : "no"} auth token - rejecting`,
+            "WebSocketHub"
+          );
+          this.sendToClient(clientId, "registrationError", {
+            error: "Agent token rejected",
+          });
+          this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
+          return;
+        }
+      } else if (existing) {
+        // Known agent, not yet secured. A valid enrollment token (reinstall
+        // over an existing system) mints inline; otherwise grandfather.
+        if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
+          mintedToken = mintAgentToken();
+        } else {
+          issueTokenViaCommand = true;
+        }
+      } else {
+        // Unknown agent: enrollment token is the only way in. A deleted
+        // system's old token does not readmit it (delete = revoke).
+        if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
+          mintedToken = mintAgentToken();
+        } else {
+          const reason = presentedEnrollment
+            ? "Deploy token invalid or expired - generate a fresh install script from the Deployment page"
+            : "Enrollment required - deploy this agent via an install script from the Deployment page";
+          log.warn(`Unknown agent ${agentId} rejected: ${reason}`, "WebSocketHub");
+          this.sendToClient(clientId, "registrationError", { error: reason });
+          this.clients.get(clientId)?.websocket.close(4403, "enrollment required");
+          return;
+        }
+      }
 
       // Mark this client as an agent connection
-      const client = this.clients.get(clientId);
       if (client) {
         client.metadata.agentId = agentId;
         client.metadata.isAgent = true;
@@ -805,6 +903,17 @@ export class WebSocketHub extends EventEmitter {
           );
         }
 
+        // Enrollment: persist the token hash now that the systems row exists,
+        // and hand the plaintext to the agent inside the registered response
+        // (the agent persists it and drops its enrollment_token).
+        if (mintedToken) {
+          await db.run(
+            "UPDATE systems SET auth_token_hash = $1 WHERE agent_id = $2",
+            [hashAgentToken(mintedToken), agentId]
+          );
+          log.info(`Agent ${agentId} enrolled - auth token issued`, "WebSocketHub");
+        }
+
         // Send registration confirmation with configuration
         this.sendToClient(clientId, "registered", {
           agentId: agentId,
@@ -812,7 +921,33 @@ export class WebSocketHub extends EventEmitter {
           message: "Agent registered successfully",
           timestamp: new Date().toISOString(),
           configuration: finalConfig, // Send configuration to agent so it can apply it
+          ...(mintedToken ? { auth_token: mintedToken } : {}),
         });
+
+        // Grandfather path: push a token to a known-but-unsecured agent. The
+        // hash is committed only on the agent's ack, so old binaries that
+        // ignore setAuthToken stay connectable (shown Unsecured in the UI)
+        // until fleet self-update delivers a binary that completes this.
+        if (issueTokenViaCommand) {
+          const grandfatherToken = mintAgentToken();
+          setTimeout(() => {
+            this.commandDispatcher
+              .sendCommand(agentId, "setAuthToken", { authToken: grandfatherToken })
+              .then(async () => {
+                await db.run(
+                  "UPDATE systems SET auth_token_hash = $1 WHERE agent_id = $2",
+                  [hashAgentToken(grandfatherToken), agentId]
+                );
+                log.info(`Agent ${agentId} secured via setAuthToken`, "WebSocketHub");
+              })
+              .catch((err) => {
+                log.debug(
+                  `Agent ${agentId} did not accept setAuthToken (pre-auth binary?): ${err?.message ?? err}`,
+                  "WebSocketHub"
+                );
+              });
+          }, 2000);
+        }
 
         // DB-priority profile sync: if DB has a profile_id that differs from agent's,
         // tell the agent to reload so it fetches the authoritative profile from the API.

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -56,6 +56,24 @@ interface WebSocketMessage {
   clientId?: string;
 }
 
+// Credential-less agent held for admin approval (D13). Lives in memory only,
+// tied to its connection; no systems row, no license seat, telemetry ignored.
+interface PendingAgent {
+  clientId: string;
+  registrationData: any;
+  agentId: string;
+  name: string;
+  ip?: string;
+  agentType?: string;
+  platform?: string;
+  version?: string;
+  reason: string;
+  requestedAt: string;
+}
+
+// Bound on concurrently held pending agents (memory + card-spam cap)
+const MAX_PENDING_AGENTS = 20;
+
 export class WebSocketHub extends EventEmitter {
   private static instance: WebSocketHub;
   private wss: WebSocketServer | null = null;
@@ -65,6 +83,8 @@ export class WebSocketHub extends EventEmitter {
   // the per-client `subscriptions` Sets; keep them in sync only through
   // add/removeClientSubscription and removeClientFromIndex.
   private subscriptionIndex: Map<string, Set<string>> = new Map();
+  // agentId -> pending-approval entry (D13)
+  private pendingAgents: Map<string, PendingAgent> = new Map();
   private dataAggregator: DataAggregator;
   private agentManager: AgentManager;
   private commandDispatcher: CommandDispatcher;
@@ -440,6 +460,21 @@ export class WebSocketHub extends EventEmitter {
         log.info(` Frontend client disconnected: ${clientId}`, "WebSocketHub");
       }
 
+      // Pending-approval entries live with their connection (D13)
+      for (const [agentId, entry] of this.pendingAgents) {
+        if (entry.clientId === clientId) {
+          this.pendingAgents.delete(agentId);
+          this.broadcast("agentPendingRemoved", { agentId }, [
+            "agents:all",
+            "systems:all",
+          ]);
+          log.info(
+            `Pending agent ${agentId} disconnected before approval`,
+            "WebSocketHub"
+          );
+        }
+      }
+
       this.removeClientFromIndex(client); // before removing the client itself
       this.clients.delete(clientId);
       this.emit("clientDisconnected", { clientId, client });
@@ -654,7 +689,10 @@ export class WebSocketHub extends EventEmitter {
    */
   private async handleAgentRegistration(
     clientId: string,
-    registrationData: any
+    registrationData: any,
+    // true only from approvePendingAgent: an admin vouched for this agent, so
+    // the credential tree is skipped and the grandfather path issues a token
+    preApproved: boolean = false
   ): Promise<void> {
     try {
       log.info(
@@ -683,55 +721,57 @@ export class WebSocketHub extends EventEmitter {
         return;
       }
 
-      // Credential decision tree (task_02 section 4.1):
+      // Credential decision tree (task_02 section 4.4):
       //   auth_token + stored hash        -> verify or close
-      //   enrollment_token, unknown agent -> exchange for a minted token
+      //   enrollment_token valid          -> exchange for a minted token
       //   known agent, no stored hash     -> grandfather, issue via setAuthToken
-      //   nothing valid                   -> close
-      const db2 = Database.getInstance();
-      const existing = await db2.get(
-        "SELECT auth_token_hash FROM systems WHERE agent_id = $1",
-        [agentId]
-      );
-      const presentedToken = registrationData.auth_token;
-      const presentedEnrollment = registrationData.enrollment_token;
-
+      //   unknown, nothing valid          -> hold as pending-approval card
       let mintedToken: string | null = null; // returned in the registered response
-      let issueTokenViaCommand = false; // grandfather path (setAuthToken push)
+      let issueTokenViaCommand = preApproved; // grandfather path (setAuthToken push)
 
-      if (existing?.auth_token_hash) {
-        if (!verifyAgentToken(presentedToken, existing.auth_token_hash)) {
-          log.warn(
-            `Agent ${agentId} presented ${presentedToken ? "an invalid" : "no"} auth token - rejecting`,
-            "WebSocketHub"
-          );
-          this.sendToClient(clientId, "registrationError", {
-            error: "Agent token rejected",
-          });
-          this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
-          return;
-        }
-      } else if (existing) {
-        // Known agent, not yet secured. A valid enrollment token (reinstall
-        // over an existing system) mints inline; otherwise grandfather.
-        if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
-          mintedToken = mintAgentToken();
+      if (!preApproved) {
+        const db2 = Database.getInstance();
+        const existing = await db2.get(
+          "SELECT auth_token_hash FROM systems WHERE agent_id = $1",
+          [agentId]
+        );
+        const presentedToken = registrationData.auth_token;
+        const presentedEnrollment = registrationData.enrollment_token;
+
+        if (existing?.auth_token_hash) {
+          if (!verifyAgentToken(presentedToken, existing.auth_token_hash)) {
+            log.warn(
+              `Agent ${agentId} presented ${presentedToken ? "an invalid" : "no"} auth token - rejecting`,
+              "WebSocketHub"
+            );
+            this.sendToClient(clientId, "registrationError", {
+              error: "Agent token rejected",
+            });
+            this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
+            return;
+          }
+        } else if (existing) {
+          // Known agent, not yet secured. A valid enrollment token (reinstall
+          // over an existing system) mints inline; otherwise grandfather.
+          if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
+            mintedToken = mintAgentToken();
+          } else {
+            issueTokenViaCommand = true;
+          }
         } else {
-          issueTokenViaCommand = true;
-        }
-      } else {
-        // Unknown agent: enrollment token is the only way in. A deleted
-        // system's old token does not readmit it (delete = revoke).
-        if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
-          mintedToken = mintAgentToken();
-        } else {
-          const reason = presentedEnrollment
-            ? "Deploy token invalid or expired - generate a fresh install script from the Deployment page"
-            : "Enrollment required - deploy this agent via an install script from the Deployment page";
-          log.warn(`Unknown agent ${agentId} rejected: ${reason}`, "WebSocketHub");
-          this.sendToClient(clientId, "registrationError", { error: reason });
-          this.clients.get(clientId)?.websocket.close(4403, "enrollment required");
-          return;
+          // Unknown agent. Valid enrollment token = automatic (script flow).
+          // Anything else is held as a pending-approval card (D13): --setup
+          // installs, stale (>24h) install scripts, deleted-but-still-running
+          // agents. A human admin decides; nothing flows until then.
+          if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
+            mintedToken = mintAgentToken();
+          } else {
+            const reason = presentedEnrollment
+              ? "Install token expired - approve on the dashboard or run a fresh install script"
+              : "Registered without credentials - approve on the dashboard";
+            this.holdPendingAgent(clientId, registrationData, reason);
+            return;
+          }
         }
       }
 
@@ -1001,6 +1041,128 @@ export class WebSocketHub extends EventEmitter {
         error: "Registration processing failed",
       });
     }
+  }
+
+  /**
+   * Hold a credential-less agent for admin approval (D13). The connection
+   * stays open (so approval can promote it instantly) but the client is never
+   * marked isAgent - existing gates ignore its telemetry and responses.
+   */
+  private holdPendingAgent(
+    clientId: string,
+    registrationData: any,
+    reason: string
+  ): void {
+    const agentId = registrationData.agentId;
+    const previous = this.pendingAgents.get(agentId);
+
+    // Same agent retrying (reconnect after dismiss/restart): the new
+    // connection supersedes the old entry
+    if (previous && previous.clientId !== clientId) {
+      this.clients
+        .get(previous.clientId)
+        ?.websocket.close(4408, "superseded by newer registration");
+    }
+
+    if (!previous && this.pendingAgents.size >= MAX_PENDING_AGENTS) {
+      log.warn(
+        `Pending-approval queue full (${MAX_PENDING_AGENTS}) - turning away agent ${agentId}`,
+        "WebSocketHub"
+      );
+      this.sendToClient(clientId, "registrationError", {
+        error: "Hub pending-approval queue is full",
+      });
+      this.clients.get(clientId)?.websocket.close(4403, "pending queue full");
+      return;
+    }
+
+    const client = this.clients.get(clientId);
+    const entry: PendingAgent = {
+      clientId,
+      registrationData,
+      agentId,
+      name: registrationData.name || agentId,
+      ip: client?.metadata.ip,
+      agentType: registrationData.agent_type,
+      platform: registrationData.platform,
+      version: registrationData.agent_version,
+      reason,
+      requestedAt: new Date().toISOString(),
+    };
+    this.pendingAgents.set(agentId, entry);
+
+    log.info(`Agent ${agentId} held for approval: ${reason}`, "WebSocketHub");
+    this.sendToClient(clientId, "registrationPending", { agentId, reason });
+    this.broadcast("agentPendingApproval", this.pendingAgentView(entry), [
+      "agents:all",
+      "systems:all",
+    ]);
+  }
+
+  /** Metadata-only view of a pending agent (never the raw registration data) */
+  private pendingAgentView(entry: PendingAgent) {
+    const { clientId, registrationData, ...view } = entry;
+    return view;
+  }
+
+  public getPendingAgents() {
+    return Array.from(this.pendingAgents.values()).map((e) =>
+      this.pendingAgentView(e)
+    );
+  }
+
+  /**
+   * Admin approved a pending agent: run the normal registration for the held
+   * connection (row, config sync, registered response) with the grandfather
+   * path pushing its permanent token.
+   */
+  public async approvePendingAgent(
+    agentId: string
+  ): Promise<{ ok: boolean; error?: string }> {
+    const entry = this.pendingAgents.get(agentId);
+    if (!entry) {
+      return { ok: false, error: "No pending agent with that ID" };
+    }
+
+    this.pendingAgents.delete(agentId);
+    this.broadcast("agentPendingRemoved", { agentId }, [
+      "agents:all",
+      "systems:all",
+    ]);
+
+    const client = this.clients.get(entry.clientId);
+    if (!client || client.websocket.readyState !== WebSocket.OPEN) {
+      return {
+        ok: false,
+        error:
+          "Agent is no longer connected - it will reappear on its next reconnect",
+      };
+    }
+
+    log.info(`Pending agent ${agentId} approved by admin`, "WebSocketHub");
+    await this.handleAgentRegistration(entry.clientId, entry.registrationData, true);
+    return { ok: true };
+  }
+
+  /**
+   * Admin dismissed a pending agent: drop the entry and close the connection.
+   * Not a ban - the agent re-pends on its next reconnect; permanent silence
+   * means uninstalling the agent on that machine.
+   */
+  public dismissPendingAgent(agentId: string): { ok: boolean; error?: string } {
+    const entry = this.pendingAgents.get(agentId);
+    if (!entry) {
+      return { ok: false, error: "No pending agent with that ID" };
+    }
+
+    this.pendingAgents.delete(agentId);
+    this.broadcast("agentPendingRemoved", { agentId }, [
+      "agents:all",
+      "systems:all",
+    ]);
+    this.clients.get(entry.clientId)?.websocket.close(4403, "dismissed");
+    log.info(`Pending agent ${agentId} dismissed by admin`, "WebSocketHub");
+    return { ok: true };
   }
 
   /**

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -71,10 +71,16 @@ interface PendingAgent {
   requestedAt: string;
 }
 
-// Max agents held awaiting approval at once (memory + card-spam bound); raise for large migrations.
+// Max agents held awaiting approval at once (memory + card-spam bound); raise for large enrollments.
 const MAX_PENDING_AGENTS = (() => {
-  const raw = parseInt(process.env.PANKHA_MAX_PENDING_AGENTS ?? '', 10);
-  return Number.isInteger(raw) && raw > 0 ? raw : 20;
+  const raw = (process.env.PANKHA_MAX_PENDING_AGENTS ?? '').trim();
+  if (!raw) return 20;
+  const n = /^\d+$/.test(raw) ? parseInt(raw, 10) : NaN;
+  if (!Number.isInteger(n) || n <= 0) {
+    log.warn(`PANKHA_MAX_PENDING_AGENTS ignored - expected a positive integer, got "${raw}". Using 20.`, 'websocket');
+    return 20;
+  }
+  return n;
 })();
 
 export class WebSocketHub extends EventEmitter {

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -71,8 +71,12 @@ interface PendingAgent {
   requestedAt: string;
 }
 
-// Bound on concurrently held pending agents (memory + card-spam cap)
-const MAX_PENDING_AGENTS = 20;
+// Bound on concurrently held pending agents (memory + card-spam cap).
+// Raise it for a large first-time migration so the whole fleet pends at once.
+const MAX_PENDING_AGENTS = (() => {
+  const raw = parseInt(process.env.PANKHA_MAX_PENDING_AGENTS ?? '', 10);
+  return Number.isInteger(raw) && raw > 0 ? raw : 20;
+})();
 
 export class WebSocketHub extends EventEmitter {
   private static instance: WebSocketHub;

--- a/backend/src/types/agent.ts
+++ b/backend/src/types/agent.ts
@@ -97,6 +97,7 @@ export interface FanControlCommand {
     | "setFailsafeSpeed"
     | "setEnableFanControl"
     | "setAgentName"
+    | "setAuthToken"
     | "selfUpdate"
     | "getDiagnostics"
     | "executeRawIpmi"
@@ -124,6 +125,7 @@ export interface FanControlCommand {
     version?: string | null; // For selfUpdate command (hub version, e.g., "v0.3.2")
     bytes?: string; // For executeRawIpmi command (hex bytes like "0x30 0x70 0x66")
     excludedSensors?: string[]; // For setExcludedSensors command - sensor IDs to skip in failsafe
+    authToken?: string; // For setAuthToken command - Hub-minted agent credential
   };
   timestamp: number;
   priority: "low" | "normal" | "high" | "emergency";

--- a/backend/src/utils/duration.ts
+++ b/backend/src/utils/duration.ts
@@ -1,0 +1,22 @@
+// Human-friendly duration parsing, e.g. "6 minutes", "2 days", "1 year".
+// Pattern adapted from the license token generator (private repo).
+
+const UNIT_SECONDS: Record<string, number> = {
+  minute: 60,
+  hour: 60 * 60,
+  day: 24 * 60 * 60,
+  week: 7 * 24 * 60 * 60,
+  month: 30 * 24 * 60 * 60, // approx 30 days
+  year: 365 * 24 * 60 * 60, // approx 365 days
+};
+
+// Parse "<n> <unit>" (unit singular or plural) into seconds. Returns null when
+// the input is empty or not in that form.
+export function parseDurationSeconds(input: string | undefined | null): number | null {
+  if (!input) return null;
+  const match = input.trim().toLowerCase().match(/^(\d+)\s*(minute|hour|day|week|month|year)s?$/);
+  if (!match) return null;
+  const value = parseInt(match[1], 10);
+  if (!(value > 0)) return null;
+  return value * UNIT_SECONDS[match[2]];
+}

--- a/documentation/public/wiki/API-Reference.md
+++ b/documentation/public/wiki/API-Reference.md
@@ -9,6 +9,41 @@ Two kinds of identifiers appear in these routes:
 
 ---
 
+## Authentication
+
+All `/api` endpoints require a login session; requests without one get `401`. Logging in via `POST /api/auth/login` sets a session cookie (httpOnly, SameSite) that browsers and same-origin requests carry automatically; command-line clients pass it with curl's cookie flags (see Quick Examples). Sessions last 7 days by default, renewed by activity, and the duration is configurable with the `PANKHA_SESSION_DURATION` environment variable. Failed logins are rate limited. The WebSocket endpoint uses the same session cookie during connection.
+
+On a fresh install no accounts exist yet: the dashboard walks you through creating the first admin account, or call `POST /api/auth/setup` directly.
+
+### Roles
+
+| Role       | Can do                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| `viewer`   | Read everything: dashboard, systems, sensors, history. Cannot change anything.                       |
+| `operator` | Everything a viewer can, plus control: fan speeds, profiles, calibration, settings.                  |
+| `admin`    | Everything an operator can, plus user management, agent approval and deployment, fleet updates, and license changes. |
+
+Default rule: `GET` requests need viewer, all other methods need operator. Admin-only endpoints are marked in their tables. Agents are separate from user accounts - they authenticate their WebSocket connection with their own tokens, install scripts use short-lived deploy tokens, and agent binaries are public downloads.
+
+### Auth Endpoints
+
+| Method | Endpoint                 | Description                                                              |
+| ------ | ------------------------ | ------------------------------------------------------------------------ |
+| POST   | `/api/auth/setup`        | First-run only: create the initial admin account                         |
+| POST   | `/api/auth/login`        | Log in; sets the session cookie                                          |
+| POST   | `/api/auth/logout`       | Log out; clears the session cookie                                       |
+| GET    | `/api/auth/me`           | Current session: username, role, whether self-registration is enabled    |
+| PUT    | `/api/auth/password`     | Change your own password (any role)                                      |
+| GET    | `/api/auth/users`        | List users (admin)                                                       |
+| POST   | `/api/auth/users`        | Create a user with a role (admin)                                        |
+| PUT    | `/api/auth/users/:id`    | Update a user's role or reset their password (admin)                     |
+| DELETE | `/api/auth/users/:id`    | Delete a user; the last admin cannot be deleted (admin)                  |
+| GET    | `/api/auth/registration` | Read the self-registration setting (admin)                               |
+| PUT    | `/api/auth/registration` | Enable or disable self-registration and set its default role (admin)     |
+| POST   | `/api/auth/register`     | Create your own account, available when self-registration is enabled     |
+
+---
+
 ## Health & Status
 
 | Method | Endpoint              | Description                                  |
@@ -33,6 +68,15 @@ Two kinds of identifiers appear in these routes:
 | DELETE | `/api/systems/:id`             | Remove system                                    |
 | GET    | `/api/systems/:id/status`      | Real-time connection status                      |
 | GET    | `/api/systems/:id/diagnostics` | Get hardware diagnostics from agent              |
+
+### Pending Approval (admin)
+New agents wait for admin approval before they register as systems.
+
+| Method | Endpoint                                | Description                                   |
+| ------ | --------------------------------------- | --------------------------------------------- |
+| GET    | `/api/systems/pending`                  | List agents awaiting approval                 |
+| POST   | `/api/systems/pending/:agentId/approve` | Approve an agent; it registers and goes live  |
+| DELETE | `/api/systems/pending/:agentId`         | Dismiss a pending agent                       |
 
 ### Controller
 | Method | Endpoint                           | Description                    |
@@ -281,16 +325,24 @@ Vendor profiles that teach the [IPMI agent](Agents-IPMI) how to talk to a server
 
 ## Quick Examples
 
+### Log In (once per session)
+```bash
+# Saves the session cookie to cookies.txt; -b cookies.txt sends it on later calls
+curl -c cookies.txt -X POST http://localhost:3143/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "your-password"}'
+```
+
 ### Set Fan Speed
 ```bash
-curl -X PUT http://localhost:3143/api/systems/1/fans/it8628_fan_1 \
+curl -b cookies.txt -X PUT http://localhost:3143/api/systems/1/fans/it8628_fan_1 \
   -H "Content-Type: application/json" \
   -d '{"speed": 75}'
 ```
 
 ### Create a Virtual Sensor
 ```bash
-curl -X POST http://localhost:3143/api/virtual-sensors \
+curl -b cookies.txt -X POST http://localhost:3143/api/virtual-sensors \
   -H "Content-Type: application/json" \
   -d '{
     "system_id": 1,
@@ -302,10 +354,10 @@ curl -X POST http://localhost:3143/api/virtual-sensors \
 
 ### Start a Manual Calibration
 ```bash
-curl -X POST http://localhost:3143/api/systems/1/fans/it8628_fan_1/calibrate
+curl -b cookies.txt -X POST http://localhost:3143/api/systems/1/fans/it8628_fan_1/calibrate
 ```
 
-### Check Health
+### Check Health (no login needed)
 ```bash
 curl http://localhost:3143/health
 ```
@@ -327,7 +379,8 @@ curl http://localhost:3143/health
 | 200  | Success                                                        |
 | 201  | Created                                                        |
 | 400  | Bad request                                                    |
-| 403  | Forbidden (license limit / read-only mode)                     |
+| 401  | Not logged in (missing or expired session - log in first)      |
+| 403  | Forbidden (role too low / license limit / read-only mode)      |
 | 404  | Not found                                                      |
 | 409  | Conflict (system offline, calibration lock, name collision)    |
 | 500  | Server error                                                   |

--- a/documentation/public/wiki/Docker-and-Env.md
+++ b/documentation/public/wiki/Docker-and-Env.md
@@ -1,0 +1,213 @@
+# Docker and Env
+
+How to deploy Pankha Fan Control with Docker, and every environment variable the stack actually reads. Essentials first; advanced setups below.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Get the two files
+curl -LO https://raw.githubusercontent.com/Anexgohan/pankha/main/compose.yml
+curl -L -o .env https://raw.githubusercontent.com/Anexgohan/pankha/main/.env
+
+# 2. Edit .env - at minimum set POSTGRES_USER, POSTGRES_PASSWORD, PANKHA_HUB_IP
+
+# 3. Start
+docker compose up -d
+```
+
+Open `http://<server-ip>:3143` - the dashboard walks you through creating the first admin account.
+
+---
+
+## Environment Variables
+
+Set these in the `.env` file next to `compose.yml` (or as `-e` flags with `docker run`).
+
+### Required
+
+| Variable            | Accepted values        | Default            | Description                                                                                            |
+| ------------------- | ---------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
+| `POSTGRES_USER`     | any string             | set your own       | Database username.                                                                                     |
+| `POSTGRES_PASSWORD` | any string             | set your own       | Database password. Never keep a published example value.                                               |
+| `POSTGRES_DB`       | database name          | `db_pankha`        | Database name.                                                                                         |
+| `PANKHA_HUB_IP`     | LAN IP or hostname     | unset              | The address agents connect to. Baked into the install scripts the Deployment page generates, so it must be reachable from every agent machine (e.g. `192.168.1.100`). |
+
+### Optional
+
+| Variable                    | Accepted values                                              | Default                    | Description                                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PANKHA_PORT`               | port number                                                  | `3143`                     | Host port for the dashboard, API, and WebSocket.                                                                                                                          |
+| `TIMEZONE`                  | [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) | `UTC`  | Timezone for dashboard times and logs.                                                                                                                                    |
+| `LOG_LEVEL`                 | `error`, `warn`, `info`, `debug`, `trace`                    | `info`                     | Backend log verbosity.                                                                                                                                                    |
+| `PANKHA_STAGING_DIR`        | absolute path                                                | `/app/backend/data/staging`| Where downloaded agent binaries, checksums, and reports are stored (mounted to `./docker-data/staging` in compose).                                                       |
+| `PANKHA_SESSION_DURATION`   | `<n> <unit>` - minute/hour/day/week/month/year, singular or plural | `7 days`             | How long a browser login stays valid (sliding - activity renews it), e.g. `12 hours`, `2 weeks`. Unrecognized values fall back to 7 days.                                 |
+| `PANKHA_MAX_PENDING_AGENTS` | positive integer                                             | `20`                       | Max agents awaiting approval at once; raise it for a large first-time enrollment so the whole fleet pends in one screen instead of refilling in waves.                      |
+| `PANKHA_TRUST_PROXY`        | comma-separated IPs/CIDRs                                    | unset (no proxy trusted)   | Addresses of your reverse proxies, e.g. `192.168.1.5` or `10.0.0.0/8, 172.16.0.1`. Forwarded-for headers are only believed when they arrive from these addresses, so the login rate limiter identifies the real client instead of the shared proxy IP. Leave unset for direct connections. Invalid values are ignored with a warning. See the reverse-proxy note below. |
+| `PANKHA_AUTH_RESET`         | `true` / `false`                                             | unset (off)                | Account recovery: when set to `true`, all user accounts are reset on startup and the dashboard returns to first-run setup. Remove the variable and restart once you are back in. Any value other than `true`, `false`, or unset refuses to start. |
+| `POSTGRES_HOST`             | hostname                                                     | `pankha-postgres`          | Database host. The compose service name by default; change only for an external database (see below).                                                                     |
+| `POSTGRES_PORT`             | port number                                                  | `5432`                     | Database port.                                                                                                                                                            |
+
+### PostgreSQL tuning (leave as-is unless you know why)
+
+| Variable                      | Accepted values | Default | Description                                       |
+| ----------------------------- | --------------- | ------- | ------------------------------------------------- |
+| `POSTGRES_MAX_WAL_SIZE`       | size            | `256MB` | Cap on transaction log size before checkpoint.    |
+| `POSTGRES_MIN_WAL_SIZE`       | size            | `80MB`  | Minimum WAL kept; old files recycle down to this. |
+| `POSTGRES_CHECKPOINT_TIMEOUT` | duration        | `5min`  | Time between checkpoints.                         |
+| `POSTGRES_WAL_KEEP_SIZE`      | size            | `64MB`  | WAL retained for recovery purposes.               |
+
+---
+
+## Docker Compose
+
+The shipped [`compose.yml`](https://github.com/Anexgohan/pankha/blob/main/compose.yml) runs two containers - the app and PostgreSQL:
+
+```yaml
+services:
+  pankha-app:
+    container_name: pankha_app
+    image: anexgohan/pankha:latest # :latest=(stable) | :beta=(absolute latest) | :testing=(pre-release)
+    ports:
+      - "${PANKHA_PORT:-3143}:3143"
+    environment:
+      - TZ=${TIMEZONE:-UTC}
+      - PORT=3143 # Internal port, do not change
+    env_file:
+      - .env
+    depends_on:
+      pankha-postgres:
+        condition: service_healthy
+    volumes:
+      - ./docker-data/staging:${PANKHA_STAGING_DIR}
+    restart: unless-stopped
+
+  pankha-postgres:
+    container_name: pankha_postgres
+    image: postgres:18-alpine
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    env_file:
+      - .env
+    volumes:
+      - ./docker-data/backend/database/postgres_data:/var/lib/postgresql
+    restart: unless-stopped
+```
+
+The database port is intentionally not published to the host; the app reaches it over the internal Docker network. Uncomment the `ports:` block in the shipped file only if external database access is needed.
+
+---
+
+## Docker Run (without Compose)
+
+The same stack as plain `docker run` commands:
+
+```bash
+docker network create pankha-net
+
+docker run -d --name pankha_postgres \
+  --network pankha-net \
+  -e POSTGRES_DB=db_pankha \
+  -e POSTGRES_USER=<your-user> \
+  -e POSTGRES_PASSWORD=<your-password> \
+  -v "$(pwd)/docker-data/backend/database/postgres_data:/var/lib/postgresql" \
+  --restart unless-stopped \
+  postgres:18-alpine
+
+docker run -d --name pankha_app \
+  --network pankha-net \
+  -p 3143:3143 \
+  -e PORT=3143 \
+  -e TZ=UTC \
+  -e POSTGRES_HOST=pankha_postgres \
+  -e POSTGRES_PORT=5432 \
+  -e POSTGRES_DB=db_pankha \
+  -e POSTGRES_USER=<your-user> \
+  -e POSTGRES_PASSWORD=<your-password> \
+  -e PANKHA_HUB_IP=<your-lan-ip> \
+  -e PANKHA_STAGING_DIR=/app/backend/data/staging \
+  -v "$(pwd)/docker-data/staging:/app/backend/data/staging" \
+  --restart unless-stopped \
+  anexgohan/pankha:latest
+```
+
+---
+
+## Troubleshooting
+
+**Dashboard unreachable / port already in use** - another service owns the port. Change `PANKHA_PORT` in `.env` and re-run `docker compose up -d`:
+
+```text
+$ docker compose up -d
+Error response from daemon: failed to bind host port 0.0.0.0:3143: address already in use
+```
+
+**App container restarts, database connection refused** - `POSTGRES_HOST` must match the database container's name on the shared network (`pankha-postgres` in compose, `pankha_postgres` with plain docker run):
+
+```text
+$ docker logs pankha_app
+Error: Database connection requires either POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB or DATABASE_URL
+```
+
+**Agents cannot connect after install** - `PANKHA_HUB_IP` was unset or not reachable from the agent's network when the install script was generated. Set it to the server's LAN IP and generate a fresh install script from the Deployment page.
+
+**Locked out of the dashboard** - set `PANKHA_AUTH_RESET=true` in `.env`, restart the app container, complete first-run setup again, then remove the variable and restart once more.
+
+**Times are wrong in the dashboard or logs** - set `TIMEZONE` in `.env` to your tz database name (e.g. `Asia/Kolkata`) and restart.
+
+---
+
+## Advanced
+
+### External PostgreSQL
+
+To use an existing PostgreSQL server instead of the bundled container: remove (or don't start) the `pankha-postgres` service, and point the app at your server in `.env`:
+
+```bash
+POSTGRES_HOST="db.example.lan"
+POSTGRES_PORT="5432"
+POSTGRES_DB="db_pankha"
+POSTGRES_USER="<your-user>"
+POSTGRES_PASSWORD="<your-password>"
+```
+
+The backend builds its connection string from these variables with proper URL-encoding, so special characters in passwords are safe. (A raw `DATABASE_URL` is accepted as a fallback only when the individual variables are absent, and you must pre-encode special characters yourself - prefer the variables above.) The schema is created automatically on first start.
+
+### Upgrading and rolling back
+
+```bash
+# Upgrade to the newest image on your chosen tag
+docker compose down && docker compose pull && docker compose up -d
+```
+
+Image tags: `latest` (stable), `beta` (absolute latest), `testing` (pre-releases). To pin or roll back, set an explicit version in `compose.yml` and recreate:
+
+```yaml
+image: anexgohan/pankha:v0.6.2
+```
+
+```bash
+docker compose up -d
+```
+
+Your data lives in `./docker-data/` on the host, outside the containers, so recreating containers does not touch it.
+
+### Running behind a reverse proxy
+
+Pankha serves HTTP and WebSocket on the same port. If you front it with nginx, Caddy, or Traefik, the proxy must forward WebSocket upgrade headers or the dashboard's live updates and agent connections will fail. For nginx:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:3143;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+Also set `PANKHA_TRUST_PROXY` to your proxy's address (see the variable table) so login rate limiting sees real client addresses instead of the proxy's.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,53 @@
 import SystemsPage from './systems/components/SystemsPage';
+import LoginPage from './components/LoginPage';
+import SetupPage from './components/SetupPage';
 import { Branding } from './components/Branding';
 import { Toaster } from './components/ui/Toaster';
 import { GraphPatternDefs } from './components/GraphPatternDefs';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { VisibilityProvider } from './contexts/VisibilityContext';
 import { DashboardSettingsProvider } from './contexts/DashboardSettingsContext';
 import { LicenseProvider } from './license';
+import { Loader2 } from 'lucide-react';
+
+// Session gate: setup screen on a fresh Hub, login without a session,
+// the dashboard once authenticated.
+function AuthGate() {
+  const { status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <div className="auth-loading">
+        <Loader2 size={28} className="animate-spin" />
+      </div>
+    );
+  }
+  if (status === 'setup') return <SetupPage />;
+  if (status === 'login') return <LoginPage />;
+
+  return (
+    <LicenseProvider>
+      <DashboardSettingsProvider>
+        <VisibilityProvider>
+          <GraphPatternDefs />
+          <div className="App">
+            <SystemsPage />
+            <Branding />
+          </div>
+        </VisibilityProvider>
+      </DashboardSettingsProvider>
+    </LicenseProvider>
+  );
+}
 
 function App() {
   return (
     <ThemeProvider>
-      <LicenseProvider>
-        <DashboardSettingsProvider>
-          <VisibilityProvider>
-            <GraphPatternDefs />
-            <div className="App">
-              <SystemsPage />
-              <Branding />
-              <Toaster />
-            </div>
-          </VisibilityProvider>
-        </DashboardSettingsProvider>
-      </LicenseProvider>
+      <AuthProvider>
+        <AuthGate />
+        <Toaster />
+      </AuthProvider>
     </ThemeProvider>
   )
 }

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff, CircleAlert } from 'lucide-react';
+import { PankhaFanIcon } from './icons/PankhaFanIcon';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Sign-in screen, with an optional create-account mode when the admin has
+ * enabled self-registration (D15). Shown whenever no session exists.
+ */
+const LoginPage: React.FC = () => {
+  const { login, registerAccount, registrationEnabled } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (mode === 'register' && password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      if (mode === 'login') {
+        await login(username, password);
+      } else {
+        await registerAccount(username, password);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const switchMode = (next: 'login' | 'register') => {
+    setMode(next);
+    setError(null);
+    setPassword('');
+    setConfirm('');
+  };
+
+  return (
+    <div className="auth-shell">
+      <form className="system-card auth-card" onSubmit={handleSubmit}>
+        <div className="auth-brand">
+          <PankhaFanIcon size={38} className="animate-fan-spin auth-brand-fan" />
+          <div className="auth-brand-name">
+            <strong>Pankha</strong>
+            <span>Fan Control</span>
+          </div>
+        </div>
+
+        {mode === 'register' && (
+          <>
+            <h2 className="auth-heading">Create your account</h2>
+            <p className="auth-subtext">
+              Pick a username and password to access this Hub.
+            </p>
+          </>
+        )}
+
+        {error && (
+          <div className="auth-error">
+            <CircleAlert size={15} /> {error}
+          </div>
+        )}
+
+        <div className="form-group">
+          <label htmlFor="auth-username">Username</label>
+          <input
+            id="auth-username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            autoFocus
+            required
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="auth-password">Password</label>
+          <div className="password-wrap">
+            <input
+              id="auth-password"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              placeholder={mode === 'register' ? 'At least 8 characters' : undefined}
+              required
+            />
+            <button
+              type="button"
+              className="password-eye"
+              title={showPassword ? 'Hide password' : 'Show password'}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOff size={17} /> : <Eye size={17} />}
+            </button>
+          </div>
+        </div>
+
+        {mode === 'register' && (
+          <div className="form-group">
+            <label htmlFor="auth-confirm">Confirm password</label>
+            <input
+              id="auth-confirm"
+              type={showPassword ? 'text' : 'password'}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              autoComplete="new-password"
+              required
+            />
+          </div>
+        )}
+
+        <button type="submit" className="control-button auth-submit" disabled={busy}>
+          {mode === 'login' ? (busy ? 'Signing in...' : 'Sign in') : busy ? 'Creating...' : 'Create account'}
+        </button>
+
+        {registrationEnabled && mode === 'login' && (
+          <div className="auth-alt">
+            New here? <a onClick={() => switchMode('register')}>Create an account</a>
+          </div>
+        )}
+        {mode === 'register' && (
+          <div className="auth-alt">
+            Already have an account? <a onClick={() => switchMode('login')}>Sign in</a>
+          </div>
+        )}
+      </form>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/components/SetupPage.tsx
+++ b/frontend/src/components/SetupPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff, CircleAlert } from 'lucide-react';
+import { PankhaFanIcon } from './icons/PankhaFanIcon';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * First-run screen: create the initial admin account (D1). Rendered while
+ * no user accounts exist (fresh install, or after PANKHA_AUTH_RESET).
+ */
+const SetupPage: React.FC = () => {
+  const { setupAdmin } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await setupAdmin(username, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Setup failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="auth-shell">
+      <form className="system-card auth-card" onSubmit={handleSubmit}>
+        <div className="auth-brand">
+          <PankhaFanIcon size={38} className="animate-fan-spin auth-brand-fan" />
+          <div className="auth-brand-name">
+            <strong>Pankha</strong>
+            <span>Fan Control</span>
+          </div>
+        </div>
+
+        <h2 className="auth-heading">Create your admin account</h2>
+        <p className="auth-subtext">
+          This Hub has no accounts yet. The first account gets full admin
+          access - create it now to secure the dashboard.
+        </p>
+
+        {error && (
+          <div className="auth-error">
+            <CircleAlert size={15} /> {error}
+          </div>
+        )}
+
+        <div className="form-group">
+          <label htmlFor="setup-username">Username</label>
+          <input
+            id="setup-username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            placeholder="admin"
+            autoFocus
+            required
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="setup-password">Password</label>
+          <div className="password-wrap">
+            <input
+              id="setup-password"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              placeholder="At least 8 characters"
+              required
+            />
+            <button
+              type="button"
+              className="password-eye"
+              title={showPassword ? 'Hide password' : 'Show password'}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOff size={17} /> : <Eye size={17} />}
+            </button>
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="setup-confirm">Confirm password</label>
+          <input
+            id="setup-confirm"
+            type={showPassword ? 'text' : 'password'}
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        <button type="submit" className="control-button auth-submit" disabled={busy}>
+          {busy ? 'Creating...' : 'Create account'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default SetupPage;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,127 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import * as authApi from '../services/authApi';
+import type { AuthMe, Role } from '../services/authApi';
+import { subscribeAuthRequired } from '../services/authEvents';
+
+// The ONLY place the frontend knows the role ladder. Components ask
+// can('operator'), never "am I an operator?" - so new roles slot in here.
+const ROLE_LEVEL: Record<Role, number> = { viewer: 1, operator: 2, admin: 3 };
+
+export type AuthStatus = 'loading' | 'setup' | 'login' | 'ready';
+
+interface AuthContextValue {
+  status: AuthStatus;
+  username: string | null;
+  role: Role | null;
+  registrationEnabled: boolean;
+  authResetActive: boolean;
+  can: (minRole: Role) => boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  setupAdmin: (username: string, password: string) => Promise<void>;
+  registerAccount: (username: string, password: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [username, setUsername] = useState<string | null>(null);
+  const [role, setRole] = useState<Role | null>(null);
+  const [registrationEnabled, setRegistrationEnabled] = useState(false);
+  const [authResetActive, setAuthResetActive] = useState(false);
+
+  const applyMe = useCallback((me: AuthMe) => {
+    setAuthResetActive(me.auth_reset_active === true);
+    if (me.authenticated && me.username && me.role) {
+      setUsername(me.username);
+      setRole(me.role);
+      setStatus('ready');
+    } else {
+      setUsername(null);
+      setRole(null);
+      setRegistrationEnabled(me.registration_enabled === true);
+      setStatus(me.setup_required ? 'setup' : 'login');
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      applyMe(await authApi.getMe());
+    } catch (error) {
+      // Backend unreachable: keep the current screen; the caller's own
+      // error handling (connection banner, retries) covers this
+      console.error('Failed to fetch auth state:', error);
+    }
+  }, [applyMe]);
+
+  useEffect(() => {
+    refresh();
+    return subscribeAuthRequired(() => {
+      refresh();
+    });
+  }, [refresh]);
+
+  const login = useCallback(async (user: string, password: string) => {
+    const result = await authApi.login(user, password);
+    setUsername(result.username);
+    setRole(result.role);
+    setStatus('ready');
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await authApi.logout();
+    } finally {
+      await refresh();
+    }
+  }, [refresh]);
+
+  const setupAdmin = useCallback(async (user: string, password: string) => {
+    const result = await authApi.setupAdmin(user, password);
+    setUsername(result.username);
+    setRole(result.role);
+    setStatus('ready');
+  }, []);
+
+  const registerAccount = useCallback(async (user: string, password: string) => {
+    const result = await authApi.registerAccount(user, password);
+    setUsername(result.username);
+    setRole(result.role);
+    setStatus('ready');
+  }, []);
+
+  const can = useCallback(
+    (minRole: Role) => role !== null && (ROLE_LEVEL[role] ?? 0) >= ROLE_LEVEL[minRole],
+    [role]
+  );
+
+  return (
+    <AuthContext.Provider
+      value={{
+        status,
+        username,
+        role,
+        registrationEnabled,
+        authResetActive,
+        can,
+        login,
+        logout,
+        setupAdmin,
+        registerAccount,
+        refresh,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/deployment/components/DeploymentPage.tsx
+++ b/frontend/src/deployment/components/DeploymentPage.tsx
@@ -28,6 +28,7 @@ import InstallConnection, { type PathMode, type UrlMode } from './InstallConnect
 import RuntimeDefaults, { type LogLevel } from './RuntimeDefaults';
 import DeploySummary from './DeploySummary';
 import MaintenanceSection from './MaintenanceSection';
+import type { PendingAgent } from '../../services/authApi';
 import ResourcesSection from './ResourcesSection';
 import '../styles/deployment.css';
 
@@ -77,6 +78,7 @@ interface DeploymentPageProps {
   unstableVersion?: string | null;
   stableReleases?: ReleaseInfo[];
   unstableReleases?: ReleaseInfo[];
+  pendingAgents?: PendingAgent[];
 }
 
 export const DeploymentPage: React.FC<DeploymentPageProps> = ({
@@ -85,6 +87,7 @@ export const DeploymentPage: React.FC<DeploymentPageProps> = ({
   unstableVersion,
   stableReleases = [],
   unstableReleases = [],
+  pendingAgents = [],
 }) => {
   // Workspace state (new shape replaces aioAgentMode/arch)
   const [platform, setPlatform] = useState<Platform>('linux');
@@ -554,6 +557,7 @@ export const DeploymentPage: React.FC<DeploymentPageProps> = ({
         isExpanded={isMaintenanceExpanded}
         onToggle={() => setIsMaintenanceExpanded(!isMaintenanceExpanded)}
         systems={systems}
+        pendingAgents={pendingAgents}
         stableVersion={latestVersion}
         unstableVersion={unstableVersion || null}
         updatingAgents={updatingAgents}

--- a/frontend/src/deployment/components/MaintenanceSection.tsx
+++ b/frontend/src/deployment/components/MaintenanceSection.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Activity, ChevronDown, ChevronRight, Download } from 'lucide-react';
 import type { HubStatus } from '../../services/api';
+import type { PendingAgent } from '../../services/authApi';
 
 type MaintenanceSortKey = 'name' | 'agentId' | 'platform' | 'agentType' | 'version' | 'status' | 'maintenance';
 type SortDirection = 'asc' | 'desc';
@@ -9,6 +10,7 @@ interface MaintenanceSectionProps {
   isExpanded: boolean;
   onToggle: () => void;
   systems: any[];
+  pendingAgents?: PendingAgent[];
   stableVersion: string | null;
   unstableVersion: string | null;
   updatingAgents: Set<number>;
@@ -66,6 +68,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
   isExpanded,
   onToggle,
   systems,
+  pendingAgents = [],
   stableVersion,
   unstableVersion,
   updatingAgents,
@@ -76,10 +79,19 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
   const [sortKey, setSortKey] = useState<MaintenanceSortKey | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
+  // Agents connected but held for admin approval: not registered, so their
+  // systems row still reads offline - show the truthful state instead
+  const pendingIds = useMemo(
+    () => new Set(pendingAgents.map(p => p.agentId)),
+    [pendingAgents]
+  );
+
   const getStatusLabel = (system: any) =>
     updatingAgents.has(system.id)
       ? 'UPDATING'
-      : (system.status === 'error' ? 'ERROR' : (system.status === 'online' ? 'ONLINE' : 'OFFLINE'));
+      : pendingIds.has(system.agent_id)
+        ? 'PENDING APPROVAL'
+        : (system.status === 'error' ? 'ERROR' : (system.status === 'online' ? 'ONLINE' : 'OFFLINE'));
 
   const getMaintenanceLabel = (system: any) => {
     const isWindows = isWindowsSystem(system);
@@ -93,6 +105,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
     const isOnline = system.status === 'online' || system.status === 'error';
 
     if (isWindows) return isOutdated ? 'DOWNLOAD MSI' : 'GET MSI';
+    if (pendingIds.has(system.agent_id)) return 'APPROVE FIRST';
     if (!hubStatus?.version) return 'UNAVAILABLE';
     if (!isOnline) return 'OFFLINE';
     if (isUpdating) return 'UPDATING';
@@ -157,7 +170,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
         case 'version':
           return compareSemver(a.agent_version, b.agent_version);
         case 'status': {
-          const rank: Record<string, number> = { OFFLINE: 0, ERROR: 1, ONLINE: 2, UPDATING: 3 };
+          const rank: Record<string, number> = { OFFLINE: 0, 'PENDING APPROVAL': 1, ERROR: 2, ONLINE: 3, UPDATING: 4 };
           return (rank[getStatusLabel(a)] ?? 0) - (rank[getStatusLabel(b)] ?? 0);
         }
         case 'maintenance':
@@ -168,7 +181,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
     });
 
     return sortDirection === 'asc' ? sorted : sorted.reverse();
-  }, [systems, sortKey, sortDirection, updatingAgents]);
+  }, [systems, sortKey, sortDirection, updatingAgents, pendingIds]);
 
   return (
     <section className={`deployment-section maintenance-panel ${!isExpanded ? 'collapsed' : ''}`}>
@@ -248,10 +261,11 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                     const isDowngrade = isMismatch && compareSemver(cleanTarget, system.agent_version) < 0;
                     const isOutdated = isMismatch && !isDowngrade;
                     const isUpdating = updatingAgents.has(system.id);
+                    const isPending = pendingIds.has(system.agent_id);
                     const isOnline = system.status === 'online' || system.status === 'error';
 
                     const statusLabel = getStatusLabel(system);
-                    const statusClass = isUpdating ? 'updating' : (isOnline ? (system.status === 'error' ? 'error' : 'online') : 'offline');
+                    const statusClass = isUpdating ? 'updating' : (isPending ? 'pending' : (isOnline ? (system.status === 'error' ? 'error' : 'online') : 'offline'));
 
                     const getFleetIcon = () => {
                       if (system.agent_type === 'ipmi_host' || system.agent_type === 'ipmi_network') {
@@ -357,27 +371,29 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                           ) : (
                             <span
                               title={
-                                !hubStatus?.version
-                                  ? `Download Stable ${stableVersion || ''} or Unstable ${unstableVersion || ''} to server first`
-                                  : (!isOnline
-                                    ? 'Agent is offline'
-                                    : (isUpdating
-                                      ? 'Update in progress...'
-                                      : (isDowngrade
-                                        ? `Downgrade agent to ${targetVersion}`
-                                        : (isOutdated
-                                          ? `Click to update agent to ${targetVersion}`
-                                          : `Reinstall agent version ${targetVersion}`))))
+                                isPending
+                                  ? 'Approve this agent on the dashboard first, then update'
+                                  : !hubStatus?.version
+                                    ? `Download Stable ${stableVersion || ''} or Unstable ${unstableVersion || ''} to server first`
+                                    : (!isOnline
+                                      ? 'Agent is offline'
+                                      : (isUpdating
+                                        ? 'Update in progress...'
+                                        : (isDowngrade
+                                          ? `Downgrade agent to ${targetVersion}`
+                                          : (isOutdated
+                                            ? `Click to update agent to ${targetVersion}`
+                                            : `Reinstall agent version ${targetVersion}`))))
                               }
                               style={{ display: 'inline-block' }}
                             >
                               <button
                                 className={`btn-table-action ${isOutdated ? 'update-needed' : ''} ${isDowngrade ? 'downgrade' : ''}`}
                                 onClick={() => onApplyUpdate(system.id)}
-                                disabled={!isOnline || isUpdating || !hubStatus?.version}
+                                disabled={isPending || !isOnline || isUpdating || !hubStatus?.version}
                                 style={{ pointerEvents: 'auto' }}
                               >
-                                {isUpdating ? 'Updating...' : (isDowngrade ? 'Downgrade' : (isOutdated ? 'Update Now' : 'Reinstall'))}
+                                {isPending ? 'Approve First' : (isUpdating ? 'Updating...' : (isDowngrade ? 'Downgrade' : (isOutdated ? 'Update Now' : 'Reinstall')))}
                               </button>
                             </span>
                           )}

--- a/frontend/src/deployment/styles/deployment.css
+++ b/frontend/src/deployment/styles/deployment.css
@@ -1389,6 +1389,12 @@
   color: var(--color-accent-dynamic);
 }
 
+.status-tag-v2.pending {
+  background: color-mix(in srgb, var(--color-info), transparent 92%);
+  border-color: color-mix(in srgb, var(--color-info), transparent 85%);
+  color: var(--color-info);
+}
+
 .status-tag-v2 .status-dot {
   width: 6px;
   height: 6px;

--- a/frontend/src/hooks/useWebSocketData.ts
+++ b/frontend/src/hooks/useWebSocketData.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { SystemData } from "../types/api";
 import WebSocketService from "../services/websocket";
+import { notifyAuthRequired } from "../services/authEvents";
+import { getPendingAgents, type PendingAgent } from "../services/authApi";
+import { useAuth } from "../contexts/AuthContext";
 
 // Delta update structure from backend
 export interface SystemDelta {
@@ -71,6 +74,8 @@ interface UseWebSocketDataReturn {
   overview: any | null;
   fanCalibration: FanCalibrationMap;
   stalledFans: StalledFanMap;
+  // Agents held for admin approval (D13); always empty for non-admins
+  pendingAgents: PendingAgent[];
 }
 
 /**
@@ -93,10 +98,15 @@ export function useWebSocketData(): UseWebSocketDataReturn {
   const [overview, setOverview] = useState<any | null>(null);
   const [fanCalibration, setFanCalibration] = useState<FanCalibrationMap>({});
   const [stalledFans, setStalledFans] = useState<StalledFanMap>({});
+  const [pendingAgents, setPendingAgents] = useState<PendingAgent[]>([]);
+  const { can } = useAuth();
 
   const wsRef = useRef<WebSocketService | null>(null);
   const mountedRef = useRef(true);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // The pending queue is admin-only; ref keeps handlers stable across renders
+  const isAdminRef = useRef(false);
+  isAdminRef.current = can("admin");
 
   /**
    * Merge delta into existing systems state
@@ -416,6 +426,15 @@ export function useWebSocketData(): UseWebSocketDataReturn {
       wsRef.current.subscribe(["systems:all"]);
       wsRef.current.send("requestFullSync");
     }
+
+    // Seed the pending-approval queue (events keep it current afterwards)
+    if (isAdminRef.current) {
+      getPendingAgents()
+        .then((pending) => {
+          if (mountedRef.current) setPendingAgents(pending);
+        })
+        .catch((err) => console.error("Failed to fetch pending agents:", err));
+    }
   }, []);
 
   // Note: handleDisconnect and handleError are handled by the WebSocket service's
@@ -498,6 +517,28 @@ export function useWebSocketData(): UseWebSocketDataReturn {
     );
     wsRef.current.on("licenseUpdated", () => {
       for (const listener of licenseUpdatedListeners) listener();
+    });
+
+    // Session expired or revoked mid-connection: hand off to the auth layer
+    // (login screen) instead of the retry loop
+    wsRef.current.on("authRequired", () => {
+      console.warn("🔒 WebSocket closed: authentication required");
+      notifyAuthRequired();
+    });
+
+    // Pending-approval queue (D13, admin-only broadcasts carry metadata only)
+    wsRef.current.on("agentPendingApproval", (data: unknown) => {
+      if (!mountedRef.current || !isAdminRef.current) return;
+      const entry = data as PendingAgent;
+      setPendingAgents((prev) => [
+        ...prev.filter((p) => p.agentId !== entry.agentId),
+        entry,
+      ]);
+    });
+    wsRef.current.on("agentPendingRemoved", (data: unknown) => {
+      if (!mountedRef.current) return;
+      const { agentId } = data as { agentId: string };
+      setPendingAgents((prev) => prev.filter((p) => p.agentId !== agentId));
     });
 
     // Fan calibration lifecycle: one event per unit per state change.
@@ -613,5 +654,6 @@ export function useWebSocketData(): UseWebSocketDataReturn {
     overview,
     fanCalibration,
     stalledFans,
+    pendingAgents,
   };
 }

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -1,0 +1,117 @@
+import { API_BASE_URL } from './api';
+
+// Auth REST client. Same-origin (Vite proxies /api in dev), so the session
+// cookie rides along automatically on every call.
+
+export type Role = 'viewer' | 'operator' | 'admin';
+
+export interface AuthMe {
+  authenticated: boolean;
+  username?: string;
+  role?: Role;
+  setup_required?: boolean;
+  registration_enabled?: boolean;
+  auth_reset_active?: boolean;
+}
+
+export interface UserRow {
+  id: number;
+  username: string;
+  role: Role;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface RegistrationSettings {
+  enabled: boolean;
+  default_role: Role;
+}
+
+export interface PendingAgent {
+  agentId: string;
+  name: string;
+  ip?: string;
+  agentType?: string;
+  platform?: string;
+  version?: string;
+  reason: string;
+  requestedAt: string;
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
+    ...init,
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.error || `Request failed (${response.status})`);
+  }
+  return body as T;
+}
+
+export const getMe = () => request<AuthMe>('/api/auth/me');
+
+export const login = (username: string, password: string) =>
+  request<{ username: string; role: Role }>('/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  });
+
+export const logout = () => request<{ message: string }>('/api/auth/logout', { method: 'POST' });
+
+export const setupAdmin = (username: string, password: string) =>
+  request<{ username: string; role: Role }>('/api/auth/setup', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  });
+
+export const registerAccount = (username: string, password: string) =>
+  request<{ username: string; role: Role }>('/api/auth/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  });
+
+export const changePassword = (currentPassword: string, newPassword: string) =>
+  request<{ message: string }>('/api/auth/password', {
+    method: 'PUT',
+    body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+  });
+
+export const listUsers = () => request<UserRow[]>('/api/auth/users');
+
+export const createUser = (username: string, password: string, role: Role) =>
+  request<UserRow>('/api/auth/users', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, role }),
+  });
+
+export const updateUser = (id: number, changes: { role?: Role; password?: string }) =>
+  request<{ message: string }>(`/api/auth/users/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(changes),
+  });
+
+export const deleteUser = (id: number) =>
+  request<{ message: string }>(`/api/auth/users/${id}`, { method: 'DELETE' });
+
+export const getRegistrationSettings = () =>
+  request<RegistrationSettings>('/api/auth/registration');
+
+export const updateRegistrationSettings = (changes: Partial<RegistrationSettings>) =>
+  request<RegistrationSettings>('/api/auth/registration', {
+    method: 'PUT',
+    body: JSON.stringify(changes),
+  });
+
+export const getPendingAgents = () => request<PendingAgent[]>('/api/systems/pending');
+
+export const approvePendingAgent = (agentId: string) =>
+  request<{ message: string }>(`/api/systems/pending/${encodeURIComponent(agentId)}/approve`, {
+    method: 'POST',
+  });
+
+export const dismissPendingAgent = (agentId: string) =>
+  request<{ message: string }>(`/api/systems/pending/${encodeURIComponent(agentId)}`, {
+    method: 'DELETE',
+  });

--- a/frontend/src/services/authEvents.ts
+++ b/frontend/src/services/authEvents.ts
@@ -1,0 +1,22 @@
+// Tiny pub/sub bridging transport-level auth failures (REST 401, WebSocket
+// close 4401) to the AuthContext without circular imports.
+
+type AuthRequiredListener = () => void;
+const listeners = new Set<AuthRequiredListener>();
+
+export function subscribeAuthRequired(listener: AuthRequiredListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function notifyAuthRequired(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.error('Error in authRequired listener:', error);
+    }
+  }
+}

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -39,7 +39,14 @@ export class WebSocketService {
 
         this.ws.onclose = (event) => {
           console.log('WebSocket disconnected:', event.code, event.reason);
-          
+
+          // 4401: hub requires a (fresh) session - reconnecting without one
+          // would loop forever. Surface to the auth layer instead.
+          if (event.code === 4401) {
+            this.handleMessage({ type: 'authRequired', data: { reason: event.reason } } as WebSocketMessage);
+            return;
+          }
+
           if (!this.isIntentionallyClosed && this.reconnectAttempts < this.maxReconnectAttempts) {
             this.scheduleReconnect();
           }

--- a/frontend/src/settings/components/AccountsTab.tsx
+++ b/frontend/src/settings/components/AccountsTab.tsx
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { User, KeyRound, Trash2, Plus } from 'lucide-react';
+import { Select } from '../../components/ui/Select';
+import { useAuth } from '../../contexts/AuthContext';
+import * as authApi from '../../services/authApi';
+import type { RegistrationSettings, Role, UserRow } from '../../services/authApi';
+import { toast } from '../../utils/toast';
+
+// Accounts tab (task_02 auth, design per approved hub-auth slice):
+// "Your account" for every rank; user management + self-registration
+// settings render for admins only.
+
+const ROLE_OPTIONS: { value: Role; label: string }[] = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'operator', label: 'Operator' },
+  { value: 'viewer', label: 'Viewer' },
+];
+
+const ENABLED_OPTIONS = [
+  { value: 'enabled', label: 'Enabled' },
+  { value: 'disabled', label: 'Disabled' },
+];
+
+const MIN_PASSWORD_LENGTH = 8;
+
+const AccountsTab: React.FC = () => {
+  const { username, role, can } = useAuth();
+
+  // Your account - change password
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [pwBusy, setPwBusy] = useState(false);
+
+  // Users (admin)
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [registration, setRegistration] = useState<RegistrationSettings | null>(null);
+  const [resetUserId, setResetUserId] = useState<number | null>(null);
+  const [resetPassword, setResetPassword] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newUsername, setNewUsername] = useState('');
+  const [newUserPassword, setNewUserPassword] = useState('');
+  const [newUserRole, setNewUserRole] = useState<Role>('viewer');
+
+  const isAdmin = can('admin');
+  const adminCount = users.filter((u) => u.role === 'admin').length;
+
+  const reloadUsers = useCallback(async () => {
+    try {
+      setUsers(await authApi.listUsers());
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load users');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    reloadUsers();
+    authApi
+      .getRegistrationSettings()
+      .then(setRegistration)
+      .catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to load settings'));
+  }, [isAdmin, reloadUsers]);
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      toast.error('Passwords do not match');
+      return;
+    }
+    setPwBusy(true);
+    try {
+      await authApi.changePassword(currentPassword, newPassword);
+      toast.success('Password updated');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Password change failed');
+    } finally {
+      setPwBusy(false);
+    }
+  };
+
+  const handleRoleChange = async (user: UserRow, nextRole: Role) => {
+    if (nextRole === user.role) return;
+    try {
+      await authApi.updateUser(user.id, { role: nextRole });
+      toast.success(`${user.username} is now ${nextRole}`);
+      await reloadUsers();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Role change failed');
+    }
+  };
+
+  const handleResetPassword = async (user: UserRow) => {
+    if (resetPassword.length < MIN_PASSWORD_LENGTH) {
+      toast.error(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
+    try {
+      await authApi.updateUser(user.id, { password: resetPassword });
+      toast.success(`Password reset for ${user.username}`);
+      setResetUserId(null);
+      setResetPassword('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Password reset failed');
+    }
+  };
+
+  const handleDeleteUser = async (user: UserRow) => {
+    if (!window.confirm(`Delete user "${user.username}"? This cannot be undone.`)) return;
+    try {
+      await authApi.deleteUser(user.id);
+      toast.success(`${user.username} deleted`);
+      await reloadUsers();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Deletion failed');
+    }
+  };
+
+  const handleAddUser = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await authApi.createUser(newUsername, newUserPassword, newUserRole);
+      toast.success(`${newUsername} added as ${newUserRole}`);
+      setShowAddForm(false);
+      setNewUsername('');
+      setNewUserPassword('');
+      setNewUserRole('viewer');
+      await reloadUsers();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add user');
+    }
+  };
+
+  const handleRegistrationChange = async (changes: Partial<RegistrationSettings>) => {
+    try {
+      setRegistration(await authApi.updateRegistrationSettings(changes));
+      toast.success('Registration settings saved');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save settings');
+    }
+  };
+
+  return (
+    <div className="settings-section">
+      <h3 style={{ marginTop: 0 }}>Your account</h3>
+      <div className="signed-in-row">
+        <User size={16} /> Signed in as <strong>{username}</strong>{' '}
+        <span className="role-chip">{role}</span>
+      </div>
+      <form onSubmit={handleChangePassword}>
+        <div className="pw-grid">
+          <div className="form-group full">
+            <label htmlFor="pw-current">Current password</label>
+            <input
+              id="pw-current"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="pw-new">New password</label>
+            <input
+              id="pw-new"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              placeholder="At least 8 characters"
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="pw-confirm">Confirm new password</label>
+            <input
+              id="pw-confirm"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              required
+            />
+          </div>
+        </div>
+        <button type="submit" className="control-button pw-save" disabled={pwBusy}>
+          {pwBusy ? 'Updating...' : 'Update password'}
+        </button>
+      </form>
+
+      {isAdmin && (
+        <>
+          <h3>Users</h3>
+
+          <div className="registration-settings">
+            <div className="setting-item">
+              <div className="setting-info-wrapper">
+                <span className="setting-label">Account creation from the sign-in screen</span>
+                <span className="setting-description">
+                  Let anyone who can reach this Hub create their own account. Off by default.
+                </span>
+              </div>
+              <Select
+                value={registration ? (registration.enabled ? 'enabled' : 'disabled') : null}
+                options={ENABLED_OPTIONS}
+                onChange={(v) => handleRegistrationChange({ enabled: v === 'enabled' })}
+                ariaLabel="Account creation from the sign-in screen"
+                width={110}
+              />
+            </div>
+            <div className="setting-item">
+              <div className="setting-info-wrapper">
+                <span className="setting-label">New accounts start as</span>
+                <span className="setting-description">
+                  Role given to self-created accounts. An admin can promote them later.
+                </span>
+              </div>
+              <Select
+                value={registration?.default_role ?? null}
+                options={ROLE_OPTIONS}
+                onChange={(v) => handleRegistrationChange({ default_role: v })}
+                ariaLabel="Default role for new accounts"
+                width={110}
+              />
+            </div>
+          </div>
+
+          <p className="role-hint">
+            <span>
+              <b>Admin</b> - everything, including users and settings
+            </span>
+            <span>
+              <b>Operator</b> - controls fans and profiles
+            </span>
+            <span>
+              <b>Viewer</b> - read-only dashboard
+            </span>
+          </p>
+
+          <div className="user-rows">
+            {users.map((user) => {
+              const isSelf = user.username === username;
+              const lastAdmin = user.role === 'admin' && adminCount <= 1;
+              return (
+                <React.Fragment key={user.id}>
+                  <div className="user-row">
+                    <span className="u-name">
+                      <User size={15} /> {user.username}
+                      {isSelf && <span className="u-you">(you)</span>}
+                    </span>
+                    <Select
+                      value={user.role}
+                      options={ROLE_OPTIONS}
+                      onChange={(v) => handleRoleChange(user, v)}
+                      disabled={lastAdmin}
+                      ariaLabel={`Role for ${user.username}`}
+                      width={110}
+                    />
+                    <div className="row-actions">
+                      <button
+                        className="row-action"
+                        title="Reset password"
+                        onClick={() => {
+                          setResetPassword('');
+                          setResetUserId(resetUserId === user.id ? null : user.id);
+                        }}
+                      >
+                        <KeyRound size={15} />
+                      </button>
+                      <button
+                        className="row-action danger"
+                        title={lastAdmin ? 'Cannot delete the last admin' : 'Delete user'}
+                        disabled={lastAdmin}
+                        onClick={() => handleDeleteUser(user)}
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </div>
+                  {resetUserId === user.id && (
+                    <div className="user-row-reset">
+                      <input
+                        type="password"
+                        value={resetPassword}
+                        onChange={(e) => setResetPassword(e.target.value)}
+                        placeholder={`New password for ${user.username} (at least 8 characters)`}
+                        autoFocus
+                      />
+                      <button
+                        className="control-button"
+                        onClick={() => handleResetPassword(user)}
+                      >
+                        Save
+                      </button>
+                      <button
+                        className="add-user-cancel"
+                        onClick={() => {
+                          setResetUserId(null);
+                          setResetPassword('');
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </div>
+
+          {!showAddForm ? (
+            <button className="add-user-btn" onClick={() => setShowAddForm(true)}>
+              <Plus size={14} /> Add user
+            </button>
+          ) : (
+            <form className="add-user-form" onSubmit={handleAddUser}>
+              <div className="form-grid">
+                <div className="form-group">
+                  <label htmlFor="new-user-name">Username</label>
+                  <input
+                    id="new-user-name"
+                    type="text"
+                    value={newUsername}
+                    onChange={(e) => setNewUsername(e.target.value)}
+                    autoComplete="off"
+                    required
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="new-user-pw">Password</label>
+                  <input
+                    id="new-user-pw"
+                    type="password"
+                    value={newUserPassword}
+                    onChange={(e) => setNewUserPassword(e.target.value)}
+                    autoComplete="new-password"
+                    placeholder="At least 8 characters"
+                    required
+                  />
+                </div>
+                <div className="form-group">
+                  <label id="new-user-role">Role</label>
+                  <Select
+                    value={newUserRole}
+                    options={ROLE_OPTIONS}
+                    onChange={setNewUserRole}
+                    ariaLabel="Role for the new user"
+                    width="100%"
+                  />
+                </div>
+              </div>
+              <div className="add-user-actions">
+                <button type="submit" className="control-button">
+                  Add user
+                </button>
+                <button
+                  type="button"
+                  className="add-user-cancel"
+                  onClick={() => setShowAddForm(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default AccountsTab;

--- a/frontend/src/settings/components/Settings.tsx
+++ b/frontend/src/settings/components/Settings.tsx
@@ -10,6 +10,8 @@ import { setLicense, getPricing, deleteLicense, getSystems, getDiagnostics } fro
 import { formatDate, formatFriendlyDate, USER_TIMEZONE } from '../../utils/formatters';
 import { toast } from '../../utils/toast';
 import { useDemoMode } from '../../hooks/useDemoMode';
+import { useAuth } from '../../contexts/AuthContext';
+import AccountsTab from './AccountsTab';
 import ColorPicker from './ColorPicker';
 import ThresholdStrip from './ThresholdStrip';
 import {
@@ -84,7 +86,7 @@ const GRAPH_SCALE_MAX_HOURS = 720; // 30 days
 const PANKHA_SITE = 'https://pankha.app';
 const GITHUB_REPO = 'https://github.com/Anexgohan/pankha';
 
-type SettingsTab = 'general' | 'license' | 'diagnostics' | 'about';
+type SettingsTab = 'general' | 'license' | 'accounts' | 'diagnostics' | 'about';
 
 interface TierPricing {
   name: string;
@@ -827,9 +829,24 @@ const AboutTab: React.FC = () => {
   );
 };
 
-const Settings: React.FC = () => {
+interface SettingsProps {
+  // Deep link from the header user menu; fresh object per click
+  requestedTab?: { tab: SettingsTab } | null;
+}
+
+const Settings: React.FC<SettingsProps> = ({ requestedTab = null }) => {
   const { isDemoMode } = useDemoMode();
-  const [activeTab, setActiveTab] = useState<SettingsTab>('general');
+  const { can } = useAuth();
+  // General and Subscription hold hub-wide settings (admin domain);
+  // everyone else lands on their own Accounts tab
+  const [activeTab, setActiveTab] = useState<SettingsTab>(can('admin') ? 'general' : 'accounts');
+
+  useEffect(() => {
+    if (requestedTab) {
+      setActiveTab(requestedTab.tab);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestedTab]);
   const { license, isLoading, refreshLicense } = useLicense();
   const [licenseKey, setLicenseKey] = useState('');
   const [licenseStatus, setLicenseStatus] = useState<{ success: boolean; message: string } | null>(null);
@@ -1487,13 +1504,15 @@ const Settings: React.FC = () => {
   return (
     <div className="settings-container">
       <nav className="settings-tabs">
-        <button
-          className={`settings-tab ${activeTab === 'general' ? 'active' : ''}`}
-          onClick={() => setActiveTab('general')}
-        >
-          General
-        </button>
-        {!isDemoMode && (
+        {can('admin') && (
+          <button
+            className={`settings-tab ${activeTab === 'general' ? 'active' : ''}`}
+            onClick={() => setActiveTab('general')}
+          >
+            General
+          </button>
+        )}
+        {!isDemoMode && can('admin') && (
           <button
             className={`settings-tab ${activeTab === 'license' ? 'active' : ''}`}
             onClick={() => setActiveTab('license')}
@@ -1501,6 +1520,12 @@ const Settings: React.FC = () => {
             Subscription
           </button>
         )}
+        <button
+          className={`settings-tab ${activeTab === 'accounts' ? 'active' : ''}`}
+          onClick={() => setActiveTab('accounts')}
+        >
+          Accounts
+        </button>
         <button
           className={`settings-tab ${activeTab === 'diagnostics' ? 'active' : ''}`}
           onClick={() => setActiveTab('diagnostics')}
@@ -1516,8 +1541,11 @@ const Settings: React.FC = () => {
       </nav>
 
       <div className="settings-content">
+        {/* Accounts Tab */}
+        {activeTab === 'accounts' && <AccountsTab />}
+
         {/* General Tab */}
-        {activeTab === 'general' && (
+        {activeTab === 'general' && can('admin') && (
           <div className="settings-section">
             <h2>General</h2>
             <p className="settings-info">
@@ -2128,7 +2156,7 @@ const Settings: React.FC = () => {
     )}
 
         {/* License/Subscription Tab */}
-        {!isDemoMode && activeTab === 'license' && (
+        {!isDemoMode && activeTab === 'license' && can('admin') && (
           <div className="settings-section">
             <h2>Subscription</h2>
             

--- a/frontend/src/settings/styles/settings.css
+++ b/frontend/src/settings/styles/settings.css
@@ -3484,3 +3484,240 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ===================================
+   Accounts tab (task_02 auth, design per approved hub-auth slice)
+   =================================== */
+
+.signed-in-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-lg);
+}
+
+.signed-in-row svg {
+  color: var(--text-tertiary);
+}
+
+.role-chip {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--font-weight-semibold);
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-info) 50%, transparent);
+  color: var(--color-info);
+}
+
+/* Registration setting rows reuse .setting-item (label left, control right) */
+.registration-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+}
+
+.user-rows {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.user-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-panels_01);
+  border-bottom: 1px solid var(--border-color);
+  font-size: var(--font-size-base);
+}
+
+.user-row:last-child {
+  border-bottom: none;
+}
+
+.user-row .u-name {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-weight: var(--font-weight-medium);
+  min-width: 0;
+}
+
+.user-row .u-name svg {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.user-row .u-you {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+}
+
+.user-row .pk-select-trigger {
+  min-width: 96px;
+}
+
+.row-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.row-action {
+  background: transparent;
+  border: none;
+  padding: 5px;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.row-action:hover:not(:disabled) {
+  color: var(--color-info);
+  background: color-mix(in srgb, var(--color-info) 8%, transparent);
+}
+
+.row-action.danger:hover:not(:disabled) {
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 8%, transparent);
+}
+
+.row-action:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* Inline password-reset strip under a user row */
+.user-row-reset {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-panels_02);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.user-row-reset input {
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm2);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: inherit;
+}
+
+.user-row-reset input:focus {
+  outline: none;
+  border-color: var(--color-info);
+}
+
+.user-row-reset .control-button {
+  padding: var(--spacing-xs) var(--spacing-lg);
+}
+
+.add-user-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--spacing-md);
+  background: transparent;
+  color: var(--color-info);
+  border: 1px dashed color-mix(in srgb, var(--color-info) 45%, transparent);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm2);
+  font-weight: var(--font-weight-medium);
+}
+
+.add-user-btn:hover {
+  border-style: solid;
+}
+
+.add-user-form {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--bg-panels_01);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+}
+
+.add-user-form .form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 130px;
+  gap: var(--spacing-md);
+  align-items: end;
+}
+
+.add-user-form .form-group {
+  margin-bottom: 0;
+}
+
+.add-user-form .form-group label {
+  font-size: var(--font-size-sm2);
+}
+
+.add-user-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.add-user-actions .control-button {
+  padding: var(--spacing-xs) var(--spacing-lg);
+}
+
+.add-user-cancel {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-xs) var(--spacing-lg);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-base);
+}
+
+.role-hint {
+  display: flex;
+  gap: var(--spacing-lg);
+  flex-wrap: wrap;
+  margin: 0 0 var(--spacing-md);
+}
+
+.role-hint span {
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+}
+
+.role-hint b {
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.pw-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 var(--spacing-lg);
+  max-width: 560px;
+}
+
+.pw-grid .full {
+  grid-column: 1 / -1;
+}
+
+.pw-save {
+  padding: var(--spacing-sm) var(--spacing-xl);
+}

--- a/frontend/src/styles/base/responsive.css
+++ b/frontend/src/styles/base/responsive.css
@@ -72,10 +72,6 @@
     min-width: 0 !important;
   }
 
-  .emergency-button .btn-label {
-    display: none; /* Hide text on mobile */
-  }
-
   .theme-toggle {
     grid-column: 3; /* Right column */
     width: 42px;

--- a/frontend/src/styles/components/auth.css
+++ b/frontend/src/styles/components/auth.css
@@ -1,0 +1,151 @@
+/* ===================================
+   Pankha Design System - Authentication Pages
+   Login and first-run setup (App-level, outside any page directory).
+   Design per the approved hub-auth vertical slice (task_02 D16).
+   Related styles live with their pages: pending card in
+   systems/components/PendingAgentCard.css, Accounts tab in
+   settings/styles/settings.css, unsecured badge in badges.css.
+   =================================== */
+
+/* Full viewport, centered card */
+.auth-shell {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xl);
+}
+
+.auth-card {
+  width: 360px;
+  max-width: 100%;
+  padding: var(--spacing-2xl);
+}
+
+.auth-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+}
+
+.auth-brand-fan {
+  color: var(--color-info);
+}
+
+.auth-brand-name {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.05;
+}
+
+.auth-brand-name strong {
+  font-size: 22px;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.01em;
+}
+
+.auth-brand-name span {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.auth-heading {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+.auth-subtext {
+  margin: 0 0 var(--spacing-xl);
+  font-size: var(--font-size-sm2);
+  color: var(--text-tertiary);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.auth-submit {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  font-size: var(--font-size-base);
+}
+
+.password-wrap {
+  position: relative;
+}
+
+.password-wrap input {
+  padding-right: 38px;
+}
+
+.password-eye {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+}
+
+.password-eye:hover {
+  color: var(--text-secondary);
+}
+
+.auth-error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-error) 45%, transparent);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm2);
+  color: var(--text-secondary);
+}
+
+.auth-error svg {
+  color: var(--color-error);
+  flex-shrink: 0;
+}
+
+/* Login footer link (shown only when self-registration is enabled) */
+.auth-alt {
+  margin-top: var(--spacing-lg);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+  font-size: var(--font-size-sm2);
+  color: var(--text-tertiary);
+}
+
+.auth-alt a {
+  color: var(--color-info);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.auth-alt a:hover {
+  text-decoration: underline;
+}
+
+/* Full-page loading while the auth state is first fetched */
+.auth-loading {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -18,6 +18,7 @@
 @import './components/buttons.css';
 @import './components/forms.css';
 @import './components/badges.css';
+@import './components/auth.css';
 
 /* 4. Page-Specific Styles */
 /* Systems Monitor Page */

--- a/frontend/src/systems/components/PendingAgentCard.css
+++ b/frontend/src/systems/components/PendingAgentCard.css
@@ -1,0 +1,86 @@
+/* Pending-approval card (D13): defanged system card, amber identity.
+   Metadata only - no gauges or controls until the admin approves. */
+
+.pending-card {
+  border-left: 4px solid var(--color-warning);
+}
+
+.pending-name {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+}
+
+.pending-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: var(--spacing-md) 0 var(--spacing-lg);
+}
+
+.pending-meta-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm2);
+}
+
+.pending-meta-row .k {
+  color: var(--text-tertiary);
+  min-width: 92px;
+  flex-shrink: 0;
+}
+
+.pending-meta-row .v {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+}
+
+.pending-reason {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--temp-caution-bg);
+  border: 1px solid color-mix(in srgb, var(--temp-caution-border) 50%, transparent);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--temp-caution-text);
+}
+
+.pending-reason svg {
+  flex-shrink: 0;
+}
+
+.pending-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}
+
+.pending-actions .control-button {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.pending-dismiss {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-weight: var(--font-weight-medium);
+}
+
+.pending-dismiss:hover {
+  border-color: var(--color-error);
+  color: var(--color-error);
+}

--- a/frontend/src/systems/components/PendingAgentCard.tsx
+++ b/frontend/src/systems/components/PendingAgentCard.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Check, X, ShieldQuestion } from 'lucide-react';
+import type { PendingAgent } from '../../services/authApi';
+import { approvePendingAgent, dismissPendingAgent } from '../../services/authApi';
+import { toast } from '../../utils/toast';
+import './PendingAgentCard.css';
+
+// Defanged card for an agent awaiting admin approval (D13): registration
+// metadata only - no telemetry flows until approved. The card disappears via
+// the agentPendingRemoved broadcast after either action.
+
+interface PendingAgentCardProps {
+  agent: PendingAgent;
+}
+
+function timeAgo(iso: string): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return 'moments ago';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+}
+
+const PendingAgentCard: React.FC<PendingAgentCardProps> = ({ agent }) => {
+  const [busy, setBusy] = useState(false);
+
+  const handleApprove = async () => {
+    setBusy(true);
+    try {
+      await approvePendingAgent(agent.agentId);
+      toast.success(`${agent.name} approved`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Approval failed');
+      setBusy(false);
+    }
+  };
+
+  const handleDismiss = async () => {
+    setBusy(true);
+    try {
+      await dismissPendingAgent(agent.agentId);
+      toast.success(`${agent.name} dismissed - it may reappear when the agent reconnects`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Dismissal failed');
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="system-card pending-card">
+      <div className="system-header">
+        <div className="system-title">
+          <div className="system-title-top">
+            <span className="pending-name">{agent.name}</span>
+            <div className="status-group">
+              <span className="status-badge read-only">
+                <span className="status-dot"></span>Pending approval
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="pending-reason">
+        <ShieldQuestion size={15} /> {agent.reason}
+      </div>
+
+      <div className="pending-meta">
+        <div className="pending-meta-row">
+          <span className="k">Agent ID</span>
+          <span className="v">{agent.agentId}</span>
+        </div>
+        {agent.ip && (
+          <div className="pending-meta-row">
+            <span className="k">Address</span>
+            <span className="v">{agent.ip}</span>
+          </div>
+        )}
+        {(agent.platform || agent.agentType) && (
+          <div className="pending-meta-row">
+            <span className="k">Platform</span>
+            <span className="v">
+              {agent.platform ?? 'unknown'}
+              {agent.agentType ? ` (${agent.agentType})` : ''}
+            </span>
+          </div>
+        )}
+        {agent.version && (
+          <div className="pending-meta-row">
+            <span className="k">Version</span>
+            <span className="v">{agent.version}</span>
+          </div>
+        )}
+        <div className="pending-meta-row">
+          <span className="k">Requested</span>
+          <span className="v">{timeAgo(agent.requestedAt)}</span>
+        </div>
+      </div>
+
+      <div className="pending-actions">
+        <button className="control-button" onClick={handleApprove} disabled={busy}>
+          <Check size={15} /> Approve
+        </button>
+        <button className="pending-dismiss" onClick={handleDismiss} disabled={busy}>
+          <X size={15} /> Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PendingAgentCard;

--- a/frontend/src/systems/components/SystemCard.tsx
+++ b/frontend/src/systems/components/SystemCard.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../services/api";
 import type { SystemCalibrations } from "../../services/api";
 import { useVisibility } from "../../contexts/VisibilityContext";
+import { useAuth } from "../../contexts/AuthContext";
 import {
   getFanProfiles,
   assignProfileToFan,
@@ -1168,10 +1169,18 @@ const SystemCard: React.FC<SystemCardProps> = ({
   const sensorSelectGroups = buildSensorOptions(sensorOptionInputs);
   const bulkSensorGroups = buildSensorOptions({ ...sensorOptionInputs, emptyLabel: "Don't change" });
 
-  // Helper to check if agent is read-only (over license limit OR IPMI without profile)
+  // Helper to check if agent is read-only (over license limit, IPMI without
+  // profile, or the signed-in user is a Viewer - same disabled rendering path)
+  const { can } = useAuth();
+  const isViewerLocked = !can('operator');
+  // Unsecured takes priority in the single status-badge slot (same layering
+  // as status-indicator health-warn/ok)
+  const isUnsecured = system.unsecured === true;
   const isIpmiNoProfile = (system.agent_type === 'ipmi_host' || system.agent_type === 'ipmi_network') && !system.profile_id && system.status === 'online';
-  const isReadOnly = system.read_only === true || isIpmiNoProfile;
-  const readOnlyTooltip = isIpmiNoProfile
+  const isReadOnly = system.read_only === true || isIpmiNoProfile || isViewerLocked;
+  const readOnlyTooltip = isViewerLocked
+    ? "Viewer accounts can watch but not control. Ask an admin for operator access."
+    : isIpmiNoProfile
     ? "Monitor-only mode\nAssign a Profile to enable fan control from Deployment"
     : "This system exceeds your license limit. Upgrade to control this agent. You can still view data.";
 
@@ -1273,15 +1282,17 @@ const SystemCard: React.FC<SystemCardProps> = ({
           <div className="system-title-top">
             <div className="status-group">
               <span
-                className={`status-badge ${isIpmiNoProfile ? 'read-only' : system.status}`}
-                title={isIpmiNoProfile
+                className={`status-badge ${isUnsecured ? 'offline' : isIpmiNoProfile ? 'read-only' : system.status}`}
+                title={isUnsecured
+                  ? "Runs without an auth token - update the agent to secure it"
+                  : isIpmiNoProfile
                   ? "Monitor-only mode\nAssign a Profile to enable fan control from Deployment"
                   : system.status === 'error' && system.last_error
                     ? `Agent status is currently "ERROR"\n\nReason: ${system.last_error}`
                     : `Agent status is currently "${system.status.toUpperCase()}"`}
               >
                 <span className="status-dot" />
-                {isIpmiNoProfile ? 'read only' : system.status}
+                {isUnsecured ? 'unsecured' : isIpmiNoProfile ? 'read only' : system.status}
               </span>
               {getPlatformIcon()}
             </div>
@@ -1292,6 +1303,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <LockIcon size={14} />
                 </span>
               )}
+              {can('admin') && (
               <button
                 className="delete-button"
                 onClick={handleDeleteSystem}
@@ -1304,6 +1316,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
                   <X size={14} />
                 )}
               </button>
+              )}
             </div>
           </div>
 
@@ -2242,6 +2255,7 @@ export default React.memo(SystemCard, (prevProps, nextProps) => {
     prevProps.system.enable_fan_control ===
       nextProps.system.enable_fan_control &&
     prevProps.system.read_only === nextProps.system.read_only && // License limit status
+    prevProps.system.unsecured === nextProps.system.unsecured && // Auth token status badge
     prevProps.system.profile_id === nextProps.system.profile_id && // IPMI profile assignment
     // Explicit sensor/fan array checks (reference equality works because mergeDelta creates new arrays)
     prevProps.system.current_temperatures ===

--- a/frontend/src/systems/components/SystemsPage.tsx
+++ b/frontend/src/systems/components/SystemsPage.tsx
@@ -399,6 +399,7 @@ const SystemsPage: React.FC = () => {
         {activeTab === 'deployment' && (
           <DeploymentPage
             systems={systems}
+            pendingAgents={pendingAgents}
             latestVersion={latestVersion}
             unstableVersion={unstableVersion}
             stableReleases={stableReleases}

--- a/frontend/src/systems/components/SystemsPage.tsx
+++ b/frontend/src/systems/components/SystemsPage.tsx
@@ -9,21 +9,41 @@ import FanProfileManager from '../../fan-profiles/components/FanProfileManager';
 import Settings from '../../settings/components/Settings';
 import { useWebSocketData } from '../../hooks/useWebSocketData';
 import { useDemoMode } from '../../hooks/useDemoMode';
+import { useAuth } from '../../contexts/AuthContext';
 import HeaderFan from '../../components/HeaderFan';
-import { 
-  Loader2, 
-  Unplug, 
-  CircleAlert, 
-  ShieldAlert, 
-  Monitor, 
-  Wind, 
+import PendingAgentCard from './PendingAgentCard';
+import { Select, type SelectOption } from '../../components/ui/Select';
+import {
+  Loader2,
+  Unplug,
+  CircleAlert,
+  ShieldAlert,
+  Monitor,
+  Wind,
   Settings2,
   ChevronRight,
-  Command
+  Command,
+  LogOut,
+  User,
+  TriangleAlert
 } from 'lucide-react';
 import DeploymentPage from '../../deployment/components/DeploymentPage';
 
 type TabType = 'systems' | 'profiles' | 'deployment' | 'settings';
+type SettingsTabName = 'general' | 'license' | 'accounts' | 'diagnostics' | 'about';
+
+// Header user menu: action list, not a value picker - value stays null
+type UserMenuAction = 'account' | 'settings' | 'logout';
+const USER_MENU_OPTIONS: SelectOption<UserMenuAction>[] = [
+  { value: 'account', label: 'Account' },
+  { value: 'settings', label: 'Settings' },
+  { value: 'logout', label: 'Log out' },
+];
+const USER_MENU_ICONS: Record<UserMenuAction, React.ReactNode> = {
+  account: <User size={15} />,
+  settings: <Settings2 size={15} />,
+  logout: <LogOut size={15} />,
+};
 
 // Stable empty slices for agents with no calibration/stall events yet.
 // Must be module-level: an inline `?? {}` would mint a new object per render
@@ -41,6 +61,9 @@ const SystemsPage: React.FC = () => {
   const [expandedSensors, setExpandedSensors] = useState<{[systemId: number]: boolean}>({});
   const [expandedFans, setExpandedFans] = useState<{[systemId: number]: boolean}>({});
   const [expandedBmc, setExpandedBmc] = useState<{[systemId: number]: boolean}>({});
+  // Deep link into Settings from the user menu (fresh object per click so
+  // Settings' effect re-fires even for the same tab)
+  const [settingsIntent, setSettingsIntent] = useState<{ tab: SettingsTabName } | null>(null);
 
   // Pure WebSocket - no HTTP polling!
   const {
@@ -51,9 +74,11 @@ const SystemsPage: React.FC = () => {
     reconnect,
     removeSystem,
     fanCalibration,
-    stalledFans
+    stalledFans,
+    pendingAgents
   } = useWebSocketData();
   const { isDemoMode } = useDemoMode();
+  const { can, username, logout, authResetActive } = useAuth();
 
   // Fetch versions from GitHub API
   React.useEffect(() => {
@@ -232,18 +257,57 @@ const SystemsPage: React.FC = () => {
             )}
           </div>
 
-          <ControllerIntervalSelector />
+          {can('admin') && <ControllerIntervalSelector />}
           <ThemeToggle />
 
-          <button
-            onClick={handleEmergencyStop}
-            className="emergency-button"
-            title="Emergency stop all fans"
-          >
-            <ShieldAlert size={18} /> <span className="btn-label">Emergency Stop</span>
-          </button>
+          {can('operator') && (
+            <button
+              onClick={handleEmergencyStop}
+              className="emergency-button"
+              title="Emergency stop all fans"
+            >
+              <ShieldAlert size={18} />
+            </button>
+          )}
+
+          <Select<UserMenuAction>
+            value={null}
+            options={USER_MENU_OPTIONS}
+            onChange={(action) => {
+              if (action === 'logout') {
+                logout();
+              } else {
+                // Non-admins have no General tab; Settings lands them on Accounts
+                setSettingsIntent({
+                  tab: action === 'account' || !can('admin') ? 'accounts' : 'general',
+                });
+                setActiveTab('settings');
+              }
+            }}
+            className="user-menu-trigger"
+            menuClassName="user-menu-list"
+            align="end"
+            ariaLabel={`Account menu (${username ?? ''})`}
+            renderTrigger={() => <User size={20} />}
+            renderOption={(opt) => (
+              <span className="user-menu-item">
+                {USER_MENU_ICONS[opt.value]} {opt.label}
+              </span>
+            )}
+          />
         </div>
       </header>
+
+      {authResetActive && can('admin') && (
+        <div className="reset-banner">
+          <TriangleAlert size={16} />
+          <span>
+            <strong>PANKHA_AUTH_RESET is active.</strong>&nbsp;User accounts are wiped on
+            every restart. Remove <code>PANKHA_AUTH_RESET</code> from your .env now that
+            access is recovered.
+          </span>
+        </div>
+      )}
 
       <nav className="dashboard-nav">
         <div className="nav-tabs">
@@ -253,18 +317,22 @@ const SystemsPage: React.FC = () => {
           >
             <Monitor size={16} /> Systems Monitor
           </button>
-          <button
-            className={`nav-tab ${activeTab === 'profiles' ? 'active' : ''}`}
-            onClick={() => setActiveTab('profiles')}
-          >
-            <Wind size={16} /> Fan Profiles
-          </button>
-          <button
-            className={`nav-tab ${activeTab === 'deployment' ? 'active' : ''}`}
-            onClick={() => setActiveTab('deployment')}
-          >
-            <Command size={16} /> Deployment
-          </button>
+          {can('operator') && (
+            <button
+              className={`nav-tab ${activeTab === 'profiles' ? 'active' : ''}`}
+              onClick={() => setActiveTab('profiles')}
+            >
+              <Wind size={16} /> Fan Profiles
+            </button>
+          )}
+          {can('admin') && (
+            <button
+              className={`nav-tab ${activeTab === 'deployment' ? 'active' : ''}`}
+              onClick={() => setActiveTab('deployment')}
+            >
+              <Command size={16} /> Deployment
+            </button>
+          )}
           <button
             className={`nav-tab ${activeTab === 'settings' ? 'active' : ''}`}
             onClick={() => setActiveTab('settings')}
@@ -281,7 +349,10 @@ const SystemsPage: React.FC = () => {
       <div className="dashboard-content">
         {activeTab === 'systems' && (
           <div className="systems-grid">
-            {systems.length === 0 ? (
+            {pendingAgents.map(agent => (
+              <PendingAgentCard key={agent.agentId} agent={agent} />
+            ))}
+            {systems.length === 0 && pendingAgents.length === 0 ? (
               <div className="no-systems-redirect-card">
                 <div className="card-header">
                   <ShieldAlert size={24} className="alert-icon" />
@@ -336,7 +407,7 @@ const SystemsPage: React.FC = () => {
         )}
 
         {activeTab === 'settings' && (
-          <Settings />
+          <Settings requestedTab={settingsIntent} />
         )}
       </div>
 

--- a/frontend/src/systems/styles/dashboard.css
+++ b/frontend/src/systems/styles/dashboard.css
@@ -92,6 +92,8 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-lg);
+  margin-left: auto; /* keep the cluster on the right side of the header */
+  margin-right: var(--spacing-xl); /* breathing room from the right edge */
 }
 
 .connection-status {
@@ -307,4 +309,88 @@
 
 .no-data p {
   margin-bottom: var(--spacing-xs);
+}
+
+/* PANKHA_AUTH_RESET warning - red family, mirrors the license seat-lost
+   banner. Pinned above the dashboard for admins while the flag is set. */
+.reset-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm2);
+  color: var(--text-secondary);
+}
+
+.reset-banner svg {
+  color: var(--color-error);
+  flex-shrink: 0;
+}
+
+.reset-banner strong {
+  color: var(--color-error);
+}
+
+.reset-banner code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  background: var(--bg-tertiary);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+/* Header user menu - Select consumer with a scoped trigger rule. The
+   trigger must read as a sibling of .theme-toggle in EVERY state, so the
+   Select's own open/focus accents (blue ring, filled bg) are quieted. */
+.header-controls .user-menu-trigger {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-circle);
+  border: 2px solid var(--border-color);
+  background: none;
+  color: var(--text-primary);
+  justify-content: center;
+  padding: 0;
+}
+
+.header-controls .user-menu-trigger .pk-select-value {
+  flex: none; /* keep the icon centered, not stretched */
+}
+
+.header-controls .user-menu-trigger::after {
+  display: none; /* no chevron on the icon button */
+}
+
+.header-controls .user-menu-trigger:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--color-info);
+  transform: scale(1.05);
+}
+
+/* Open/focused: same quiet treatment as the neighbors' hover - no blue
+   ring, no fill (overrides pk-select-trigger[aria-expanded] + focus) */
+.header-controls .user-menu-trigger:focus-visible,
+.header-controls .user-menu-trigger[aria-expanded="true"] {
+  border-color: var(--color-info);
+  box-shadow: none;
+  background: var(--bg-hover);
+}
+
+/* No min-width here: Select measures the menu before applying its inline
+   minWidth, so a class min-width skews the align-end position. Row padding
+   gives the menu its comfortable width instead. */
+.user-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding-right: var(--spacing-2xl);
+}
+
+.user-menu-item svg {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -29,6 +29,7 @@ export interface SystemData {
   // License limit fields
   read_only?: boolean; // Agent is over license limit (can view but not control)
   access_status?: "active" | "over_limit";
+  unsecured?: boolean; // Agent has no auth token yet (grandfathered pre-auth binary)
   last_error?: string | null;
   system_health?: {
     cpuUsage: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,15 +24,18 @@
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.18.1",
         "compression": "^1.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "jose": "^5.10.0",
         "pg": "^8.13.1",
         "uuid": "^14.0.0",
         "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/compression": "^1.8.1",
+        "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.19",
         "@types/dotenv": "^6.1.1",
         "@types/express": "^5.0.3",
@@ -1638,6 +1641,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -2846,6 +2859,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -4366,6 +4398,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",


### PR DESCRIPTION
**Login, roles, and agent authentication**

Pankha's dashboard and API now sit behind a login. First start opens a setup screen to create the admin account; after that, users sign in with one of three roles - Viewer (watch), Operator (fan control), Admin (everything, including user management in Settings).

The REST API requires an authenticated session, with access classified per route: public health checks, viewer-level reads, operator-level mutations, and admin-only provisioning. Sessions are httpOnly cookies with a sliding duration.

Agents authenticate with per-machine tokens. Install scripts enroll automatically via a one-time token (valid 24 hours); everything else - fresh manual installs, agents from older builds, unknown machines - appears as a pending-approval card on the dashboard instead of registering silently. The admin decides what joins the fleet. Approved agents receive their token over the existing WebSocket channel and reconnect silently from then on. Fleet Maintenance shows held agents as "pending approval" rather than misreporting them offline.

Supporting changes:

- New environment variables for deployments: reverse-proxy allowlist (`PANKHA_TRUST_PROXY`, now a comma-separated IP/CIDR list), session duration, admin reset - documented on the new "Docker and Env" wiki page, with strict validation and clear boot-time errors for critical values.
- CI now compiles the Windows agent on every PR, builds Docker images for both amd64 and arm64, and uses clearer job names.
- API Reference wiki page updated with authentication, roles, and cookie-based examples.