### PR TITLE
Fix: Linux agent install on SELinux systems and  improve TLS support for WebSocket secure (wss://) connections

### DIFF
--- a/agents/clients/linux/rust/Cargo.lock
+++ b/agents/clients/linux/rust/Cargo.lock
@@ -197,6 +197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "pankha-agent"
 version = "0.0.0-dev"
 dependencies = [
@@ -691,6 +707,7 @@ dependencies = [
  "hostname",
  "libc",
  "nvml-wrapper",
+ "rustls",
  "serde",
  "serde_json",
  "sysinfo",
@@ -872,10 +889,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -905,10 +935,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1184,6 +1246,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/agents/clients/linux/rust/Cargo.toml
+++ b/agents/clients/linux/rust/Cargo.toml
@@ -15,8 +15,12 @@ path = "src/main.rs"
 [dependencies]
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 futures-util = "0.3"
+
+# TLS crypto provider: pin ring so rustls resolves exactly one provider.
+# Without this, wss:// connections panic (no default CryptoProvider).
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/agents/clients/linux/rust/src/main.rs
+++ b/agents/clients/linux/rust/src/main.rs
@@ -34,6 +34,10 @@ use daemon::LOG_DIR;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install the ring crypto provider before any TLS use so wss:// connections
+    // don't panic on a missing default CryptoProvider. Idempotent; safe to ignore.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Parse arguments with custom error handling
     let args = match Args::try_parse() {
         Ok(args) => args,

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.lock
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.lock
@@ -197,6 +197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "pankha-agent-ipmi"
 version = "0.0.0-dev"
 dependencies = [
@@ -598,6 +614,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "libc",
+ "rustls",
  "serde",
  "serde_json",
  "time",
@@ -768,10 +785,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -801,10 +831,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1046,6 +1108,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.toml
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/Cargo.toml
@@ -15,8 +15,12 @@ path = "src/main.rs"
 [dependencies]
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 futures-util = "0.3"
+
+# TLS crypto provider: pin ring so rustls resolves exactly one provider.
+# Without this, wss:// connections panic (no default CryptoProvider).
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
+++ b/agents/clients/linux/virtual-agents/host-ipmi-rust/src/main.rs
@@ -34,6 +34,10 @@ use daemon::LOG_DIR;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install the ring crypto provider before any TLS use so wss:// connections
+    // don't panic on a missing default CryptoProvider. Idempotent; safe to ignore.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Parse arguments with custom error handling
     let args = match Args::try_parse() {
         Ok(args) => args,

--- a/backend/src/routes/deploy.ts
+++ b/backend/src/routes/deploy.ts
@@ -399,13 +399,14 @@ if [ "$HTTP_CODE" != "200" ]; then
     exit 1
 fi
 
+# install(1) creates a fresh destination file, so it inherits the target
+# directory's SELinux context instead of the temp dir's user_tmp_t label.
 if [ "$INSTALL_DIR" = "$(pwd)" ]; then
-    mv "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
-    chmod +x "$INSTALL_DIR/pankha-agent"
+    install -m 755 "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
 else
-    run_as_root mv "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
-    run_as_root chmod +x "$INSTALL_DIR/pankha-agent"
+    run_as_root install -m 755 "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
 fi
+rm -f "$DOWNLOAD_RESPONSE"
 
 echo "[4/6] Generating configuration..."
 
@@ -601,13 +602,14 @@ if [ "$HTTP_CODE" != "200" ]; then
     exit 1
 fi
 
+# install(1) creates a fresh destination file, so it inherits the target
+# directory's SELinux context instead of the temp dir's user_tmp_t label.
 if [ "$INSTALL_DIR" = "$(pwd)" ]; then
-    mv "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
-    chmod +x "$INSTALL_DIR/pankha-agent"
+    install -m 755 "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
 else
-    run_as_root mv "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
-    run_as_root chmod +x "$INSTALL_DIR/pankha-agent"
+    run_as_root install -m 755 "$DOWNLOAD_RESPONSE" "$INSTALL_DIR/pankha-agent"
 fi
+rm -f "$DOWNLOAD_RESPONSE"
 
 echo "[4/5] Generating configuration..."
 

--- a/documentation/public/wiki/Troubleshooting.md
+++ b/documentation/public/wiki/Troubleshooting.md
@@ -9,9 +9,9 @@
     2.  Check if the server firewall allows port `3143` (or your `PANKHA_PORT`).
     3.  Verify the `server_url` in `config.json` uses the correct IP (not `localhost` if on a different machine).
 
-### "WebSocket Handshake Failed"
-*   **Cause**: Protocol mismatch or proxy issue.
-*   **Fix**: Ensure your URL starts with `ws://`. If you are running behind a reverse proxy (like Nginx Proxy Manager), ensure that WebSocket support is enabled.
+### Connection Fails on a Secure (`wss://`) URL
+*   **Cause**: agents older than `v0.6.4` cannot complete a TLS handshake and exit immediately when the server URL uses `wss://`. Plain `ws://` is unaffected.
+*   **Fix**: upgrade the agent to `v0.6.4` or newer. From that version `wss://` through a reverse proxy (like Nginx Proxy Manager) works out of the box for public certificate authorities such as Let's Encrypt; for an internal or self-signed CA, add your CA to the host's system trust store. If you cannot upgrade yet, connect directly over `ws://` on a trusted network. Whichever you use, make sure the proxy has WebSocket support enabled.
 
 ### Agent Disconnects After Backend Restart
 *   **Info**: Agents have automatic reconnection with exponential backoff. They will retry indefinitely until the backend is available again. If you need to force a reconnect:
@@ -26,6 +26,15 @@
 ### Agent Stays Stopped After Every Reboot
 *   **Cause**: The systemd service was never installed - nothing starts the agent at boot.
 *   **Fix**: `sudo ./pankha-agent --install-service` (see [Linux Agent](Agents-Linux)). Deployment Center installs it automatically; the setup wizard asks - answer yes.
+
+### Agent Won't Start on SELinux Systems (Fedora, RHEL, Alma, Rocky)
+*   **Cause**: on installs from before `v0.6.4`, the install script placed the binary with a temporary-file security label (`user_tmp_t`) that SELinux blocks systemd from executing. The log shows an AVC `denied { execute }` for `pankha-agent`.
+*   **Fix**: restore the correct label, then restart:
+    ```bash
+    sudo restorecon -Rv /opt/pankha-agent
+    sudo systemctl restart pankha-agent
+    ```
+    Install scripts from `v0.6.4` onward set the label correctly, so a fresh reinstall also resolves it.
 
 ## Accounts & Approval
 


### PR DESCRIPTION
## Issues
Two issues prevented the Linux agents from running in some setups. Both are fixed here.

- **SELinux blocked the agent from starting.** On SELinux-enforcing distributions (Fedora, RHEL, Alma, Rocky), the install script placed the agent binary with a security label the system then refused to execute, so the service never started. The installer now writes the binary with the correct label, and Troubleshooting has a note for repairing an existing install.

- **Secure WebSocket (wss://) connections crashed the agent.** An agent pointed at a `wss://` URL exited immediately instead of connecting. Agents now complete TLS handshakes correctly. Connections through a reverse proxy with a public certificate authority such as Let's Encrypt work out of the box; internal or self-signed certificate authorities are trusted once added to the host's system trust store. Plain `ws://` is unchanged.

## Fix
Both the standard and IPMI Linux agents are covered.

- Added `rustls` and related dependencies to ensure proper TLS handling.
- Updated `tokio-tungstenite` to support native roots for secure WebSocket connections.
- Modified installation script to use `install` command for SELinux compatibility.
- Enhanced troubleshooting documentation for agents on SELinux systems.

Fixes #62