### PR TITLE
Feature: Approve & Update one-click migration for older agents.

### DIFF
--- a/.github/input/release-notes.md
+++ b/.github/input/release-notes.md
@@ -15,13 +15,15 @@
 
 ## Highlights
 
-<!-- Lead with 1-3 big things. Example:
-- **IPMI Support (Alpha)**: Pankha now talks to /dev/ipmi0 on enterprise BMC servers.
-  Currently supports Supermicro and Dell; HP is read-only. -->
+- **Login and user accounts**: The dashboard now sits behind a login. Three roles - Viewer (watch), Operator (control fans), Admin (everything) - with user management in Settings. First start opens a setup screen to create the admin account.
+- **Agent security**: Agents authenticate with per-machine tokens. New machines appear as approval cards on the dashboard instead of registering silently - you decide what joins your fleet.
+- **Approve & Update**: Approving an agent that runs an older build also updates it, in the same click. The agent upgrades itself from the Hub cache, reconnects, and is secured automatically.
 
 ## Breaking Changes
 
-<!-- List behaviour changes for existing users. If none, write "None" or delete this section. -->
+- **The REST API now requires login.** Anything that calls the API directly (scripts, curl, integrations) must authenticate first and send the session cookie. Cookie-based examples are in the [API Reference](https://github.com/Anexgohan/pankha/wiki/API-Reference).
+- **Existing agents need a one-time approval after this upgrade.** They will appear as pending approval cards. Stage this release's binaries in Fleet Maintenance first, then click Approve & Update on each Linux/IPMI agent - it updates and secures itself in one step. Windows agents: install the new MSI on the machine, then approve.
+- **Install scripts expire after 24 hours.** A script generated before this upgrade (or older than a day) will not enroll new agents - generate a fresh one from the Deployment page.
 
 ## Screenshots
 
@@ -29,4 +31,5 @@
 
 ## Notes
 
-<!-- Migration steps, known issues, anything else worth calling out. -->
+- New optional environment variables (reverse-proxy allowlist, session duration, admin reset) are documented on the [Docker and Env](https://github.com/Anexgohan/pankha/wiki/Docker-and-Env) wiki page. Note that `PANKHA_TRUST_PROXY` is now a comma-separated list of proxy IPs/CIDRs.
+- Deleting a system on the dashboard no longer uninstalls anything on the machine; a still-running agent simply reappears as a pending card.

--- a/agents/clients/linux/rust/src/websocket/client.rs
+++ b/agents/clients/linux/rust/src/websocket/client.rs
@@ -526,7 +526,7 @@ impl WebSocketClient {
                     }
                 }
                 "registrationPending" => {
-                    // Hub is holding this agent for admin approval (D13).
+                    // Hub is holding this agent for admin approval.
                     // Keep the connection; the Hub promotes us with a
                     // "registered" message once approved. Telemetry we send
                     // meanwhile is ignored Hub-side.

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/websocket/client.rs
@@ -490,7 +490,7 @@ impl WebSocketClient {
                     }
                 }
                 "registrationPending" => {
-                    // Hub is holding this agent for admin approval (D13).
+                    // Hub is holding this agent for admin approval.
                     // Keep the connection; the Hub promotes us with a
                     // "registered" message once approved. Telemetry we send
                     // meanwhile is ignored Hub-side.

--- a/agents/clients/windows/varient-c/Core/WebSocketClient.cs
+++ b/agents/clients/windows/varient-c/Core/WebSocketClient.cs
@@ -464,7 +464,7 @@ public class WebSocketClient : IDisposable
                     break;
 
                 case "registrationPending":
-                    // Hub is holding this agent for admin approval (D13). Keep
+                    // Hub is holding this agent for admin approval. Keep
                     // the connection; the Hub promotes us with "registered"
                     // once approved. Telemetry sent meanwhile is ignored.
                     var pendingJson = Newtonsoft.Json.Linq.JObject.Parse(json);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -40,7 +40,7 @@ type AccessClass = 'public' | 'deploy-token' | 'agent-token' | Role;
 const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
   // Auth bootstrap + boot-time frontend config (login page needs these).
   // register is public here; the route itself enforces the admin's
-  // self-registration toggle (D15)
+  // self-registration toggle
   { pattern: /^POST \/auth\/(login|logout|setup|register)$/, access: 'public' },
   { pattern: /^GET \/auth\/me$/, access: 'public' },
   { pattern: /^GET \/config\/deployment(\.js)?$/, access: 'public' },
@@ -67,7 +67,7 @@ const ACCESS_RULES: Array<{ pattern: RegExp; access: AccessClass }> = [
   { pattern: /^POST \/deploy\/profiles\/custom$/, access: 'admin' },
   { pattern: /^POST \/systems\/\d+\/update$/, access: 'admin' },
   { pattern: /^DELETE \/systems\/\d+$/, access: 'admin' },
-  // Pending-approval queue (D13): admitting machines is admin territory
+  // Pending-approval queue: admitting machines is admin territory
   { pattern: /^(GET|POST|DELETE) \/systems\/pending(\/|$)/, access: 'admin' },
   { pattern: /^(POST|DELETE) \/license$/, access: 'admin' },
   { pattern: /^POST \/license\/(sync|renew|cancel|checkout)$/, access: 'admin' },

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -23,7 +23,7 @@ const MIN_PASSWORD_LENGTH = 8;
 // Fixed delay on failed logins to slow guessing
 const FAIL_DELAY_MS = 500;
 
-// Self-registration settings (D15), stored in backend_settings.
+// Self-registration settings, stored in backend_settings.
 // Off by default: open registration on a LAN would undo the auth feature.
 const REG_ENABLED_KEY = 'auth_self_registration';
 const REG_ROLE_KEY = 'auth_default_role';

--- a/backend/src/routes/systems.ts
+++ b/backend/src/routes/systems.ts
@@ -402,7 +402,7 @@ router.put("/controller/interval", async (req: Request, res: Response) => {
   }
 });
 
-// GET /api/systems/pending - Agents held for admin approval (D13)
+// GET /api/systems/pending - Agents held for admin approval
 router.get("/pending", (_req: Request, res: Response) => {
   res.json(WebSocketHub.getInstance().getPendingAgents());
 });

--- a/backend/src/services/CalibrationService.ts
+++ b/backend/src/services/CalibrationService.ts
@@ -318,7 +318,7 @@ export class CalibrationService extends EventEmitter {
         for (const u of active) u.curve.push({ duty, rpm: rpms.get(u.target) ?? 0 });
 
         if (duty === 100) {
-          // Tach check: no reading at full duty -> no usable tach (design D11)
+          // Tach check: no reading at full duty -> no usable tach
           for (const u of [...active]) {
             const rpm = rpms.get(u.target) ?? 0;
             if (rpm <= 0) {

--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -15,6 +15,8 @@ import { log } from "../utils/logger";
 import { SESSION_COOKIE, parseCookieHeader, verifySession } from "../auth/session";
 import { mintAgentToken, hashAgentToken, verifyAgentToken } from "../auth/tokens";
 import { isValidDeployToken } from "../auth/enrollment";
+import { UpdateDownloadService } from "./UpdateDownloadService";
+import { compareSemver } from "../utils/version";
 import { 
   defaultUpdateInterval, 
   defaultFanStep, 
@@ -56,7 +58,7 @@ interface WebSocketMessage {
   clientId?: string;
 }
 
-// Credential-less agent held for admin approval (D13). Lives in memory only,
+// Credential-less agent held for admin approval. Lives in memory only,
 // tied to its connection; no systems row, no license seat, telemetry ignored.
 interface PendingAgent {
   clientId: string;
@@ -83,6 +85,14 @@ const MAX_PENDING_AGENTS = (() => {
   return n;
 })();
 
+// Oldest agent build that can store a pushed auth token. Approving an older
+// Linux/IPMI agent chains a self-update first; its token is pushed after it
+// reconnects on the new build.
+const MIN_TOKEN_CAPABLE_AGENT_VERSION = "v0.6.3-alpha1";
+
+// How long an updating agent has to reconnect before it must pend again.
+const UPDATE_RECONNECT_WINDOW_MS = 300_000;
+
 export class WebSocketHub extends EventEmitter {
   private static instance: WebSocketHub;
   private wss: WebSocketServer | null = null;
@@ -92,8 +102,11 @@ export class WebSocketHub extends EventEmitter {
   // the per-client `subscriptions` Sets; keep them in sync only through
   // add/removeClientSubscription and removeClientFromIndex.
   private subscriptionIndex: Map<string, Set<string>> = new Map();
-  // agentId -> pending-approval entry (D13)
+  // agentId -> pending-approval entry
   private pendingAgents: Map<string, PendingAgent> = new Map();
+  // Approve-and-update in flight: agentId -> reconnect window (same source IP)
+  private updateReconnectTickets: Map<string, { ip?: string; deadline: number }> =
+    new Map();
   private dataAggregator: DataAggregator;
   private agentManager: AgentManager;
   private commandDispatcher: CommandDispatcher;
@@ -469,7 +482,7 @@ export class WebSocketHub extends EventEmitter {
         log.info(` Frontend client disconnected: ${clientId}`, "WebSocketHub");
       }
 
-      // Pending-approval entries live with their connection (D13)
+      // Pending-approval entries live with their connection
       for (const [agentId, entry] of this.pendingAgents) {
         if (entry.clientId === clientId) {
           this.pendingAgents.delete(agentId);
@@ -700,7 +713,9 @@ export class WebSocketHub extends EventEmitter {
     clientId: string,
     registrationData: any,
     // Set only by approvePendingAgent: admin vouched, so skip the credential tree and push a token.
-    preApproved: boolean = false
+    preApproved: boolean = false,
+    // Old build that can't store a token yet: self-update it instead of pushing one.
+    chainSelfUpdate: boolean = false
   ): Promise<void> {
     try {
       log.info(
@@ -746,28 +761,62 @@ export class WebSocketHub extends EventEmitter {
 
         if (existing?.auth_token_hash) {
           if (!verifyAgentToken(presentedToken, existing.auth_token_hash)) {
-            log.warn(
-              `Agent ${agentId} presented ${presentedToken ? "an invalid" : "no"} auth token - rejecting`,
-              "WebSocketHub"
+            // A failed credential counts as impersonation only while the
+            // real agent is connected; otherwise hold for approval so the
+            // admin can reissue a token.
+            const liveConflict = Array.from(this.clients.entries()).some(
+              ([cid, c]) =>
+                cid !== clientId &&
+                c.metadata.isAgent &&
+                c.metadata.agentId === agentId
             );
-            this.sendToClient(clientId, "registrationError", {
-              error: "Agent token rejected",
-            });
-            this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
-            return;
+            if (liveConflict) {
+              log.warn(
+                `Agent ${agentId} presented ${presentedToken ? "an invalid" : "no"} auth token while an authenticated connection is online - rejecting (possible impersonation)`,
+                "WebSocketHub"
+              );
+              this.sendToClient(clientId, "registrationError", {
+                error: "Agent token rejected",
+              });
+              this.clients.get(clientId)?.websocket.close(4403, "agent token rejected");
+              return;
+            }
+            // An approved-with-update agent reconnects tokenless even when an
+            // old hash exists; a valid window ticket completes the approval.
+            if (this.redeemUpdateTicket(agentId, client?.metadata.ip)) {
+              preApproved = true;
+            } else {
+              const reason = presentedToken
+                ? "Secured system presented an invalid token - approve to issue a new one"
+                : presentedEnrollment
+                  ? (await isValidDeployToken(presentedEnrollment))
+                    ? "Secured system reinstalled with a valid install token - approve to issue a new one"
+                    : "Secured system presented an expired install token - approve to issue a new one"
+                  : "Secured system reconnected without its token - approve to issue a new one";
+              this.holdPendingAgent(clientId, registrationData, reason);
+              return;
+            }
           }
         } else {
-          // No stored token (known or unknown): a valid enrollment token auto-enrolls (script flow); anything else is held for admin approval (D13, single door).
+          // No stored token (known or unknown): a valid enrollment token auto-enrolls (script flow); anything else is held for admin approval.
           if (presentedEnrollment && (await isValidDeployToken(presentedEnrollment))) {
             mintedToken = mintAgentToken();
           } else {
-            const reason = presentedEnrollment
-              ? "Install token expired - approve on the dashboard or run a fresh install script"
-              : existing
-                ? "Existing agent has no token yet - approve to migrate it"
-                : "Registered without credentials - approve on the dashboard";
-            this.holdPendingAgent(clientId, registrationData, reason);
-            return;
+            // An agent the admin just approved-with-update reconnects here
+            // tokenless; inside its window and from the same address, the
+            // approval completes without a second click.
+            if (this.redeemUpdateTicket(agentId, client?.metadata.ip)) {
+              preApproved = true;
+            }
+            if (!preApproved) {
+              const reason = presentedEnrollment
+                ? "Install token expired - approve on the dashboard or run a fresh install script"
+                : existing
+                  ? "Existing agent has no token yet - approve to migrate it"
+                  : "Registered without credentials - approve on the dashboard";
+              this.holdPendingAgent(clientId, registrationData, reason);
+              return;
+            }
           }
         }
       }
@@ -966,8 +1015,42 @@ export class WebSocketHub extends EventEmitter {
           ...(mintedToken ? { auth_token: mintedToken } : {}),
         });
 
+        if (preApproved && chainSelfUpdate) {
+          // Update the old build first; the reconnect on the new binary
+          // completes the approval and receives the token.
+          const staged = UpdateDownloadService.getInstance().getLocalStatus().version;
+          const sourceIp = this.clients.get(clientId)?.metadata.ip;
+          this.updateReconnectTickets.set(agentId, {
+            ip: sourceIp,
+            deadline: Date.now() + UPDATE_RECONNECT_WINDOW_MS,
+          });
+          setTimeout(() => {
+            this.commandDispatcher
+              .sendCommand(agentId, "selfUpdate", { version: staged }, "normal")
+              .then(() => {
+                log.info(
+                  `Agent ${agentId} accepted update to ${staged} - expecting reconnect from ${sourceIp} within ${UPDATE_RECONNECT_WINDOW_MS / 1000}s`,
+                  "WebSocketHub"
+                );
+                // Let dashboards show UPDATING instead of a bare offline
+                this.broadcast(
+                  "agentUpdating",
+                  { agentId, version: staged, windowMs: UPDATE_RECONNECT_WINDOW_MS },
+                  ["agents:all", "systems:all"]
+                );
+              })
+              .catch((err) => {
+                this.updateReconnectTickets.delete(agentId);
+                log.warn(
+                  `Agent ${agentId} did not accept selfUpdate: ${err?.message ?? err}`,
+                  "WebSocketHub"
+                );
+              });
+          }, 2000);
+        }
+
         // Approved agent: push its permanent token. Hash commits only on the agent's ack, so pre-auth binaries stay connectable (shown Unsecured) until self-update.
-        if (preApproved) {
+        if (preApproved && !chainSelfUpdate) {
           const approvalToken = mintAgentToken();
           setTimeout(() => {
             this.commandDispatcher
@@ -1048,7 +1131,7 @@ export class WebSocketHub extends EventEmitter {
   }
 
   /**
-   * Hold a credential-less agent for admin approval (D13). The connection
+   * Hold a credential-less agent for admin approval. The connection
    * stays open (so approval can promote it instantly) but the client is never
    * marked isAgent - existing gates ignore its telemetry and responses.
    */
@@ -1103,10 +1186,39 @@ export class WebSocketHub extends EventEmitter {
     ]);
   }
 
+  /**
+   * Single-use reconnect ticket for an approved-with-update agent: deleted on
+   * sight; only an in-window reconnect from the same address completes the
+   * approval without a second admin click.
+   */
+  private redeemUpdateTicket(agentId: string, sourceIp?: string): boolean {
+    const ticket = this.updateReconnectTickets.get(agentId);
+    if (!ticket) return false;
+    this.updateReconnectTickets.delete(agentId);
+    if (Date.now() <= ticket.deadline && ticket.ip && sourceIp === ticket.ip) {
+      log.info(
+        `Agent ${agentId} reconnected from ${sourceIp} within the update window - completing approval`,
+        "WebSocketHub"
+      );
+      return true;
+    }
+    log.info(
+      `Agent ${agentId} reconnected ${Date.now() > ticket.deadline ? "after the update window closed" : `from unexpected address ${sourceIp}`} - holding for approval`,
+      "WebSocketHub"
+    );
+    return false;
+  }
+
   /** Metadata-only view of a pending agent (never the raw registration data) */
   private pendingAgentView(entry: PendingAgent) {
     const { clientId, registrationData, ...view } = entry;
-    return view;
+    return {
+      ...view,
+      // Lets the UI label the approve action honestly: below this version,
+      // approving a Linux/IPMI agent also updates it.
+      belowTokenVersion:
+        compareSemver(entry.version || "0.0.0", MIN_TOKEN_CAPABLE_AGENT_VERSION) < 0,
+    };
   }
 
   public getPendingAgents() {
@@ -1128,6 +1240,38 @@ export class WebSocketHub extends EventEmitter {
       return { ok: false, error: "No pending agent with that ID" };
     }
 
+    // Credential recovery guard: if the real agent came back online while
+    // this claim sat pending, approving would hand its identity away.
+    const liveConflict = Array.from(this.clients.entries()).some(
+      ([cid, c]) =>
+        cid !== entry.clientId &&
+        c.metadata.isAgent &&
+        c.metadata.agentId === agentId
+    );
+    if (liveConflict) {
+      return {
+        ok: false,
+        error: "This system is already online and secured - dismiss this request instead",
+      };
+    }
+
+    // Old Linux/IPMI builds can't store a pushed token, so approval also
+    // updates them - which needs new-enough binaries staged on the hub.
+    // A failed check leaves the agent pending so the click can be retried.
+    const agentType = entry.agentType ?? entry.registrationData?.agent_type;
+    const chainSelfUpdate =
+      (agentType === "os_linux" || agentType === "ipmi_host") &&
+      compareSemver(entry.version || "0.0.0", MIN_TOKEN_CAPABLE_AGENT_VERSION) < 0;
+    if (chainSelfUpdate) {
+      const staged = UpdateDownloadService.getInstance().getLocalStatus().version;
+      if (!staged || compareSemver(staged, MIN_TOKEN_CAPABLE_AGENT_VERSION) < 0) {
+        return {
+          ok: false,
+          error: `Stage ${MIN_TOKEN_CAPABLE_AGENT_VERSION} binaries in Fleet Maintenance first`,
+        };
+      }
+    }
+
     this.pendingAgents.delete(agentId);
     this.broadcast("agentPendingRemoved", { agentId }, [
       "agents:all",
@@ -1143,8 +1287,16 @@ export class WebSocketHub extends EventEmitter {
       };
     }
 
-    log.info(`Pending agent ${agentId} approved by admin`, "WebSocketHub");
-    await this.handleAgentRegistration(entry.clientId, entry.registrationData, true);
+    log.info(
+      `Pending agent ${agentId} approved by admin${chainSelfUpdate ? " (old build - chaining update)" : ""}`,
+      "WebSocketHub"
+    );
+    await this.handleAgentRegistration(
+      entry.clientId,
+      entry.registrationData,
+      true,
+      chainSelfUpdate
+    );
     return { ok: true };
   }
 

--- a/backend/src/utils/version.ts
+++ b/backend/src/utils/version.ts
@@ -1,0 +1,40 @@
+// Semver compare with pre-release ordering (release > rc > beta > alpha ...).
+// Mirrors the frontend's utils/version.ts - keep in sync.
+
+const parsePreRelease = (version: string): number => {
+  if (!version.includes('-')) return Infinity;
+
+  const suffix = version.split('-')[1]?.toLowerCase() || '';
+  const numMatch = suffix.match(/\d+$/);
+  const num = numMatch ? parseInt(numMatch[0], 10) : 0;
+
+  let weight = 0;
+  if (suffix.startsWith('rc')) weight = 8000;
+  else if (suffix.startsWith('beta')) weight = 7000;
+  else if (suffix.startsWith('alpha')) weight = 6000;
+  else if (suffix.startsWith('pre') || suffix.startsWith('preview')) weight = 5000;
+  else if (suffix.startsWith('insiders')) weight = 4000;
+  else if (suffix.startsWith('experimental')) weight = 3000;
+  else if (suffix.startsWith('canary')) weight = 2000;
+  else if (suffix.startsWith('dev')) weight = 1000;
+  else if (suffix.startsWith('nightly')) weight = 500;
+  else weight = 100;
+
+  return weight + num;
+};
+
+const stripPreRelease = (version: string): string =>
+  (version || '0.0.0').replace(/^v/, '').replace(/-.*$/, '');
+
+export const compareSemver = (a: string, b: string): number => {
+  const cleanA = (a || '0.0.0').replace(/^v/, '');
+  const cleanB = (b || '0.0.0').replace(/^v/, '');
+  const pa = stripPreRelease(cleanA).split('.').map(Number);
+  const pb = stripPreRelease(cleanB).split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na !== nb) return na - nb;
+  }
+  return (parsePreRelease(cleanA) - parsePreRelease(cleanB)) || 0;
+};

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 
 /**
  * Sign-in screen, with an optional create-account mode when the admin has
- * enabled self-registration (D15). Shown whenever no session exists.
+ * enabled self-registration. Shown whenever no session exists.
  */
 const LoginPage: React.FC = () => {
   const { login, registerAccount, registrationEnabled } = useAuth();

--- a/frontend/src/deployment/components/DeploymentPage.tsx
+++ b/frontend/src/deployment/components/DeploymentPage.tsx
@@ -29,6 +29,7 @@ import RuntimeDefaults, { type LogLevel } from './RuntimeDefaults';
 import DeploySummary from './DeploySummary';
 import MaintenanceSection from './MaintenanceSection';
 import type { PendingAgent } from '../../services/authApi';
+import { approvePendingAgent } from '../../services/authApi';
 import ResourcesSection from './ResourcesSection';
 import '../styles/deployment.css';
 
@@ -79,6 +80,7 @@ interface DeploymentPageProps {
   stableReleases?: ReleaseInfo[];
   unstableReleases?: ReleaseInfo[];
   pendingAgents?: PendingAgent[];
+  updatingAgentIds?: Set<string>;
 }
 
 export const DeploymentPage: React.FC<DeploymentPageProps> = ({
@@ -88,6 +90,7 @@ export const DeploymentPage: React.FC<DeploymentPageProps> = ({
   stableReleases = [],
   unstableReleases = [],
   pendingAgents = [],
+  updatingAgentIds,
 }) => {
   // Workspace state (new shape replaces aioAgentMode/arch)
   const [platform, setPlatform] = useState<Platform>('linux');
@@ -332,6 +335,28 @@ export const DeploymentPage: React.FC<DeploymentPageProps> = ({
     return `wget -qO- "${url}" | bash`;
   };
 
+  // Approve from Fleet Maintenance: same endpoint as the dashboard card;
+  // for old builds the hub chains the update, so no second click needed
+  const handleApprovePending = async (agentId: string) => {
+    try {
+      await approvePendingAgent(agentId);
+      toast.success('Agent approved');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Approval failed');
+    }
+  };
+
+  // Hub-driven updating state (approve-and-update chain) merged with the
+  // locally tracked Update Now clicks
+  const allUpdatingAgents = useMemo(() => {
+    if (!updatingAgentIds || updatingAgentIds.size === 0) return updatingAgents;
+    const merged = new Set(updatingAgents);
+    for (const system of systems) {
+      if (updatingAgentIds.has(system.agent_id)) merged.add(system.id);
+    }
+    return merged;
+  }, [updatingAgents, updatingAgentIds, systems]);
+
   const handleRemoteUpdate = async (systemId: number) => {
     try {
       setUpdatingAgents(prev => new Set(prev).add(systemId));
@@ -558,9 +583,10 @@ export const DeploymentPage: React.FC<DeploymentPageProps> = ({
         onToggle={() => setIsMaintenanceExpanded(!isMaintenanceExpanded)}
         systems={systems}
         pendingAgents={pendingAgents}
+        onApprove={handleApprovePending}
         stableVersion={latestVersion}
         unstableVersion={unstableVersion || null}
-        updatingAgents={updatingAgents}
+        updatingAgents={allUpdatingAgents}
         onApplyUpdate={handleRemoteUpdate}
         hubStatus={hubStatus}
         githubRepo={GITHUB_REPO}

--- a/frontend/src/deployment/components/MaintenanceSection.tsx
+++ b/frontend/src/deployment/components/MaintenanceSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { Activity, ChevronDown, ChevronRight, Download } from 'lucide-react';
 import type { HubStatus } from '../../services/api';
 import type { PendingAgent } from '../../services/authApi';
+import { compareSemver } from '../../utils/version';
 
 type MaintenanceSortKey = 'name' | 'agentId' | 'platform' | 'agentType' | 'version' | 'status' | 'maintenance';
 type SortDirection = 'asc' | 'desc';
@@ -15,54 +16,13 @@ interface MaintenanceSectionProps {
   unstableVersion: string | null;
   updatingAgents: Set<number>;
   onApplyUpdate: (systemId: number) => void;
+  onApprove: (agentId: string) => Promise<void>;
   hubStatus: HubStatus | null;
   githubRepo: string;
 }
 
 const isWindowsSystem = (system: any) =>
   system.platform === 'windows' || system.agent_id?.toLowerCase().startsWith('windows-');
-
-/**
- * Parse pre-release tag into a comparable number based on GitHub workflow definition.
- * Ranks: stable (Infinity) > rc > beta > alpha > dev/nightly/etc.
- */
-const parsePreRelease = (version: string): number => {
-  if (!version.includes('-')) return Infinity;
-
-  const suffix = version.split('-')[1]?.toLowerCase() || '';
-  const numMatch = suffix.match(/\d+$/);
-  const num = numMatch ? parseInt(numMatch[0], 10) : 0;
-
-  let weight = 0;
-  if (suffix.startsWith('rc')) weight = 8000;
-  else if (suffix.startsWith('beta')) weight = 7000;
-  else if (suffix.startsWith('alpha')) weight = 6000;
-  else if (suffix.startsWith('pre') || suffix.startsWith('preview')) weight = 5000;
-  else if (suffix.startsWith('insiders')) weight = 4000;
-  else if (suffix.startsWith('experimental')) weight = 3000;
-  else if (suffix.startsWith('canary')) weight = 2000;
-  else if (suffix.startsWith('dev')) weight = 1000;
-  else if (suffix.startsWith('nightly')) weight = 500;
-  else weight = 100;
-
-  return weight + num;
-};
-
-const stripPreRelease = (version: string): string =>
-  (version || '0.0.0').replace(/^v/, '').replace(/-.*$/, '');
-
-const compareSemver = (a: string, b: string): number => {
-  const cleanA = (a || '0.0.0').replace(/^v/, '');
-  const cleanB = (b || '0.0.0').replace(/^v/, '');
-  const pa = stripPreRelease(cleanA).split('.').map(Number);
-  const pb = stripPreRelease(cleanB).split('.').map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const na = pa[i] || 0;
-    const nb = pb[i] || 0;
-    if (na !== nb) return na - nb;
-  }
-  return (parsePreRelease(cleanA) - parsePreRelease(cleanB)) || 0;
-};
 
 const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
   isExpanded,
@@ -73,6 +33,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
   unstableVersion,
   updatingAgents,
   onApplyUpdate,
+  onApprove,
   hubStatus,
   githubRepo,
 }) => {
@@ -80,11 +41,31 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
   // Agents connected but held for admin approval: not registered, so their
-  // systems row still reads offline - show the truthful state instead
-  const pendingIds = useMemo(
-    () => new Set(pendingAgents.map(p => p.agentId)),
+  // systems row still reads offline (and a stale version) - show the live
+  // connection's state instead
+  const pendingByAgentId = useMemo(
+    () => new Map(pendingAgents.map(p => [p.agentId, p])),
     [pendingAgents]
   );
+  const pendingIds = useMemo(
+    () => new Set(pendingByAgentId.keys()),
+    [pendingByAgentId]
+  );
+  // Approve clicks in flight, so a slow approve can't double-fire
+  const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
+
+  const handleApprove = async (agentId: string) => {
+    setApprovingIds(prev => new Set(prev).add(agentId));
+    try {
+      await onApprove(agentId);
+    } finally {
+      setApprovingIds(prev => {
+        const next = new Set(prev);
+        next.delete(agentId);
+        return next;
+      });
+    }
+  };
 
   const getStatusLabel = (system: any) =>
     updatingAgents.has(system.id)
@@ -104,8 +85,11 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
     const isUpdating = updatingAgents.has(system.id);
     const isOnline = system.status === 'online' || system.status === 'error';
 
+    const pending = pendingByAgentId.get(system.agent_id);
+    if (pending) {
+      return pending.belowTokenVersion && !isWindows ? 'APPROVE & UPDATE' : 'APPROVE';
+    }
     if (isWindows) return isOutdated ? 'DOWNLOAD MSI' : 'GET MSI';
-    if (pendingIds.has(system.agent_id)) return 'APPROVE FIRST';
     if (!hubStatus?.version) return 'UNAVAILABLE';
     if (!isOnline) return 'OFFLINE';
     if (isUpdating) return 'UPDATING';
@@ -181,7 +165,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
     });
 
     return sortDirection === 'asc' ? sorted : sorted.reverse();
-  }, [systems, sortKey, sortDirection, updatingAgents, pendingIds]);
+  }, [systems, sortKey, sortDirection, updatingAgents, pendingIds, pendingByAgentId]);
 
   return (
     <section className={`deployment-section maintenance-panel ${!isExpanded ? 'collapsed' : ''}`}>
@@ -253,16 +237,21 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                 ) : (
                   sortedSystems.map(system => {
                     const isWindows = isWindowsSystem(system);
+                    const pending = pendingByAgentId.get(system.agent_id);
+                    const isPending = !!pending;
+                    // Pending rows show the live connection's version, not the stale row
+                    const agentVersion = pending?.version || system.agent_version;
                     const hubVer = hubStatus?.version?.replace('v', '') || '';
                     const stableVer = stableVersion?.replace('v', '') || '';
                     const cleanTarget = isWindows ? stableVer : (hubVer || stableVer);
                     const targetVersion = cleanTarget ? `v${cleanTarget}` : null;
-                    const isMismatch = cleanTarget && system.agent_version && compareSemver(cleanTarget, system.agent_version) !== 0;
-                    const isDowngrade = isMismatch && compareSemver(cleanTarget, system.agent_version) < 0;
+                    const isMismatch = cleanTarget && agentVersion && compareSemver(cleanTarget, agentVersion) !== 0;
+                    const isDowngrade = isMismatch && compareSemver(cleanTarget, agentVersion) < 0;
                     const isOutdated = isMismatch && !isDowngrade;
                     const isUpdating = updatingAgents.has(system.id);
-                    const isPending = pendingIds.has(system.agent_id);
                     const isOnline = system.status === 'online' || system.status === 'error';
+                    const willChainUpdate = isPending && !!pending?.belowTokenVersion && !isWindows;
+                    const isApproving = isPending && approvingIds.has(system.agent_id);
 
                     const statusLabel = getStatusLabel(system);
                     const statusClass = isUpdating ? 'updating' : (isPending ? 'pending' : (isOnline ? (system.status === 'error' ? 'error' : 'online') : 'offline'));
@@ -333,7 +322,7 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                         </td>
                         <td>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-xs)' }}>
-                            <span>v{system.agent_version || '0.0.0'}</span>
+                            <span>v{agentVersion || '0.0.0'}</span>
                             {isOutdated && !isUpdating && (
                               <span className="update-badge" title={`Update to ${targetVersion} available`}>
                                 NEW {targetVersion}
@@ -358,7 +347,20 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                           </span>
                         </td>
                         <td>
-                          {isWindows ? (
+                          {isPending ? (
+                            <button
+                              className={`btn-table-action ${willChainUpdate ? 'update-needed' : ''}`}
+                              onClick={() => handleApprove(system.agent_id)}
+                              disabled={isApproving}
+                              title={willChainUpdate
+                                ? `Approve and update this agent to ${targetVersion ?? 'the staged version'} in one step`
+                                : isWindows
+                                  ? 'Approve this agent - old Windows builds update via the MSI installer'
+                                  : 'Approve this agent'}
+                            >
+                              {isApproving ? 'Approving...' : (willChainUpdate ? 'Approve & Update' : 'Approve')}
+                            </button>
+                          ) : isWindows ? (
                             <a
                               href={`${githubRepo}/releases/latest/download/pankha-agent-windows_x64.msi`}
                               className={`btn-table-action windows-download ${isOutdated ? 'update-needed' : ''}`}
@@ -371,29 +373,27 @@ const MaintenanceSection: React.FC<MaintenanceSectionProps> = React.memo(({
                           ) : (
                             <span
                               title={
-                                isPending
-                                  ? 'Approve this agent on the dashboard first, then update'
-                                  : !hubStatus?.version
-                                    ? `Download Stable ${stableVersion || ''} or Unstable ${unstableVersion || ''} to server first`
-                                    : (!isOnline
-                                      ? 'Agent is offline'
-                                      : (isUpdating
-                                        ? 'Update in progress...'
-                                        : (isDowngrade
-                                          ? `Downgrade agent to ${targetVersion}`
-                                          : (isOutdated
-                                            ? `Click to update agent to ${targetVersion}`
-                                            : `Reinstall agent version ${targetVersion}`))))
+                                !hubStatus?.version
+                                  ? `Download Stable ${stableVersion || ''} or Unstable ${unstableVersion || ''} to server first`
+                                  : (!isOnline
+                                    ? 'Agent is offline'
+                                    : (isUpdating
+                                      ? 'Update in progress...'
+                                      : (isDowngrade
+                                        ? `Downgrade agent to ${targetVersion}`
+                                        : (isOutdated
+                                          ? `Click to update agent to ${targetVersion}`
+                                          : `Reinstall agent version ${targetVersion}`))))
                               }
                               style={{ display: 'inline-block' }}
                             >
                               <button
                                 className={`btn-table-action ${isOutdated ? 'update-needed' : ''} ${isDowngrade ? 'downgrade' : ''}`}
                                 onClick={() => onApplyUpdate(system.id)}
-                                disabled={isPending || !isOnline || isUpdating || !hubStatus?.version}
+                                disabled={!isOnline || isUpdating || !hubStatus?.version}
                                 style={{ pointerEvents: 'auto' }}
                               >
-                                {isPending ? 'Approve First' : (isUpdating ? 'Updating...' : (isDowngrade ? 'Downgrade' : (isOutdated ? 'Update Now' : 'Reinstall')))}
+                                {isUpdating ? 'Updating...' : (isDowngrade ? 'Downgrade' : (isOutdated ? 'Update Now' : 'Reinstall'))}
                               </button>
                             </span>
                           )}

--- a/frontend/src/deployment/components/ReleaseHubCache.tsx
+++ b/frontend/src/deployment/components/ReleaseHubCache.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Bookmark, Zap, Trash2, Download, Check } from 'lucide-react';
 import type { HubStatus } from '../../services/api';
 import { Select } from '../../components/ui/Select';
+import { compareSemver } from '../../utils/version';
 
 export type Channel = 'stable' | 'unstable';
 
@@ -67,8 +68,18 @@ const ReleaseHubCache: React.FC<ReleaseHubCacheProps> = React.memo(({
   onClearCache,
   githubRepo,
 }) => {
-  const latestStable = stableReleases[0];
-  const latestUnstable = unstableReleases[0];
+  // Release feed arrives in publish-date order; rank by version instead
+  // (beta1 published before alpha4 must still list above it)
+  const sortedStable = useMemo(
+    () => [...stableReleases].sort((a, b) => compareSemver(b.tag_name, a.tag_name)),
+    [stableReleases]
+  );
+  const sortedUnstable = useMemo(
+    () => [...unstableReleases].sort((a, b) => compareSemver(b.tag_name, a.tag_name)),
+    [unstableReleases]
+  );
+  const latestStable = sortedStable[0];
+  const latestUnstable = sortedUnstable[0];
 
   const selectedVersion = channel === 'stable' ? selectedStableVersion : selectedUnstableVersion;
   const hubVersion = hubStatus?.version || null;
@@ -109,7 +120,7 @@ const ReleaseHubCache: React.FC<ReleaseHubCacheProps> = React.memo(({
               sessionStorage.setItem('pankha-picker-stable', ver);
               if (channel !== 'stable') onChannelChange('stable');
             }}
-            options={stableReleases.map(r => ({
+            options={sortedStable.map(r => ({
               value: r.tag_name,
               label: `${r.tag_name}${hubVersion === r.tag_name ? ' (Ready)' : ''}`,
             }))}
@@ -132,7 +143,7 @@ const ReleaseHubCache: React.FC<ReleaseHubCacheProps> = React.memo(({
               sessionStorage.setItem('pankha-picker-unstable', ver);
               if (channel !== 'unstable') onChannelChange('unstable');
             }}
-            options={unstableReleases.map(r => ({
+            options={sortedUnstable.map(r => ({
               value: r.tag_name,
               label: `${r.tag_name}${hubVersion === r.tag_name ? ' (Ready)' : ''}`,
             }))}

--- a/frontend/src/hooks/useWebSocketData.ts
+++ b/frontend/src/hooks/useWebSocketData.ts
@@ -74,8 +74,10 @@ interface UseWebSocketDataReturn {
   overview: any | null;
   fanCalibration: FanCalibrationMap;
   stalledFans: StalledFanMap;
-  // Agents held for admin approval (D13); always empty for non-admins
+  // Agents held for admin approval; always empty for non-admins
   pendingAgents: PendingAgent[];
+  // agent_ids mid self-update (approve-and-update chain)
+  updatingAgentIds: Set<string>;
 }
 
 /**
@@ -99,6 +101,24 @@ export function useWebSocketData(): UseWebSocketDataReturn {
   const [fanCalibration, setFanCalibration] = useState<FanCalibrationMap>({});
   const [stalledFans, setStalledFans] = useState<StalledFanMap>({});
   const [pendingAgents, setPendingAgents] = useState<PendingAgent[]>([]);
+  // Agents mid self-update (approve-and-update chain): shown as UPDATING
+  // instead of offline until they re-register or their window lapses
+  const [updatingAgentIds, setUpdatingAgentIds] = useState<Set<string>>(new Set());
+  const updatingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const clearUpdatingAgent = useCallback((agentId: string) => {
+    const timer = updatingTimersRef.current.get(agentId);
+    if (timer) {
+      clearTimeout(timer);
+      updatingTimersRef.current.delete(agentId);
+    }
+    setUpdatingAgentIds((prev) => {
+      if (!prev.has(agentId)) return prev;
+      const next = new Set(prev);
+      next.delete(agentId);
+      return next;
+    });
+  }, []);
   const { can } = useAuth();
 
   const wsRef = useRef<WebSocketService | null>(null);
@@ -330,12 +350,15 @@ export function useWebSocketData(): UseWebSocketDataReturn {
 
     if (!mountedRef.current) return;
 
+    // Back from its self-update restart
+    if (data?.agentId) clearUpdatingAgent(data.agentId);
+
     // Request full sync to get complete data for this agent
     if (wsRef.current) {
       console.log("🔄 Requesting full sync after agent registration");
       wsRef.current.send("requestFullSync");
     }
-  }, []);
+  }, [clearUpdatingAgent]);
 
   /**
    * Handle agent unregistered (agent stopped/gracefully disconnected)
@@ -526,7 +549,7 @@ export function useWebSocketData(): UseWebSocketDataReturn {
       notifyAuthRequired();
     });
 
-    // Pending-approval queue (D13, admin-only broadcasts carry metadata only)
+    // Pending-approval queue (admin-only broadcasts carry metadata only)
     wsRef.current.on("agentPendingApproval", (data: unknown) => {
       if (!mountedRef.current || !isAdminRef.current) return;
       const entry = data as PendingAgent;
@@ -539,6 +562,22 @@ export function useWebSocketData(): UseWebSocketDataReturn {
       if (!mountedRef.current) return;
       const { agentId } = data as { agentId: string };
       setPendingAgents((prev) => prev.filter((p) => p.agentId !== agentId));
+    });
+
+    // Approve-and-update in flight: mark UPDATING until the agent
+    // re-registers or its reconnect window lapses
+    wsRef.current.on("agentUpdating", (data: unknown) => {
+      if (!mountedRef.current) return;
+      const { agentId, windowMs } = data as { agentId: string; version?: string; windowMs?: number };
+      if (!agentId) return;
+      setUpdatingAgentIds((prev) => new Set(prev).add(agentId));
+      const timer = setTimeout(
+        () => clearUpdatingAgent(agentId),
+        windowMs && windowMs > 0 ? windowMs : 300_000
+      );
+      const old = updatingTimersRef.current.get(agentId);
+      if (old) clearTimeout(old);
+      updatingTimersRef.current.set(agentId, timer);
     });
 
     // Fan calibration lifecycle: one event per unit per state change.
@@ -611,6 +650,7 @@ export function useWebSocketData(): UseWebSocketDataReturn {
     handleAgentError,
     handleAgentRecovered,
     handleAgentConfigUpdated,
+    clearUpdatingAgent,
   ]);
 
   /**
@@ -655,5 +695,6 @@ export function useWebSocketData(): UseWebSocketDataReturn {
     fanCalibration,
     stalledFans,
     pendingAgents,
+    updatingAgentIds,
   };
 }

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -36,6 +36,8 @@ export interface PendingAgent {
   version?: string;
   reason: string;
   requestedAt: string;
+  // Hub-computed: approving an old Linux/IPMI build also updates it
+  belowTokenVersion?: boolean;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/styles/components/badges.css
+++ b/frontend/src/styles/components/badges.css
@@ -50,6 +50,16 @@
   animation: status-dot-pulse 1s infinite;
 }
 
+.status-badge.updating {
+  background: color-mix(in srgb, var(--color-info), transparent 90%);
+  border-color: color-mix(in srgb, var(--color-info), transparent 85%);
+  color: var(--color-info);
+}
+
+.status-badge.updating .status-dot {
+  animation: status-dot-pulse 1s infinite;
+}
+
 .status-badge.installing {
   background: color-mix(in srgb, var(--color-info), transparent 90%);
   border-color: color-mix(in srgb, var(--color-info), transparent 85%);

--- a/frontend/src/systems/components/PendingAgentCard.tsx
+++ b/frontend/src/systems/components/PendingAgentCard.tsx
@@ -5,7 +5,7 @@ import { approvePendingAgent, dismissPendingAgent } from '../../services/authApi
 import { toast } from '../../utils/toast';
 import './PendingAgentCard.css';
 
-// Defanged card for an agent awaiting admin approval (D13): registration
+// Defanged card for an agent awaiting admin approval: registration
 // metadata only - no telemetry flows until approved. The card disappears via
 // the agentPendingRemoved broadcast after either action.
 
@@ -24,6 +24,11 @@ function timeAgo(iso: string): string {
 
 const PendingAgentCard: React.FC<PendingAgentCardProps> = ({ agent }) => {
   const [busy, setBusy] = useState(false);
+
+  const isWindows = agent.platform === 'windows' || agent.agentType === 'os_windows';
+  // Old Linux/IPMI builds are updated as part of the approval
+  const willChainUpdate = agent.belowTokenVersion === true && !isWindows;
+  const windowsOldBuild = agent.belowTokenVersion === true && isWindows;
 
   const handleApprove = async () => {
     setBusy(true);
@@ -98,9 +103,21 @@ const PendingAgentCard: React.FC<PendingAgentCardProps> = ({ agent }) => {
         </div>
       </div>
 
+      {windowsOldBuild && (
+        <div className="pending-reason">
+          <ShieldQuestion size={15} /> Old build: after approving, run the latest
+          Windows MSI installer on the machine, then approve it again to secure it.
+        </div>
+      )}
+
       <div className="pending-actions">
-        <button className="control-button" onClick={handleApprove} disabled={busy}>
-          <Check size={15} /> Approve
+        <button
+          className="control-button"
+          onClick={handleApprove}
+          disabled={busy}
+          title={willChainUpdate ? 'Approves this agent and updates it in one step' : undefined}
+        >
+          <Check size={15} /> {willChainUpdate ? 'Approve & Update' : 'Approve'}
         </button>
         <button className="pending-dismiss" onClick={handleDismiss} disabled={busy}>
           <X size={15} /> Dismiss

--- a/frontend/src/systems/components/SystemCard.tsx
+++ b/frontend/src/systems/components/SystemCard.tsx
@@ -111,6 +111,8 @@ interface SystemCardProps {
   // Identity changes only when THIS agent has an event (see useWebSocketData).
   fanCalibration: Record<string, string>;
   stalledFans: Record<string, boolean>;
+  // Mid self-update: shown as UPDATING instead of offline/unsecured
+  isUpdating?: boolean;
 }
 
 const SystemCard: React.FC<SystemCardProps> = ({
@@ -126,6 +128,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
   onToggleBmc,
   fanCalibration,
   stalledFans,
+  isUpdating = false,
 }) => {
   const [loading, setLoading] = useState<string | null>(null);
   const { tempThresholds } = useDashboardSettings();
@@ -1282,8 +1285,10 @@ const SystemCard: React.FC<SystemCardProps> = ({
           <div className="system-title-top">
             <div className="status-group">
               <span
-                className={`status-badge ${isUnsecured ? 'offline' : isIpmiNoProfile ? 'read-only' : system.status}`}
-                title={isUnsecured
+                className={`status-badge ${isUpdating ? 'updating' : isUnsecured ? 'offline' : isIpmiNoProfile ? 'read-only' : system.status}`}
+                title={isUpdating
+                  ? "Updating to a new version - reconnects automatically"
+                  : isUnsecured
                   ? "Runs without an auth token - update the agent to secure it"
                   : isIpmiNoProfile
                   ? "Monitor-only mode\nAssign a Profile to enable fan control from Deployment"
@@ -1292,7 +1297,7 @@ const SystemCard: React.FC<SystemCardProps> = ({
                     : `Agent status is currently "${system.status.toUpperCase()}"`}
               >
                 <span className="status-dot" />
-                {isUnsecured ? 'unsecured' : isIpmiNoProfile ? 'read only' : system.status}
+                {isUpdating ? 'updating' : isUnsecured ? 'unsecured' : isIpmiNoProfile ? 'read only' : system.status}
               </span>
               {getPlatformIcon()}
             </div>
@@ -2268,6 +2273,7 @@ export default React.memo(SystemCard, (prevProps, nextProps) => {
     prevProps.isDemoMode === nextProps.isDemoMode &&
     // Calibration/stall maps - new object reference on every event
     prevProps.fanCalibration === nextProps.fanCalibration &&
-    prevProps.stalledFans === nextProps.stalledFans
+    prevProps.stalledFans === nextProps.stalledFans &&
+    prevProps.isUpdating === nextProps.isUpdating // Self-update badge
   );
 });

--- a/frontend/src/systems/components/SystemsPage.tsx
+++ b/frontend/src/systems/components/SystemsPage.tsx
@@ -75,7 +75,8 @@ const SystemsPage: React.FC = () => {
     removeSystem,
     fanCalibration,
     stalledFans,
-    pendingAgents
+    pendingAgents,
+    updatingAgentIds
   } = useWebSocketData();
   const { isDemoMode } = useDemoMode();
   const { can, username, logout, authResetActive } = useAuth();
@@ -384,6 +385,7 @@ const SystemsPage: React.FC = () => {
                   onToggleBmc={(expanded) => setExpandedBmc(prev => ({...prev, [system.id]: expanded}))}
                   fanCalibration={fanCalibration[system.agent_id] ?? EMPTY_CAL}
                   stalledFans={stalledFans[system.agent_id] ?? EMPTY_STALLS}
+                  isUpdating={updatingAgentIds.has(system.agent_id)}
                 />
               ))
             )}
@@ -400,6 +402,7 @@ const SystemsPage: React.FC = () => {
           <DeploymentPage
             systems={systems}
             pendingAgents={pendingAgents}
+            updatingAgentIds={updatingAgentIds}
             latestVersion={latestVersion}
             unstableVersion={unstableVersion}
             stableReleases={stableReleases}

--- a/frontend/src/utils/version.ts
+++ b/frontend/src/utils/version.ts
@@ -1,0 +1,41 @@
+// Semver compare with pre-release ordering (release > rc > beta > alpha ...).
+// Channel order follows the release workflow's definition; the backend's
+// utils/version.ts is a verbatim copy - keep all of them in sync.
+
+const parsePreRelease = (version: string): number => {
+  if (!version.includes('-')) return Infinity;
+
+  const suffix = version.split('-')[1]?.toLowerCase() || '';
+  const numMatch = suffix.match(/\d+$/);
+  const num = numMatch ? parseInt(numMatch[0], 10) : 0;
+
+  let weight = 0;
+  if (suffix.startsWith('rc')) weight = 8000;
+  else if (suffix.startsWith('beta')) weight = 7000;
+  else if (suffix.startsWith('alpha')) weight = 6000;
+  else if (suffix.startsWith('pre') || suffix.startsWith('preview')) weight = 5000;
+  else if (suffix.startsWith('insiders')) weight = 4000;
+  else if (suffix.startsWith('experimental')) weight = 3000;
+  else if (suffix.startsWith('canary')) weight = 2000;
+  else if (suffix.startsWith('dev')) weight = 1000;
+  else if (suffix.startsWith('nightly')) weight = 500;
+  else weight = 100;
+
+  return weight + num;
+};
+
+const stripPreRelease = (version: string): string =>
+  (version || '0.0.0').replace(/^v/, '').replace(/-.*$/, '');
+
+export const compareSemver = (a: string, b: string): number => {
+  const cleanA = (a || '0.0.0').replace(/^v/, '');
+  const cleanB = (b || '0.0.0').replace(/^v/, '');
+  const pa = stripPreRelease(cleanA).split('.').map(Number);
+  const pb = stripPreRelease(cleanB).split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na !== nb) return na - nb;
+  }
+  return (parsePreRelease(cleanA) - parsePreRelease(cleanB)) || 0;
+};


### PR DESCRIPTION
**Approve & Update: one-click migration for older agents**

Builds on the authentication release (#59) with a smoother path for bringing existing fleets onto secured agents, plus recovery for agents that lose their credentials.

**Approve & Update.** Approving a pending agent that runs an older build now updates it in the same click: the agent upgrades itself from the Hub cache, reconnects, and is approved and secured automatically - no second visit to the dashboard. The flow requires staged binaries and refuses with a clear message pointing at Fleet Maintenance otherwise. Reconnects are matched by machine and a 5-minute window; anything else waits for a normal approval. Older Windows agents can't self-update yet, so their approval card explains the MSI route instead.

**Credential recovery.** A secured system whose agent lost its token - reinstalled OS, wiped config, restored backup - used to be rejected silently. It now reappears as a pending-approval card with wording that makes the situation explicit, and approving it issues a fresh token while keeping the system's history, names, and profile assignments. Impersonation protection stays: while the real agent is connected and authenticated, a second connection claiming its identity is still rejected.

**UI**

- Pending agents get an active **Approve & Update** / **Approve** button directly in Fleet Maintenance, alongside the dashboard card.
- Agents mid-update show an **UPDATING** badge with an explanatory tooltip, instead of flickering through offline/unsecured states.
- Fleet Maintenance shows the live reported version for pending agents rather than the version from their last registration.
- Release version dropdowns sort by version instead of publish date, so `beta` builds list above older `alpha` builds of the same release.

Also included: a shared semver comparator used by backend and frontend, the drafted release notes for v0.6.3, and a comment cleanup pass.