### PR TITLE
feature: Docker & Env in the wiki sidebar, move the platform badge, fix container healthcheck

### DIFF
--- a/backend/src/services/WebSocketHub.ts
+++ b/backend/src/services/WebSocketHub.ts
@@ -88,7 +88,7 @@ const MAX_PENDING_AGENTS = (() => {
 // Oldest agent build that can store a pushed auth token. Approving an older
 // Linux/IPMI agent chains a self-update first; its token is pushed after it
 // reconnects on the new build.
-const MIN_TOKEN_CAPABLE_AGENT_VERSION = "v0.6.3-alpha1";
+const MIN_TOKEN_CAPABLE_AGENT_VERSION = "v0.6.3";
 
 // How long an updating agent has to reconnect before it must pend again.
 const UPDATE_RECONNECT_WINDOW_MS = 300_000;

--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:${PORT:-3143}/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3143/health || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 3

--- a/documentation/public/wiki/Docker-and-Env.md
+++ b/documentation/public/wiki/Docker-and-Env.md
@@ -2,6 +2,8 @@
 
 How to deploy Pankha Fan Control with Docker, and every environment variable the stack actually reads. Essentials first; advanced setups below.
 
+New here? [Server Installation](Server-Installation) walks through a first-time setup step by step - this page is the full reference to come back to.
+
 ---
 
 ## Quick Start

--- a/documentation/public/wiki/Server-Configuration.md
+++ b/documentation/public/wiki/Server-Configuration.md
@@ -19,6 +19,8 @@ The Pankha Fan Control server is configured through environment variables in you
 
 Some settings also have a **runtime home in the dashboard** - log level, data retention, and hardware pruning live in [Settings](Settings-Page) and take effect without a restart.
 
+> Looking for something not listed here - accepted values for each variable, the authentication settings, running without Compose, an external PostgreSQL, or a reverse proxy? [Docker & Env](Docker-and-Env) is the complete reference.
+
 ---
 
 ## Custom Port

--- a/documentation/public/wiki/Server-Installation.md
+++ b/documentation/public/wiki/Server-Installation.md
@@ -108,4 +108,5 @@ Your `.env`, database, and staged binaries are untouched by updates.
 
 *   [Quick Start](Quick-Start): deploy your first agent and put a fan under control.
 *   [Server Configuration](Server-Configuration): environment variables and runtime settings in depth.
+*   [Docker & Env](Docker-and-Env): the complete reference - every variable with its accepted values, `docker run` without Compose, external PostgreSQL, and reverse-proxy setup.
 *   [Deployment Center](Deployment-Center): roll agents out to your machines.

--- a/documentation/public/wiki/_Sidebar.md
+++ b/documentation/public/wiki/_Sidebar.md
@@ -18,6 +18,7 @@
   * [Fan Profiles](Fan-Profiles)
   * [Calibration & Health](Fan-Calibration)
 * [API Reference](API-Reference)
+* [Docker & Env](Docker-and-Env)
 * **Development**
   * [Building from Source](Development-Build)
   * [Backend](Development-Backend)

--- a/frontend/src/systems/components/SystemCard.tsx
+++ b/frontend/src/systems/components/SystemCard.tsx
@@ -1268,12 +1268,12 @@ const SystemCard: React.FC<SystemCardProps> = ({
 
     return (
       <div className="platform-icon-minimal" title={tooltip}>
-        <img src={getIconSrc()} alt={platformLabel} style={{ maxWidth: '48px', height: '26px', objectFit: 'contain' }} />
         {(agentTypeLabel || archLabel) && (
           <span className="arch-badge">
             {[agentTypeLabel, archLabel].filter(Boolean).join(' · ')}
           </span>
         )}
+        <img src={getIconSrc()} alt={platformLabel} style={{ maxWidth: '48px', height: '26px', objectFit: 'contain' }} />
       </div>
     );
   };
@@ -1299,7 +1299,6 @@ const SystemCard: React.FC<SystemCardProps> = ({
                 <span className="status-dot" />
                 {isUpdating ? 'updating' : isUnsecured ? 'unsecured' : isIpmiNoProfile ? 'read only' : system.status}
               </span>
-              {getPlatformIcon()}
             </div>
 
             <div className="header-actions">
@@ -1339,6 +1338,8 @@ const SystemCard: React.FC<SystemCardProps> = ({
               />
             </h3>
           </div>
+
+          {getPlatformIcon()}
         </div>
 
         <div className="system-meta">

--- a/frontend/src/systems/styles/cards.css
+++ b/frontend/src/systems/styles/cards.css
@@ -227,6 +227,7 @@
   flex-shrink: 0;
   opacity: 0.75;
   transition: all 0.2s ease;
+  margin-top: calc(var(--spacing-lg) * -1);
 }
 
 .platform-icon-minimal:hover {


### PR DESCRIPTION
## Wiki navigation

The Docker & Env reference was published without ever being linked from the sidebar, so it was reachable only by direct URL. It now appears as a top-level entry, and the three server-side pages point at each other properly:

- **Server Installation** and **Server Configuration** both send readers to Docker & Env when they need the full reference - every variable with its accepted values, running without Compose, external PostgreSQL, or a reverse proxy.
- **Docker & Env** now opens by pointing first-timers back at Server Installation, so the deep reference doesn't read as the starting point.

The split is deliberate: the two server pages stay short and get you running, Docker & Env is the complete reference you come back to.

## Agent card layout

The platform icon and its badge have moved out of the status row and now sit on their own line beneath the agent name, with the badge to the left of the icon. The status badge keeps the top-left corner to itself, which makes an agent's state easier to scan across a wall of cards.

## Fixes

- The app container's healthcheck now targets its fixed internal port directly. It was being built from a variable that could resolve to a port the check couldn't reach from inside the container, marking a perfectly healthy container unhealthy.
- Agents older than v0.6.3 are now the ones that get a self-update chained onto approval, rather than the pre-release build that was standing in as the threshold during development.